### PR TITLE
fix: remove unused tool permissions from monitor skill

### DIFF
--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -5,10 +5,10 @@ argument-hint: "[PR number or URL] [every <interval>] [--ready-delay <duration>]
 user-invocable: true
 allowed-tools:
   ["Bash", "Read", "Grep", "Edit", "Write", "Skill", "CronList"]
-  # CronCreate and CronDelete are intentionally omitted: they are invoked
-  # internally by /loop (via the Skill tool), never called directly by this skill.
-  # CronList is kept because the skill explicitly calls it to check for an
-  # existing loop before starting a new one.
+  # CronCreate and CronDelete are intentionally omitted: loop creation and
+  # cancellation are both delegated to /loop via the Skill tool. CronList is
+  # kept because the skill explicitly calls it to check for an existing loop
+  # before starting a new one.
 ---
 
 # pr-shepherd monitor — Continuous PR Monitor

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: "Start continuous CI monitoring — marks PR ready for review when 
 argument-hint: "[PR number or URL] [every <interval>] [--ready-delay <duration>]"
 user-invocable: true
 allowed-tools:
-  ["Bash", "Read", "Grep", "Edit", "Write", "Glob", "Skill", "CronList"]
+  ["Bash", "Read", "Grep", "Edit", "Write", "Skill", "CronList"]
   # CronCreate and CronDelete are intentionally omitted: they are invoked
   # internally by /loop (via the Skill tool), never called directly by this skill.
   # CronList is kept because the skill explicitly calls it to check for an

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -4,7 +4,11 @@ description: "Start continuous CI monitoring — marks PR ready for review when 
 argument-hint: "[PR number or URL] [every <interval>] [--ready-delay <duration>]"
 user-invocable: true
 allowed-tools:
-  ["Bash", "Read", "Grep", "Edit", "Write", "Glob", "Skill", "CronCreate", "CronList", "CronDelete"]
+  ["Bash", "Read", "Grep", "Edit", "Write", "Glob", "Skill", "CronList"]
+  # CronCreate and CronDelete are intentionally omitted: they are invoked
+  # internally by /loop (via the Skill tool), never called directly by this skill.
+  # CronList is kept because the skill explicitly calls it to check for an
+  # existing loop before starting a new one.
 ---
 
 # pr-shepherd monitor — Continuous PR Monitor


### PR DESCRIPTION
The monitor skill listed \`CronCreate\` and \`CronDelete\` in \`allowed-tools\` but the skill body funnels loop creation through \`/loop\` via the \`Skill\` tool — \`CronCreate\`/\`CronDelete\` are never called directly. Listing unused tool permissions grants the plugin broader access than it actually needs.

Kept \`CronList\` since the skill explicitly calls it to check for an existing loop before starting a new one.