### PR TITLE
refactor: remove generated bin/pr-shepherd launcher, point bin at bin/index.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Jonathan Ong",
   "type": "module",
   "bin": {
-    "pr-shepherd": "bin/pr-shepherd"
+    "pr-shepherd": "bin/index.mjs"
   },
   "files": [
     "bin/**",
@@ -31,7 +31,7 @@
     "@vitest/coverage-v8": "^4.1.4"
   },
   "scripts": {
-    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && printf '#!/usr/bin/env node\\nimport(\"./index.mjs\")\\n' > bin/pr-shepherd && chmod +x bin/pr-shepherd",
+    "build": "rm -rf bin && tsc -p tsconfig.build.json && cp src/config.json bin/ && mkdir -p bin/github && cp -r src/github/gql bin/github/ && chmod +x bin/index.mjs",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
The build was generating a `bin/pr-shepherd` shim with `printf` + `chmod` that just did `import("./index.mjs")`. This was needed because tsc emits `bin/index.mjs` without the executable bit set.

Simpler: `src/index.mts` already has `#!/usr/bin/env node`, tsc preserves shebangs, so we can just `chmod +x bin/index.mjs` in the build and point `package.json bin` directly at it. One less generated file.