### PR TITLE
fix: guard repo split result and remove non-null assertions in runIterate

### DIFF
--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -1252,6 +1252,24 @@ describe("runIterate — escalate (pr-level-changes-requested with actionable co
   });
 });
 
+describe("runIterate — malformed repo format", () => {
+  it("throws when report.repo has no slash (e.g. 'badformat')", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ repo: "badformat" }));
+
+    await expect(runIterate(makeOpts())).rejects.toThrow(
+      'Unexpected repo format: "badformat" (expected "owner/name")',
+    );
+  });
+
+  it("throws when report.repo has a leading slash (e.g. '/noowner')", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ repo: "/noowner" }));
+
+    await expect(runIterate(makeOpts())).rejects.toThrow(
+      'Unexpected repo format: "/noowner" (expected "owner/name")',
+    );
+  });
+});
+
 describe("runIterate — escalate (thread-missing-location)", () => {
   it("escalates when an actionable thread has no file/line reference", async () => {
     const threadNoPath = { ...THREAD, id: "thread-noloc", path: null, line: null };

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -108,13 +108,16 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
 
   // Step 3: Ready-delay state machine.
   const [repoOwner, repoName] = report.repo.split("/");
+  if (!repoOwner || !repoName) {
+    throw new Error(`Unexpected repo format: "${report.repo}" (expected "owner/name")`);
+  }
   const isReady = report.status === "READY";
   const readyState = await updateReadyDelay(
     report.pr,
     isReady,
     readyDelaySeconds,
-    repoOwner!,
-    repoName!,
+    repoOwner,
+    repoName,
   );
 
   const base: IterateResultBase = {
@@ -155,7 +158,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   if (hasActionableWork) {
     // Load fix-attempt counts, resetting if HEAD SHA changed (new commit pushed).
     const headSha = await getCurrentHeadSha();
-    const attemptsKey = { owner: repoOwner!, repo: repoName!, pr: prNumber };
+    const attemptsKey = { owner: repoOwner, repo: repoName, pr: prNumber };
     const stored = await readFixAttempts(attemptsKey);
     const attempts =
       stored?.headSha === headSha


### PR DESCRIPTION
\`report.repo.split("/")\` was followed by \`repoOwner!\`/\`repoName!\` which hide the invariant and produce confusing downstream errors if the format is ever wrong.

Added an explicit guard that throws early with a clear message, then removed the non-null assertions since TypeScript can now narrow the types.