### PR TITLE
fix: add project-specific oxlint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {}
+  "rules": {
+    "unicorn/prefer-node-protocol": "error",
+    "radix": "error"
+  }
 }


### PR DESCRIPTION
The oxlint config was empty — no rules beyond defaults. Added rules that enforce conventions already present throughout the codebase:

- `radix`: require the radix argument to `parseInt` (already used everywhere with `, 10`, now enforced)
- `unicorn/prefer-node-protocol`: require the `node:` prefix on built-in imports (already used everywhere, now enforced)

`no-restricted-syntax` (to ban `process.exit()`) was considered but is not supported by oxlint 1.60.0 — confirmed by testing against the schema.

Zero new violations — the rules just lock in what the code already does. Rule count goes from 93 → 95.