### PR TITLE
fix: remove spurious gh --version warmup from getCurrentBranch

### DIFF
--- a/src/github/client.mock.test.mts
+++ b/src/github/client.mock.test.mts
@@ -158,16 +158,13 @@ describe("graphqlWithRateLimit — header parsing", () => {
 
 describe("getCurrentPrNumber", () => {
   it("returns null when branch is HEAD (detached)", async () => {
-    // First call: gh --version (warmup), second call: git rev-parse
-    mockExecFile
-      .mockResolvedValueOnce({ stdout: "gh version 2.0.0" })
-      .mockResolvedValueOnce({ stdout: "HEAD\n" });
+    // First call: git rev-parse
+    mockExecFile.mockResolvedValueOnce({ stdout: "HEAD\n" });
     expect(await getCurrentPrNumber()).toBeNull();
   });
 
   it("returns null when gh pr list returns empty string", async () => {
     mockExecFile
-      .mockResolvedValueOnce({ stdout: "gh version 2.0.0" })
       .mockResolvedValueOnce({ stdout: "my-branch\n" })
       .mockResolvedValueOnce({ stdout: "\n" });
     expect(await getCurrentPrNumber()).toBeNull();
@@ -175,7 +172,6 @@ describe("getCurrentPrNumber", () => {
 
   it("returns null when gh pr list returns 'null'", async () => {
     mockExecFile
-      .mockResolvedValueOnce({ stdout: "gh version 2.0.0" })
       .mockResolvedValueOnce({ stdout: "my-branch\n" })
       .mockResolvedValueOnce({ stdout: "null\n" });
     expect(await getCurrentPrNumber()).toBeNull();
@@ -183,7 +179,6 @@ describe("getCurrentPrNumber", () => {
 
   it("returns PR number on success", async () => {
     mockExecFile
-      .mockResolvedValueOnce({ stdout: "gh version 2.0.0" })
       .mockResolvedValueOnce({ stdout: "my-branch\n" })
       .mockResolvedValueOnce({ stdout: "123\n" });
     expect(await getCurrentPrNumber()).toBe(123);

--- a/src/github/client.mts
+++ b/src/github/client.mts
@@ -129,7 +129,6 @@ export async function getCurrentPrNumber(): Promise<number | null> {
 }
 
 async function getCurrentBranch(): Promise<string> {
-  await runGh(["--version"]); // warm up gh CLI before git call
   // Use git directly for branch name — gh doesn't expose it.
   const { stdout } = await execFile("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   return stdout.trim();


### PR DESCRIPTION
\`gh\` and \`git\` are independent processes with no shared state. The warm-up call has no observable effect and adds ~40-80 ms of latency on every \`getCurrentBranch()\` invocation (used by \`getCurrentPrNumber()\` in both \`runIterate\` and \`runResolveFetch\`).