### PR TITLE
fix(monitor): prevent duplicate cron runners from ScheduleWakeup

### DIFF
--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -39,6 +39,14 @@ Invoke `/loop <INTERVAL> --max-turns 50 --expires 8h` via the Skill tool. Use th
 
 ````
 # pr-shepherd-loop:pr=<PR_NUMBER>
+
+**IMPORTANT — recurrence rules for this session:**
+- **Do NOT call `ScheduleWakeup`.** This session was fired by a recurring cron job. Calling `ScheduleWakeup` (with a `/loop` prompt) would create a duplicate cron job, leading to concurrent git operations and `.git/index.lock` collisions.
+- **Do NOT invoke `/loop`.** Same reason — `/loop` with an interval calls `CronCreate`, which creates a second recurrent runner.
+- After completing the actions below, end the turn cleanly. The cron job handles the next fire automatically.
+
+**Self-dedup:** Run `CronList`. If more than one job has a prompt containing `# pr-shepherd-loop:pr=<PR_NUMBER>`, duplicate runners exist. Keep the job with the lowest job ID and `CronDelete` the rest, then continue this iteration.
+
 Run the following in a single Bash invocation:
   npx pr-shepherd iterate <PR_NUMBER> --ready-delay <READY_DELAY> --no-cache --last-push-time "$(git log -1 --format=%ct HEAD)" --format=json
 

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -45,7 +45,7 @@ Invoke `/loop <INTERVAL> --max-turns 50 --expires 8h` via the Skill tool. Use th
 - **Do NOT invoke `/loop`.** Same reason — `/loop` with an interval calls `CronCreate`, which creates a second recurrent runner.
 - After completing the actions below, end the turn cleanly. The cron job handles the next fire automatically.
 
-**Self-dedup:** Run `CronList`. If more than one job has a prompt containing `# pr-shepherd-loop:pr=<PR_NUMBER>`, duplicate runners exist. Keep the job with the lowest job ID and `CronDelete` the rest, then continue this iteration.
+**Self-dedup:** Run `CronList`. If more than one job has a prompt containing `# pr-shepherd-loop:pr=<PR_NUMBER>`, duplicate runners exist. Keep the job with the lowest job ID and `CronDelete` the rest (ignore errors if a job is already gone — another concurrent runner may have deleted it first), then continue this iteration.
 
 Run the following in a single Bash invocation:
   npx pr-shepherd iterate <PR_NUMBER> --ready-delay <READY_DELAY> --no-cache --last-push-time "$(git log -1 --format=%ct HEAD)" --format=json


### PR DESCRIPTION
## Summary

- The `"Do NOT call ScheduleWakeup"` warning in `monitor/SKILL.md` lived only in the outer skill text — cron-fired sessions never see it, only the heredoc prompt body
- When a cron-fired session had `/loop 4m ...` in its transcript context, `ScheduleWakeup`'s always-resident tool description ("pass the /loop prompt back verbatim each turn") pulled the model into dynamic-mode behavior, creating a second `CronCreate` → two concurrent runners → `.git/index.lock` collisions
- Adds the recurrence warning **inside** the cron-fire prompt body where the model actually sees it, plus a self-dedup `CronList` check to recover from any pre-existing duplicates

## Test plan

- [ ] Invoke `/pr-shepherd:monitor <PR>` — confirm `CronList` shows exactly one matching `# pr-shepherd-loop:pr=*` job
- [ ] Wait for a cron tick that does `fix_code` or `rebase` — confirm no new `CronCreate` was created and no `ScheduleWakeup` fired
- [ ] Duplicate-recovery: manually `CronCreate` a second job with the same prompt tag; on next tick confirm it is `CronDelete`d and only one job remains
- [ ] Watch several iterations — no `.git/index.lock` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)