### PR TITLE
docs: clarify cacheSet doc comment

### DIFF
--- a/src/cache/file-cache.mts
+++ b/src/cache/file-cache.mts
@@ -47,7 +47,8 @@ export async function cacheGet<T>(key: CacheKey, opts: CacheOptions = {}): Promi
 }
 
 /**
- * Write a value to the cache (fire-and-forget — never throws).
+ * Write a value to the cache. Errors are swallowed — callers can await
+ * to know when the write is done, but the write never rejects.
  */
 export async function cacheSet<T>(key: CacheKey, value: T, opts: CacheOptions = {}): Promise<void> {
   if (opts.disabled) return;


### PR DESCRIPTION
The previous doc said "fire-and-forget — never throws", but callers \`await cacheSet(...)\`. "Fire-and-forget" implies unawaited; the actual semantics are "awaitable, but errors are silently swallowed". Updated to reflect the real behavior.