### PR TITLE
docs: add usage instructions and custom slash command guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ See [Usage](#usage) below.
 ### Without the plugin — custom slash command
 
 If you don't want the full plugin, create a project-local (or user-scope)
-slash command that wraps the CLI directly.
+slash command that wraps the CLI directly. This still requires `pr-shepherd`
+to be installed in the repository first (`npm install pr-shepherd`), so that
+`npx pr-shepherd ...` runs without prompting to install the package.
 
 1. **Create the command file:**
    - Project-scope: `.claude/commands/pr-check.md`
@@ -95,10 +97,14 @@ slash command that wraps the CLI directly.
    /pr-check 42
    ```
 
-For `monitor` and `resolve` equivalents, copy
-[`skills/monitor/SKILL.md`](skills/monitor/SKILL.md) and
-[`skills/resolve/SKILL.md`](skills/resolve/SKILL.md) the same way. To drive
-the CLI without Claude at all, see [docs/usage.md](docs/usage.md).
+For `monitor` and `resolve` custom commands, do **not** copy the
+[`skills/`](skills/) files directly — those contain skill/plugin-specific
+frontmatter that is not valid for `.claude/commands/` files. Instead, create
+`.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
+using the same command-file structure as the `pr-check` example above, with
+the CLI invocation changed to `npx pr-shepherd iterate ...` or
+`npx pr-shepherd resolve ...`. To drive the CLI without Claude at all, see
+[docs/usage.md](docs/usage.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Autonomous PR CI monitor and review-comment resolver for Claude Code.
 
 Claude's cloud autofix requires CI to verify changes for apps that can't run in the cloud. Running targeted tests locally and letting Claude Code drive is cheaper and avoids vendor lock-in. Skills are used (not subagents) because subagents load all CLAUDE.md context, increasing cost; skills inject into the main conversation instead.
 
+## Requirements
+
+- Node.js ≥ 24.0.0
+- `gh` CLI authenticated (`gh auth login`)
+- `git`
+
 ## Install
 
 ```bash
@@ -39,11 +45,99 @@ claude /plugin marketplace add jonathanong/pr-shepherd
 claude /plugin install pr-shepherd
 ```
 
-Then use:
+See [Usage](#usage) below.
 
-- `/pr-shepherd:monitor [PR]` — start continuous monitoring
-- `/pr-shepherd:check [PR]` — one-shot status check
-- `/pr-shepherd:resolve [PR]` — fetch, fix, and resolve review comments
+### Without the plugin — custom slash command
+
+If you don't want the full plugin, create a project-local (or user-scope)
+slash command that wraps the CLI directly.
+
+1. **Create the command file:**
+   - Project-scope: `.claude/commands/pr-check.md`
+   - User-scope: `~/.claude/commands/pr-check.md`
+
+2. **Paste this as the file contents:**
+
+   ````markdown
+   ---
+   description: "Check GitHub CI status and review comments for the current PR"
+   argument-hint: "[PR number or URL ...]"
+   allowed-tools: ["Bash", "Read", "Grep"]
+   ---
+
+   # PR Status Check
+
+   ## Arguments: $ARGUMENTS
+
+   ## Resolve PR number(s)
+
+   1. If `$ARGUMENTS` contains PR numbers or GitHub PR URLs, extract the number(s).
+   2. Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
+   3. If no PR found, report an error and stop.
+
+   ## Run the check
+
+   ```bash
+   npx pr-shepherd check <N> --format=json
+   ```
+
+   Parse the JSON and report:
+
+   - **Merge status** (`report.mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN
+   - **CI check results** (`report.checks`): passing count, failing names, in-progress names
+   - **Unresolved review comments** (`report.threads.actionable` + `report.comments.actionable`): count + details
+   ````
+
+3. **Use it in Claude Code:**
+
+   ```
+   /pr-check
+   /pr-check 42
+   ```
+
+For `monitor` and `resolve` equivalents, copy
+[`skills/monitor/SKILL.md`](skills/monitor/SKILL.md) and
+[`skills/resolve/SKILL.md`](skills/resolve/SKILL.md) the same way. To drive
+the CLI without Claude at all, see [docs/usage.md](docs/usage.md).
+
+## Usage
+
+### Monitor a PR
+
+Creates a cron loop that fires every 4 minutes, checks CI and review
+comments, fixes issues, and marks the PR ready for review when clean. The
+loop cancels automatically when the PR is merged or closed.
+
+```
+/pr-shepherd:monitor                     # infer PR from current branch
+/pr-shepherd:monitor 42
+/pr-shepherd:monitor 42 every 8m
+/pr-shepherd:monitor 42 --ready-delay 15m
+```
+
+### Check a PR
+
+One-shot status snapshot — merge state, CI results, and unresolved comments.
+Accepts multiple PR numbers.
+
+```
+/pr-shepherd:check        # infer from branch
+/pr-shepherd:check 42
+/pr-shepherd:check 41 42 43
+```
+
+### Resolve review comments
+
+Fetches all actionable threads and comments, triages them, applies fixes,
+pushes, then resolves/minimizes/dismisses via `--require-sha` (waits until
+GitHub has seen the push before resolving).
+
+```
+/pr-shepherd:resolve       # infer from branch
+/pr-shepherd:resolve 42
+```
+
+See [docs/skills.md](docs/skills.md) for full argument reference.
 
 ## Workflow
 
@@ -134,12 +228,6 @@ actions:
 ```
 
 See [docs/configuration.md](docs/configuration.md) for all options.
-
-## Requirements
-
-- Node.js ≥ 24.0.0
-- `gh` CLI authenticated (`gh auth login`)
-- `git`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ slash command that wraps the CLI directly.
    ## Run the check
 
    ```bash
-   npx pr-shepherd check <N> --format=json
+   npx pr-shepherd check <PR_NUMBER> --format=json
    ```
 
    Parse the JSON and report:


### PR DESCRIPTION
## Summary

- Adds a **Usage** section to README with examples for all three slash commands (`/pr-shepherd:monitor`, `/pr-shepherd:check`, `/pr-shepherd:resolve`)
- Adds a **Without the plugin — custom slash command** section under Install, with a copy-pasteable `.claude/commands/pr-check.md` example
- Moves Requirements above Install so prereqs are visible before installation steps
- Trims the bare bullet list under "As a Claude Code plugin" — points to the new Usage section instead

## Test plan

- [ ] `npm run format:check` passes
- [ ] All intra-repo links resolve: `docs/skills.md`, `docs/usage.md`, `skills/monitor/SKILL.md`, `skills/resolve/SKILL.md`
- [ ] Paste the custom-command snippet into `.claude/commands/pr-check.md` in a project with an open PR and verify `/pr-check` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)