### PR TITLE
build: compile TypeScript to dist/ for npm publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 .DS_Store
 *.log
 .pr-shepherdrc.yml

--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
   "author": "Jonathan Ong",
   "type": "module",
   "bin": {
-    "pr-shepherd": "./src/index.mts"
+    "pr-shepherd": "./dist/index.mjs"
   },
   "files": [
-    "src/**/*.mts",
-    "src/**/*.json",
-    "src/**/*.gql",
+    "dist/**",
     "skills/**",
     ".claude-plugin/**",
     "marketplace.json",
@@ -33,7 +31,8 @@
     "@vitest/coverage-v8": "^4.1.4"
   },
   "scripts": {
-    "prepublishOnly": "npm run typecheck && npm test",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && cp src/config.json dist/ && cp -r src/github/gql dist/github/",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/ skills/",
     "format": "oxfmt src/ skills/ docs/ README.md",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@vitest/coverage-v8": "^4.1.4"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.build.json && cp src/config.json dist/ && cp -r src/github/gql dist/github/",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && cp src/config.json dist/ && mkdir -p dist/github && cp -r src/github/gql dist/github/",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/ skills/",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.mts", "src/**/*.mock.test.mts"]
+}


### PR DESCRIPTION
## Problem

Node.js v25 refuses to strip types from files inside \`node_modules\`:

\`\`\`
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently
unsupported for files under node_modules, for ".../node_modules/pr-shepherd/src/index.mts"
\`\`\`

The published package pointed \`bin\` at raw \`.mts\` source, which works in dev (the file isn't in \`node_modules\`) but fails when users run \`npx pr-shepherd\`.

## Fix

- Add \`tsconfig.build.json\` that emits compiled JS to \`dist/\` (tests excluded)
- Build script: \`tsc\` + copy \`config.json\` and GQL files into \`dist/\`
- Update \`bin\` to \`./dist/index.mjs\`
- Update \`files\` to \`dist/**\` (no longer ship \`src/**\`)
- Add \`dist/\` to \`.gitignore\`
- Prepend \`build\` to \`prepublishOnly\`

## Test plan

- [ ] \`npm run build\` produces clean \`dist/\` with no test files
- [ ] \`node dist/index.mjs\` prints usage without error
- [ ] \`npx pr-shepherd@next iterate\` works after publishing a prerelease

🤖 Generated with [Claude Code](https://claude.com/claude-code)