### PR TITLE
docs: explain dual marketplace.json files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ claude /plugin marketplace add jonathanong/pr-shepherd
 claude /plugin install pr-shepherd
 ```
 
+This repo ships two `marketplace.json` files that serve different install flows: the root `marketplace.json` resolves the plugin from the npm registry (used by the `claude /plugin marketplace add` command above); `.claude-plugin/marketplace.json` is the owner-level registry manifest that resolves the plugin from the local plugin directory (used when Claude Code installs from a local or git-based source). Both files are needed to support these two install paths.
+
 See [Usage](#usage) below.
 
 ### Without the plugin — custom slash command


### PR DESCRIPTION
The repo ships two \`marketplace.json\` files that serve different install flows, which was confusing to anyone reading the source. Added a note in the README Install section explaining the distinction:

- root \`marketplace.json\` → npm-based install
- \`.claude-plugin/marketplace.json\` → local/git-based install