### PR TITLE
fix: relax engines.node to >=22.0.0 (Node 22 LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['24.x']
+        node-version: ['22.x', '24.x']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "yaml": "^2.7.0"


### PR DESCRIPTION
Node 22 is the active LTS (supported through October 2026) but was excluded by the `>=24.0.0` requirement. The codebase uses no Node-24-only APIs, so this was overly restrictive.

Changes:
- `engines.node`: `>=24.0.0` → `>=22.0.0`
- CI matrix: add `22.x` alongside `24.x` so both LTS versions are validated