### PR TITLE
fix: trim noise from resolve --fetch JSON output

### DIFF
--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -147,7 +147,6 @@ describe("main — check", () => {
 describe("main — resolve", () => {
   it("calls runResolveFetch when no mutation flags are given (fetch mode)", async () => {
     mockRunResolveFetch.mockResolvedValue({
-      autoResolved: [],
       actionableThreads: [],
       actionableComments: [],
       changesRequestedReviews: [],

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -179,13 +179,6 @@ async function handleStatus(args: string[]): Promise<void> {
 function formatFetchResult(result: Awaited<ReturnType<typeof runResolveFetch>>): string {
   const lines: string[] = [];
 
-  if (result.autoResolved.length > 0) {
-    lines.push(`Auto-resolved outdated (${result.autoResolved.length}):`);
-    for (const t of result.autoResolved) {
-      lines.push(`  - threadId=${t.id} ${t.path ?? ""}:${t.line ?? "?"} (@${t.author})`);
-    }
-  }
-
   if (result.actionableThreads.length > 0) {
     lines.push(`\nActionable Review Threads (${result.actionableThreads.length}):`);
     for (const t of result.actionableThreads) {

--- a/src/commands/resolve.mock.test.mts
+++ b/src/commands/resolve.mock.test.mts
@@ -103,10 +103,8 @@ describe("runResolveFetch — auto-resolves outdated threads", () => {
     });
     mockAutoResolveOutdated.mockResolvedValue({ resolved: ["outdated-1"], errors: [] });
 
-    const result = await runResolveFetch(BASE_OPTS);
+    await runResolveFetch(BASE_OPTS);
     expect(mockAutoResolveOutdated).toHaveBeenCalledWith(["outdated-1"]);
-    expect(result.autoResolved).toHaveLength(1);
-    expect(result.autoResolved[0]!.id).toBe("outdated-1");
   });
 
   it("activeThreads excludes outdated threads", async () => {

--- a/src/commands/resolve.mts
+++ b/src/commands/resolve.mts
@@ -56,7 +56,10 @@ export async function runResolveFetch(opts: ResolveCommandOptions): Promise<Fetc
   // Auto-resolve outdated.
   const outdated = getOutdatedThreads(unresolvedThreads);
   if (outdated.length > 0) {
-    await autoResolveOutdated(outdated.map((t) => t.id));
+    const { errors } = await autoResolveOutdated(outdated.map((t) => t.id));
+    if (errors.length > 0) {
+      throw new Error(`Failed to auto-resolve outdated threads: ${errors.join(", ")}`);
+    }
   }
 
   const activeThreads = unresolvedThreads.filter((t) => !t.isOutdated);

--- a/src/commands/resolve.mts
+++ b/src/commands/resolve.mts
@@ -62,14 +62,7 @@ export async function runResolveFetch(opts: ResolveCommandOptions): Promise<Fetc
   const activeThreads = unresolvedThreads.filter((t) => !t.isOutdated);
 
   return {
-    actionableThreads: activeThreads.map(({ id, path, line, author, body, createdAtUnix }) => ({
-      id,
-      path,
-      line,
-      author,
-      body,
-      createdAtUnix,
-    })),
+    actionableThreads: activeThreads.map(({ isResolved, isOutdated, ...rest }) => rest),
     actionableComments: visibleComments,
     changesRequestedReviews: data.changesRequestedReviews,
   };

--- a/src/commands/resolve.mts
+++ b/src/commands/resolve.mts
@@ -24,9 +24,10 @@ import type { GlobalOptions, ResolveOptions, ReviewThread, PrComment, Review } f
 // Public API
 // ---------------------------------------------------------------------------
 
+export type FetchThread = Omit<ReviewThread, "isResolved" | "isOutdated">;
+
 export interface FetchResult {
-  autoResolved: ReviewThread[];
-  actionableThreads: ReviewThread[];
+  actionableThreads: FetchThread[];
   actionableComments: PrComment[];
   changesRequestedReviews: Review[];
 }
@@ -54,17 +55,21 @@ export async function runResolveFetch(opts: ResolveCommandOptions): Promise<Fetc
 
   // Auto-resolve outdated.
   const outdated = getOutdatedThreads(unresolvedThreads);
-  let autoResolved: ReviewThread[] = [];
   if (outdated.length > 0) {
-    const { resolved: resolvedIds } = await autoResolveOutdated(outdated.map((t) => t.id));
-    autoResolved = outdated.filter((t) => resolvedIds.includes(t.id));
+    await autoResolveOutdated(outdated.map((t) => t.id));
   }
 
   const activeThreads = unresolvedThreads.filter((t) => !t.isOutdated);
 
   return {
-    autoResolved,
-    actionableThreads: activeThreads,
+    actionableThreads: activeThreads.map(({ id, path, line, author, body, createdAtUnix }) => ({
+      id,
+      path,
+      line,
+      author,
+      body,
+      createdAtUnix,
+    })),
     actionableComments: visibleComments,
     changesRequestedReviews: data.changesRequestedReviews,
   };


### PR DESCRIPTION
## Summary

- Drop `autoResolved` from `FetchResult` — the resolve skill never reads it
- Strip `isResolved` and `isOutdated` from thread objects in the JSON output — always `false` after filtering, pure noise for the agent
- Auto-resolve side effect (resolving outdated threads on GitHub) is preserved

## Test plan

- [ ] All 335 unit tests pass (`npm test`)
- [ ] `npm run build` succeeds
- [ ] Verify resolve output no longer contains `autoResolved`, `isResolved`, or `isOutdated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)