### PR TITLE
fix: pin oxlint and oxfmt devDependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "pr-shepherd": "src/index.mts"
+        "pr-shepherd": "bin/pr-shepherd"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.4",
-        "oxfmt": "latest",
-        "oxlint": "latest",
+        "oxfmt": "^0.45.0",
+        "oxlint": "^1.60.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
       },

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "oxfmt": "latest",
-    "oxlint": "latest",
+    "oxfmt": "^0.45.0",
+    "oxlint": "^1.60.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4",
     "@vitest/coverage-v8": "^4.1.4"


### PR DESCRIPTION
`latest` is not a valid semver range — two `npm install` runs on different dates can resolve different tool versions and silently change linter/formatter output. `npm ci` is consistent (it uses the lockfile) but `npm install` in a contributor clone will drift.

Pins to the versions already in the lockfile: `oxlint@^1.60.0`, `oxfmt@^0.45.0`. No behavior change.