### PR TITLE
docs: add npx skills install option and CLI prerequisite note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Autonomous PR CI monitor and review-comment resolver for Claude Code.
 
 ## Install
 
-> **Note:** All install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. Add it to your project's dev dependencies so `npx` resolves it without prompting:
+> **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. Add it to your project's dev dependencies so `npx` resolves it without prompting:
 >
 > ```bash
 > npm install --save-dev pr-shepherd

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Autonomous PR CI monitor and review-comment resolver for Claude Code.
 
 ## Install
 
-> **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. Add it to your project's dev dependencies so `npx` resolves it without prompting:
+> **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. If you're using `pr-shepherd` as development tooling for your repo, install it as a dev dependency so `npx` resolves it without prompting:
 >
 > ```bash
 > npm install --save-dev pr-shepherd
 > ```
 >
-> Or install globally: `npm i -g pr-shepherd`.
+> A plain `npm install pr-shepherd` adds it to regular dependencies instead; use that only if you specifically want it under `dependencies`. Or install globally: `npm install -g pr-shepherd`.
 
 ### As individual skills via `npx skills`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ Autonomous PR CI monitor and review-comment resolver for Claude Code.
 
 ## Install
 
+> **Note:** All install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. Add it to your project's dev dependencies so `npx` resolves it without prompting:
+>
+> ```bash
+> npm install --save-dev pr-shepherd
+> ```
+>
+> Or install globally: `npm i -g pr-shepherd`.
+
+### As individual skills via `npx skills`
+
+```bash
+npx skills add jonathanong/pr-shepherd
+```
+
+Installs the three skills (`check`, `monitor`, `resolve`) into your agent's skill directory (`.claude/skills/` for project scope, `~/.claude/skills/` with `-g` for global scope). Powered by [skills.sh](https://skills.sh).
+
 ### As a Claude Code plugin (recommended)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds an `npx skills add jonathanong/pr-shepherd` install option at the top of the Install section (works today — the CLI's recursive search finds all three skills).
- Adds a top-level note explaining that skill/plugin installs add skill definitions only, not the CLI executable, and directing users to `npm install --save-dev pr-shepherd` to ensure `npx pr-shepherd` resolves without prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)