### PR TITLE
fix: validate parseInt flag values and throw on NaN

### DIFF
--- a/src/cli.mts
+++ b/src/cli.mts
@@ -117,7 +117,9 @@ async function handleIterate(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
 
   const lastPushTimeStr = getFlag(extra, "--last-push-time");
-  const lastPushTime = lastPushTimeStr ? parseIntStrict(lastPushTimeStr, "--last-push-time") : undefined;
+  const lastPushTime = lastPushTimeStr
+    ? parseIntStrict(lastPushTimeStr, "--last-push-time")
+    : undefined;
   const readyDelayStr = getFlag(extra, "--ready-delay");
   const cfg = loadConfig();
   const readyDelaySeconds =

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -25,6 +25,7 @@ import {
   parseList,
   parseStatusPrNumbers,
   parseDurationToMinutes,
+  parseIntStrict,
   statusToExitCode,
   iterateActionToExitCode,
   deriveSimpleReady,
@@ -116,14 +117,14 @@ async function handleIterate(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
 
   const lastPushTimeStr = getFlag(extra, "--last-push-time");
-  const lastPushTime = lastPushTimeStr ? parseInt(lastPushTimeStr, 10) : undefined;
+  const lastPushTime = lastPushTimeStr ? parseIntStrict(lastPushTimeStr, "--last-push-time") : undefined;
   const readyDelayStr = getFlag(extra, "--ready-delay");
   const cfg = loadConfig();
   const readyDelaySeconds =
     parseDurationToMinutes(readyDelayStr ?? "", cfg.watch.readyDelayMinutes) * 60;
   const cooldownSecondsStr = getFlag(extra, "--cooldown-seconds");
   const cooldownSeconds = cooldownSecondsStr
-    ? parseInt(cooldownSecondsStr, 10)
+    ? parseIntStrict(cooldownSecondsStr, "--cooldown-seconds")
     : cfg.iterate.cooldownSeconds;
   const noAutoRerun = hasFlag(extra, "--no-auto-rerun");
   const noAutoMarkReady = hasFlag(extra, "--no-auto-mark-ready");

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -26,11 +26,10 @@ const FLAGS_WITH_VALUES = new Set([
 // ---------------------------------------------------------------------------
 
 export function parseIntStrict(value: string, flag: string): number {
-  const n = parseInt(value, 10);
-  if (!Number.isFinite(n)) {
+  if (!/^-?\d+$/.test(value.trim())) {
     throw new Error(`Invalid value for ${flag}: "${value}" is not an integer`);
   }
-  return n;
+  return parseInt(value, 10);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -60,7 +60,9 @@ export function parseCommonArgs(args: string[]): ParsedArgs {
   const format = (values.format ?? "text") as string as "text" | "json";
   const noCache = (values["no-cache"] ?? false) as boolean;
   const cacheTtlStr = values["cache-ttl"] as string | undefined;
-  const cacheTtlSeconds = cacheTtlStr ? parseIntStrict(cacheTtlStr, "--cache-ttl") : config.cache.ttlSeconds;
+  const cacheTtlSeconds = cacheTtlStr
+    ? parseIntStrict(cacheTtlStr, "--cache-ttl")
+    : config.cache.ttlSeconds;
 
   // Build the set of arg indices consumed by global flags so we can strip
   // them from `extra`.  Subcommand-specific flags are left untouched.

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -22,6 +22,18 @@ const FLAGS_WITH_VALUES = new Set([
 ]);
 
 // ---------------------------------------------------------------------------
+// Strict integer parsing
+// ---------------------------------------------------------------------------
+
+export function parseIntStrict(value: string, flag: string): number {
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) {
+    throw new Error(`Invalid value for ${flag}: "${value}" is not an integer`);
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
 // Common arg parsing
 // ---------------------------------------------------------------------------
 
@@ -49,7 +61,7 @@ export function parseCommonArgs(args: string[]): ParsedArgs {
   const format = (values.format ?? "text") as string as "text" | "json";
   const noCache = (values["no-cache"] ?? false) as boolean;
   const cacheTtlStr = values["cache-ttl"] as string | undefined;
-  const cacheTtlSeconds = cacheTtlStr ? parseInt(cacheTtlStr, 10) : config.cache.ttlSeconds;
+  const cacheTtlSeconds = cacheTtlStr ? parseIntStrict(cacheTtlStr, "--cache-ttl") : config.cache.ttlSeconds;
 
   // Build the set of arg indices consumed by global flags so we can strip
   // them from `extra`.  Subcommand-specific flags are left untouched.

--- a/src/cli/args.test.mts
+++ b/src/cli/args.test.mts
@@ -6,12 +6,45 @@ import {
   parseStatusPrNumbers,
   parseCommonArgs,
   parseDurationToMinutes,
+  parseIntStrict,
   statusToExitCode,
   iterateActionToExitCode,
   deriveSimpleReady,
 } from "./args.mts";
 import type { PrSummary } from "../commands/status.mts";
 import type { ShepherdAction } from "../types.mts";
+
+// ---------------------------------------------------------------------------
+// parseIntStrict
+// ---------------------------------------------------------------------------
+
+describe("parseIntStrict", () => {
+  it("returns an integer for a valid integer string", () => {
+    expect(parseIntStrict("42", "--flag")).toBe(42);
+  });
+
+  it("accepts negative integers", () => {
+    expect(parseIntStrict("-5", "--flag")).toBe(-5);
+  });
+
+  it("throws for a float string like '10.5'", () => {
+    expect(() => parseIntStrict("10.5", "--cache-ttl")).toThrow(
+      'Invalid value for --cache-ttl: "10.5" is not an integer',
+    );
+  });
+
+  it("throws for a partial integer like '10abc'", () => {
+    expect(() => parseIntStrict("10abc", "--cache-ttl")).toThrow(
+      'Invalid value for --cache-ttl: "10abc" is not an integer',
+    );
+  });
+
+  it("throws for a non-numeric string", () => {
+    expect(() => parseIntStrict("abc", "--cache-ttl")).toThrow(
+      'Invalid value for --cache-ttl: "abc" is not an integer',
+    );
+  });
+});
 
 // ---------------------------------------------------------------------------
 // getFlag


### PR DESCRIPTION
\`parseInt("abc", 10)\` returns \`NaN\` silently. Passing a non-integer to \`--cache-ttl\` caused the cache to never expire; passing one to \`--cooldown-seconds\` caused the cooldown to be skipped.

Added a \`parseIntStrict\` helper that throws a clear error for non-integer flag values, and applied it to the three affected call sites.