### PR TITLE
fix: only pass --message when dismissing a review, require specific text

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ pr-shepherd resolve 42 \
   --resolve-thread-ids RT_kwDOabc,RT_kwDOdef \
   --minimize-comment-ids IC_kwDOxyz \
   --dismiss-review-ids PRR_kwDO123 \
-  --message "Addressed in $(git rev-parse HEAD)" \
+  --message "Switched query to parameterized form in src/db.ts" \
   --require-sha $(git rev-parse HEAD)
 ```
 
@@ -244,7 +244,7 @@ Minimized comments (1): IC_kwDOxyz
 Dismissed reviews (1): PRR_kwDO123
 ```
 
-`--require-sha` polls GitHub until the PR head matches the SHA before mutating — ensures reviewers see the fix before threads are closed. Exit code: always `0`.
+`--require-sha` polls GitHub until the PR head matches the SHA before mutating — ensures reviewers see the fix before threads are closed. Exit code: always `0`. `--message` is required only when `--dismiss-review-ids` is set, and should describe the specific fix — it is shown to the reviewer on GitHub.
 
 ### pr-shepherd iterate [PR]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,11 +35,11 @@ pr-shepherd resolve 42 \
   --resolve-thread-ids RT_abc,RT_def \
   --minimize-comment-ids IC_xyz \
   --dismiss-review-ids PRR_123 \
-  --message "Addressed in $(git rev-parse HEAD)" \
+  --message "Switched query to parameterized form in src/db.ts" \
   --require-sha $(git rev-parse HEAD)
 ```
 
-`--require-sha` polls GitHub until the PR head matches the SHA before mutating — prevents resolving before reviewers see the fix.
+`--require-sha` polls GitHub until the PR head matches the SHA before mutating — prevents resolving before reviewers see the fix. `--message` is required only when `--dismiss-review-ids` is set, and should describe the specific fix — it is shown to the reviewer on GitHub.
 
 ### `pr-shepherd iterate [PR]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "pr-shepherd": "bin/pr-shepherd"
+        "pr-shepherd": "bin/index.mjs"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -23,7 +23,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -88,7 +88,14 @@ Parse the `action` field and act:
   4. If files were changed, `git add <files> && git commit -m "<appropriate commit message>"`
   5. If files were changed: `git fetch origin && git rebase origin/<BASE_BRANCH> && git push --force-with-lease` (dangerouslyDisableSandbox: true), then `HEAD_SHA=$(git rev-parse HEAD)`.
   6. If **only noise** was found (no files changed, no threads/checks/reviews to act on): skip commit/push and omit `--require-sha` in the next step.
-  7. `npx pr-shepherd resolve <PR_NUMBER> --resolve-thread-ids <IDs> --minimize-comment-ids <NOISE_COMMENT_IDS plus any other comment IDs> --dismiss-review-ids <IDs> --message "address review comments" --require-sha "$HEAD_SHA"` (dangerouslyDisableSandbox: true). Omit any flag whose ID list is empty. Omit `--require-sha` when no push occurred.
+  7. Resolve the items on GitHub (dangerouslyDisableSandbox: true). Build the command from the non-empty ID lists only — always start with:
+     `npx pr-shepherd resolve <PR_NUMBER>`
+     Then append:
+     - `--resolve-thread-ids <IDs>` only if `fix.threads` was non-empty.
+     - `--minimize-comment-ids <IDs>` if any comments exist (use `NOISE_COMMENT_IDS` plus IDs of any other comments to minimize).
+     - `--dismiss-review-ids <IDs> --message "<specific description of what you changed>"` only if `fix.changesRequestedReviews` was non-empty. The message is shown to the reviewer on GitHub — write one sentence describing the actual fix (e.g. `"Switched to parameterized query in src/db.ts"`). Never use generic text like `"address review comments"`.
+     - `--require-sha "$HEAD_SHA"` only if a push occurred (omit when only noise was handled).
+     Omit any flag whose ID list is empty.
 
 ````
 

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -62,7 +62,7 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
    - `git fetch origin && git rebase origin/$BASE_BRANCH && git push --force-with-lease`
    - Cancel stale CI runs: `gh run list --branch "$BRANCH" --status in_progress --json databaseId --jq '.[].databaseId' | xargs -I{} gh run cancel {}`
 
-6. **Resolve all verified items** — **only after the push.** Build the command from the non-empty ID lists; omit any flag whose list is empty:
+6. **Resolve all verified items** — **only after the push, and only if at least one of the three ID lists is non-empty.** If all lists are empty, skip this step entirely (running resolve with no mutation IDs enters fetch mode as a side effect). Build the command from the non-empty ID lists; omit any flag whose list is empty:
 
    ```bash
    npx pr-shepherd resolve <N> \

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -62,16 +62,18 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
    - `git fetch origin && git rebase origin/$BASE_BRANCH && git push --force-with-lease`
    - Cancel stale CI runs: `gh run list --branch "$BRANCH" --status in_progress --json databaseId --jq '.[].databaseId' | xargs -I{} gh run cancel {}`
 
-6. **Resolve all verified items** — **only after the push:**
+6. **Resolve all verified items** — **only after the push.** Build the command from the non-empty ID lists; omit any flag whose list is empty:
 
    ```bash
    npx pr-shepherd resolve <N> \
      --resolve-thread-ids <comma-separated-IDs> \
      --minimize-comment-ids <comma-separated-IDs> \
      --dismiss-review-ids <comma-separated-IDs> \
-     --message "Addressed in $(git rev-parse HEAD)" \
+     --message "<specific description of the fix that addressed this review>" \
      --require-sha $(git rev-parse HEAD)
    ```
+
+   `--message` belongs **only** with `--dismiss-review-ids`. Omit it entirely when not dismissing a review. When you are dismissing, write one sentence describing the actual fix — the text is sent to GitHub as the dismissal reason and is shown to the reviewer. Generic text like `"Addressed in <SHA>"` or `"address review comments"` is not acceptable.
 
    The `--require-sha` flag ensures pr-shepherd verifies GitHub has the new commit before resolving.
 
@@ -82,4 +84,4 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
 - NEVER resolve threads before pushing fixes (use `--require-sha`).
 - NEVER blindly resolve items — always read and verify first.
 - Resolve from ALL authors — bots, AI reviewers, and humans alike.
-- `--message` is required when using `--dismiss-review-ids`. The CLI will throw if it is missing.
+- `--message` is required when using `--dismiss-review-ids`, and must NOT be passed otherwise. The CLI throws if it is missing during dismissal. The message must describe the specific change that addressed the review (e.g. `"Added null check in handler.ts:42"`); generic boilerplate like `"address review comments"` or `"Addressed in <SHA>"` is reviewer-hostile and forbidden.


### PR DESCRIPTION
## Summary

- Agents were unconditionally emitting `--message "address review comments"` on every `pr-shepherd resolve` call, even when no review was being dismissed
- `--message` is only consumed by `dismissReview()` — when no `--dismiss-review-ids` are present it is silently ignored, and when it is used the text is shown to the reviewer on GitHub
- Updated `monitor` and `resolve` skill prompts to make `--message` conditional on `--dismiss-review-ids` being non-empty, and explicitly forbid generic phrasing in favor of a one-sentence description of the actual fix
- Updated docs examples to match

## Test plan

- [ ] Dry-run the monitor loop prompt mentally with `fix.changesRequestedReviews = []` — produced command should contain no `--message`
- [ ] With `fix.changesRequestedReviews` non-empty — agent is prompted to write a specific fix description, not boilerplate

🤖 Generated with [Claude Code](https://claude.com/claude-code)