### PR TITLE
fix: update plugin.json skills path after skills/ moved to plugin/skills/

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,5 @@
     "code-review",
     "automation"
   ],
-  "skills": "./skills/"
+  "skills": "./plugin/skills/"
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes `skills path not found` error that has been breaking the plugin since v0.4.2
- Root cause: commit ca3e91a moved `skills/` → `plugin/skills/` but missed updating `.claude-plugin/plugin.json`, which still declared `"skills": "./skills/"`
- One-line fix: `"./skills/"` → `"./plugin/skills/"`

## Test plan

- [ ] `/plugin marketplace remove jonathanong`
- [ ] `/plugin marketplace add jonathanong/pr-shepherd`
- [ ] `/plugin install pr-shepherd@jonathanong`
- [ ] Confirm no "skills path not found" error on reload
- [ ] Confirm `/check`, `/monitor`, `/resolve` skills are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)