### PR TITLE
fix: use statSync for RC file existence check

### DIFF
--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { parse } from "yaml";
@@ -53,11 +53,8 @@ function findRcFile(startDir: string): string | null {
   let current = startDir;
   while (true) {
     const candidate = join(current, RC_FILENAME);
-    try {
-      readFileSync(candidate);
+    if (statSync(candidate, { throwIfNoEntry: false })) {
       return candidate;
-    } catch {
-      // not found here
     }
     if (current === home || current === dirname(current)) return null;
     current = dirname(current);

--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -53,7 +53,7 @@ function findRcFile(startDir: string): string | null {
   let current = startDir;
   while (true) {
     const candidate = join(current, RC_FILENAME);
-    if (statSync(candidate, { throwIfNoEntry: false })) {
+    if (statSync(candidate, { throwIfNoEntry: false })?.isFile()) {
       return candidate;
     }
     if (current === home || current === dirname(current)) return null;


### PR DESCRIPTION
\`findRcFile\` was using \`readFileSync\` + try/catch to check for each candidate RC file, which allocates an Error on every directory traversal miss. \`statSync(path, { throwIfNoEntry: false })\` (Node 16+) returns \`undefined\` without throwing, making the hot path allocation-free.