### PR TITLE
build: compile CLI into bin/ for Claude Code plugin PATH discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 test-results/
 coverage/
 node_modules/
-dist/
+bin/
 .DS_Store
 *.log
 .pr-shepherdrc.yml

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vitest/coverage-v8": "^4.1.4"
   },
   "scripts": {
-    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && mv bin/index.mjs bin/pr-shepherd && node -e \"require('fs').chmodSync('bin/pr-shepherd', 0o755)\"",
+    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && node -e \"const fs=require('fs');fs.renameSync('bin/index.mjs','bin/pr-shepherd');fs.chmodSync('bin/pr-shepherd',0o755)\"",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vitest/coverage-v8": "^4.1.4"
   },
   "scripts": {
-    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && node -e \"const fs=require('fs');fs.renameSync('bin/index.mjs','bin/pr-shepherd');fs.chmodSync('bin/pr-shepherd',0o755)\"",
+    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && printf '#!/usr/bin/env node\\nimport(\"./index.mjs\")\\n' > bin/pr-shepherd && chmod +x bin/pr-shepherd",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "author": "Jonathan Ong",
   "type": "module",
   "bin": {
-    "pr-shepherd": "dist/index.mjs"
+    "pr-shepherd": "bin/pr-shepherd"
   },
   "files": [
-    "dist/**",
+    "bin/**",
     "skills/**",
     ".claude-plugin/**",
     "marketplace.json",
@@ -31,7 +31,7 @@
     "@vitest/coverage-v8": "^4.1.4"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.build.json && cp src/config.json dist/ && mkdir -p dist/github && cp -r src/github/gql dist/github/ && node -e \"require('fs').chmodSync('dist/index.mjs', 0o755)\"",
+    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && mv bin/index.mjs bin/pr-shepherd && node -e \"require('fs').chmodSync('bin/pr-shepherd', 0o755)\"",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
+    "outDir": "./bin",
     "declaration": false,
     "sourceMap": false
   },
-  "exclude": ["node_modules", "dist", "src/**/*.test.mts", "src/**/*.mock.test.mts"]
+  "exclude": ["node_modules", "bin", "src/**/*.test.mts", "src/**/*.mock.test.mts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.mts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "bin"]
 }


### PR DESCRIPTION
## Summary

- Retargets the TypeScript build output from `dist/` to `bin/`, renaming the entry `index.mjs` → `pr-shepherd` (no extension, 0755)
- Updates `package.json` `bin`, `files`, and `build` script accordingly
- Replaces `dist/` with `bin/` in `.gitignore` and both tsconfig `exclude` arrays

## Why

Claude Code plugins automatically add `bin/` at the plugin root to the Bash tool's `PATH` when the plugin is enabled. Previously the CLI lived at `dist/index.mjs` — npm's `bin` field handled PATH symlinking for `npm install` users, but the Claude Code plugin loader never saw an executable because there was no `bin/` directory. With this change, `bin/pr-shepherd` is available on PATH for plugin users out of the box.

## Test plan

- [ ] `npm run build` produces `bin/pr-shepherd` (0755, shebang `#!/usr/bin/env node`) with full compiled tree alongside
- [ ] `./bin/pr-shepherd` prints usage (resolves sibling `bin/cli.mjs` imports correctly)
- [ ] `npm run typecheck && npm test` pass
- [ ] `npm pack --dry-run` shows `bin/**` in tarball, no `dist/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)