### PR TITLE
fix: use process.exitCode instead of process.exit in CLI handlers

### DIFF
--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -31,9 +31,7 @@ const mockRunResolveMutate = vi.mocked(runResolveMutate);
 const mockRunIterate = vi.mocked(runIterate);
 const mockRunStatus = vi.mocked(runStatus);
 
-// Spy on process.exit to avoid actually exiting.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let exitSpy: any;
 let stdoutSpy: any;
 let stderrSpy: any;
 
@@ -108,15 +106,14 @@ function makeIterateResult(action: IterateResult["action"] = "wait"): IterateRes
 
 beforeEach(() => {
   vi.clearAllMocks();
-  exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as () => never);
+  process.exitCode = undefined;
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-  // Default: return empty arrays so code doesn't crash after mocked process.exit.
   mockRunStatus.mockResolvedValue([]);
 });
 
 afterEach(() => {
-  exitSpy.mockRestore();
+  process.exitCode = undefined;
   stdoutSpy.mockRestore();
   stderrSpy.mockRestore();
 });
@@ -130,13 +127,13 @@ describe("main — check", () => {
     mockRunCheck.mockResolvedValue(makeReport({ status: "READY" }));
     await main(["node", "shepherd", "check", "42"]);
     expect(mockRunCheck).toHaveBeenCalledTimes(1);
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(process.exitCode).toBe(0);
   });
 
   it("exits with code 1 for FAILING status", async () => {
     mockRunCheck.mockResolvedValue(makeReport({ status: "FAILING" }));
     await main(["node", "shepherd", "check", "42"]);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
   });
 });
 
@@ -177,13 +174,13 @@ describe("main — iterate", () => {
   it("exits with iterateActionToExitCode(fix_code)=1", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("fix_code"));
     await main(["node", "shepherd", "iterate", "42"]);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
   });
 
   it("exits with 0 for wait action", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
     await main(["node", "shepherd", "iterate", "42"]);
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(process.exitCode).toBe(0);
   });
 });
 
@@ -196,7 +193,7 @@ describe("main — status", () => {
     await main(["node", "shepherd", "status"]);
     const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
     expect(stderrOutput).toContain("Usage");
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
   });
 
   it("calls runStatus and exits 0 when all PRs are ready", async () => {
@@ -215,7 +212,7 @@ describe("main — status", () => {
     ]);
     await main(["node", "shepherd", "status", "1"]);
     expect(mockRunStatus).toHaveBeenCalledTimes(1);
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(process.exitCode).toBe(0);
   });
 });
 
@@ -228,6 +225,6 @@ describe("main — unknown subcommand", () => {
     await main(["node", "shepherd", "unknown-command"]);
     const stderrOutput = stderrSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
     expect(stderrOutput).toContain("Unknown subcommand");
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -55,7 +55,7 @@ export async function main(argv: string[]): Promise<void> {
     default:
       process.stderr.write(`Unknown subcommand: ${subcommand ?? "(none)"}\n`);
       process.stderr.write("Usage: pr-shepherd <check|resolve|iterate|status> [options]\n");
-      process.exit(1);
+      process.exitCode = 1; return;
   }
 }
 
@@ -70,7 +70,7 @@ async function handleCheck(args: string[]): Promise<void> {
   const output = globalOpts.format === "json" ? formatJson(report) : formatText(report);
   process.stdout.write(`${output}\n`);
 
-  process.exit(statusToExitCode(report.status));
+  process.exitCode = statusToExitCode(report.status); return;
 }
 
 async function handleResolve(args: string[]): Promise<void> {
@@ -146,7 +146,7 @@ async function handleIterate(args: string[]): Promise<void> {
     process.stdout.write(`${formatIterateResult(result)}\n`);
   }
 
-  process.exit(iterateActionToExitCode(result.action));
+  process.exitCode = iterateActionToExitCode(result.action); return;
 }
 
 async function handleStatus(args: string[]): Promise<void> {
@@ -156,7 +156,7 @@ async function handleStatus(args: string[]): Promise<void> {
 
   if (prNumbers.length === 0) {
     process.stderr.write("Usage: pr-shepherd status PR1 [PR2 …]\n");
-    process.exit(1);
+    process.exitCode = 1; return;
   }
 
   const repo = await getRepoInfo();
@@ -169,7 +169,7 @@ async function handleStatus(args: string[]): Promise<void> {
   process.stdout.write(`${output}\n`);
 
   const allReady = summaries.every((s) => deriveSimpleReady(s));
-  process.exit(allReady ? 0 : 1);
+  process.exitCode = allReady ? 0 : 1; return;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -55,7 +55,8 @@ export async function main(argv: string[]): Promise<void> {
     default:
       process.stderr.write(`Unknown subcommand: ${subcommand ?? "(none)"}\n`);
       process.stderr.write("Usage: pr-shepherd <check|resolve|iterate|status> [options]\n");
-      process.exitCode = 1; return;
+      process.exitCode = 1;
+      return;
   }
 }
 
@@ -70,7 +71,8 @@ async function handleCheck(args: string[]): Promise<void> {
   const output = globalOpts.format === "json" ? formatJson(report) : formatText(report);
   process.stdout.write(`${output}\n`);
 
-  process.exitCode = statusToExitCode(report.status); return;
+  process.exitCode = statusToExitCode(report.status);
+  return;
 }
 
 async function handleResolve(args: string[]): Promise<void> {
@@ -146,7 +148,8 @@ async function handleIterate(args: string[]): Promise<void> {
     process.stdout.write(`${formatIterateResult(result)}\n`);
   }
 
-  process.exitCode = iterateActionToExitCode(result.action); return;
+  process.exitCode = iterateActionToExitCode(result.action);
+  return;
 }
 
 async function handleStatus(args: string[]): Promise<void> {
@@ -156,7 +159,8 @@ async function handleStatus(args: string[]): Promise<void> {
 
   if (prNumbers.length === 0) {
     process.stderr.write("Usage: pr-shepherd status PR1 [PR2 …]\n");
-    process.exitCode = 1; return;
+    process.exitCode = 1;
+    return;
   }
 
   const repo = await getRepoInfo();
@@ -169,7 +173,8 @@ async function handleStatus(args: string[]): Promise<void> {
   process.stdout.write(`${output}\n`);
 
   const allReady = summaries.every((s) => deriveSimpleReady(s));
-  process.exitCode = allReady ? 0 : 1; return;
+  process.exitCode = allReady ? 0 : 1;
+  return;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
\`main\` is an exported async function but the handler functions called \`process.exit(N)\` directly, which skips \`finally\` blocks in callers and makes the function unusable in tests without mocking \`process.exit\`.

\`process.exitCode = N; return;\` achieves the same observable exit code (the process exits when the event loop drains) while allowing normal cleanup and making the function testable without spying on \`process.exit\`.