### PR TITLE
feat: cancel monitor loop when only human approval is pending

### DIFF
--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -42,6 +42,18 @@ GitHub sometimes updates `mergeStateStatus` to `'DRAFT'` before the `isDraft` bo
 
 `state` (OPEN/MERGED/CLOSED) is passed through directly from `BatchPrData` without any transformation. It is used by `iterate.mts` at step 2.5 to cancel the loop for terminal PRs. The merge status derivation logic itself does not branch on `state` — it always derives a `status` regardless of PR state.
 
+### BLOCKED + REVIEW_REQUIRED → ShepherdStatus READY
+
+`deriveMergeStatus` sets `status: "BLOCKED"` whenever `mergeStateStatus` is `BLOCKED`. However, `computeStatus` in `check.mts` overrides this to `ShepherdStatus: "READY"` when all of the following are true:
+
+- `verdict.allPassed` — no failing or in-progress CI checks.
+- No unresolved threads, comments, or changes-requested reviews.
+- `mergeStatus.status === "BLOCKED"` (from `deriveMergeStatus`).
+- `mergeStatus.copilotReviewInProgress === false` — bot review pending means the blocking reason is not solely a human.
+- `mergeStatus.reviewDecision === "REVIEW_REQUIRED"` — explicitly awaiting human approval.
+
+In this case `mergeStatus.status` in the report is still `BLOCKED` (truthful about the GitHub merge state), but the top-level `ShepherdStatus` is `READY`, signalling that shepherd has nothing more to do. The ready-delay timer starts, and `action: cancel` is emitted after it elapses.
+
 ## Copilot detection
 
 `detectCopilotReview(pr)` returns true when:

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -6,6 +6,8 @@
 
 The ready-delay prevents shepherd from cancelling the loop the instant CI goes green. It waits for a configurable window of consecutive READY status before emitting `action: cancel`. This gives reviewers time to post comments before the loop exits.
 
+The timer also starts when the PR is READY solely because a human reviewer hasn't approved yet (`reviewDecision === REVIEW_REQUIRED` with all CI green and no unresolved work). From shepherd's perspective the PR is ready for human review — it has nothing more to do — so the same ready-delay countdown applies and the loop cancels once it elapses.
+
 ## The `updateReadyDelay` function
 
 Located in `commands/ready-delay.mts`, called from `iterate.mts` (step 3).

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -218,6 +218,78 @@ describe("runCheck — computeStatus precedence", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Human approval pending — BLOCKED + REVIEW_REQUIRED
+// ---------------------------------------------------------------------------
+
+describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () => {
+  it("returns READY when CI passed and only human approval is missing", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED" }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("READY");
+    expect(report.mergeStatus.status).toBe("BLOCKED");
+    expect(report.mergeStatus.reviewDecision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("returns FAILING when a CI check is also failing", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        mergeStateStatus: "BLOCKED",
+        reviewDecision: "REVIEW_REQUIRED",
+        checks: [makeCheck({ category: "failing", conclusion: "FAILURE" })],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("FAILING");
+  });
+
+  it("returns FAILING when an unresolved thread also exists (iterate handles it via actionable check)", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        mergeStateStatus: "BLOCKED",
+        reviewDecision: "REVIEW_REQUIRED",
+        reviewThreads: [
+          {
+            id: "t1",
+            isResolved: false,
+            isOutdated: false,
+            isMinimized: false,
+            path: "src/foo.ts",
+            line: 1,
+            author: "alice",
+            body: "fix this",
+            createdAtUnix: 0,
+          },
+        ],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("FAILING");
+  });
+
+  it("returns FAILING when copilot review is also in progress", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        mergeStateStatus: "BLOCKED",
+        reviewDecision: "REVIEW_REQUIRED",
+        reviewRequests: [{ login: "copilot-pull-request-reviewer[bot]" }],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("FAILING");
+  });
+
+  it("returns FAILING when BLOCKED but reviewDecision is null (other branch protection)", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: null }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("FAILING");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Thread minimization filtering
 // ---------------------------------------------------------------------------
 

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -201,10 +201,7 @@ function computeStatus(
   if (changesRequestedReviews > 0) return "UNRESOLVED_COMMENTS";
   if (unresolvedThreads > 0 || unresolvedComments > 0) return "UNRESOLVED_COMMENTS";
   // DRAFT is treated the same as CLEAN for readiness — marking the PR ready resolves it.
-  if (
-    (mergeStatus.status === "CLEAN" || mergeStatus.status === "DRAFT") &&
-    verdict.allPassed
-  )
+  if ((mergeStatus.status === "CLEAN" || mergeStatus.status === "DRAFT") && verdict.allPassed)
     return "READY";
   return "UNKNOWN";
 }

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -22,6 +22,7 @@ import { autoResolveOutdated } from "../comments/resolve.mts";
 import { deriveMergeStatus } from "../merge-status/derive.mts";
 import type {
   GlobalOptions,
+  MergeStatusResult,
   ShepherdReport,
   ShepherdStatus,
   ClassifiedCheck,
@@ -129,7 +130,7 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
     verdict,
     actionableThreads.length,
     actionableComments.length,
-    mergeStatus.status,
+    mergeStatus,
     batchData.changesRequestedReviews.length,
   );
 
@@ -168,21 +169,42 @@ function computeStatus(
   verdict: ReturnType<typeof getCiVerdict>,
   unresolvedThreads: number,
   unresolvedComments: number,
-  mergeStatus: string,
+  mergeStatus: MergeStatusResult,
   changesRequestedReviews: number,
 ): ShepherdStatus {
   // Merge conflicts are always terminal regardless of CI state.
-  if (mergeStatus === "CONFLICTS") return "FAILING";
+  if (mergeStatus.status === "CONFLICTS") return "FAILING";
   // Check CI state before merge-blocking states: BLOCKED/UNSTABLE/BEHIND are
   // often caused by CI not having passed yet, so they shouldn't mask IN_PROGRESS.
   if (verdict.anyFailing) return "FAILING";
   if (verdict.anyInProgress) return "IN_PROGRESS";
-  if (mergeStatus === "BLOCKED" || mergeStatus === "UNSTABLE" || mergeStatus === "BEHIND")
+  // BLOCKED solely because a human reviewer hasn't approved yet — shepherd is done, hand off.
+  // copilotReviewInProgress means a bot still owes a review, which is not this case.
+  if (
+    verdict.allPassed &&
+    unresolvedThreads === 0 &&
+    unresolvedComments === 0 &&
+    changesRequestedReviews === 0 &&
+    mergeStatus.status === "BLOCKED" &&
+    !mergeStatus.copilotReviewInProgress &&
+    mergeStatus.reviewDecision === "REVIEW_REQUIRED"
+  ) {
+    return "READY";
+  }
+  if (
+    mergeStatus.status === "BLOCKED" ||
+    mergeStatus.status === "UNSTABLE" ||
+    mergeStatus.status === "BEHIND"
+  )
     return "FAILING";
-  if (mergeStatus === "UNKNOWN") return "UNKNOWN";
+  if (mergeStatus.status === "UNKNOWN") return "UNKNOWN";
   if (changesRequestedReviews > 0) return "UNRESOLVED_COMMENTS";
   if (unresolvedThreads > 0 || unresolvedComments > 0) return "UNRESOLVED_COMMENTS";
   // DRAFT is treated the same as CLEAN for readiness — marking the PR ready resolves it.
-  if ((mergeStatus === "CLEAN" || mergeStatus === "DRAFT") && verdict.allPassed) return "READY";
+  if (
+    (mergeStatus.status === "CLEAN" || mergeStatus.status === "DRAFT") &&
+    verdict.allPassed
+  )
+    return "READY";
   return "UNKNOWN";
 }

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -1277,7 +1277,11 @@ describe("runIterate — human approval pending (BLOCKED + REVIEW_REQUIRED)", ()
 
   it("returns action: wait during the ready-delay window", async () => {
     mockRunCheck.mockResolvedValue(blockedApprovalReport);
-    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: false, remainingSeconds: 300 });
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: false,
+      remainingSeconds: 300,
+    });
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("wait");
@@ -1285,7 +1289,11 @@ describe("runIterate — human approval pending (BLOCKED + REVIEW_REQUIRED)", ()
 
   it("returns action: cancel when ready-delay has elapsed", async () => {
     mockRunCheck.mockResolvedValue(blockedApprovalReport);
-    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: true, remainingSeconds: 0 });
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: true,
+      remainingSeconds: 0,
+    });
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("cancel");

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -1257,6 +1257,42 @@ describe("runIterate — escalate (pr-level-changes-requested with actionable co
   });
 });
 
+// ---------------------------------------------------------------------------
+// Human approval pending — cancel after ready-delay elapses
+// ---------------------------------------------------------------------------
+
+describe("runIterate — human approval pending (BLOCKED + REVIEW_REQUIRED)", () => {
+  const blockedApprovalReport = makeReport({
+    status: "READY",
+    mergeStatus: {
+      status: "BLOCKED",
+      state: "OPEN" as const,
+      isDraft: false,
+      mergeable: "MERGEABLE",
+      reviewDecision: "REVIEW_REQUIRED",
+      copilotReviewInProgress: false,
+      mergeStateStatus: "BLOCKED",
+    },
+  });
+
+  it("returns action: wait during the ready-delay window", async () => {
+    mockRunCheck.mockResolvedValue(blockedApprovalReport);
+    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: false, remainingSeconds: 300 });
+
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("wait");
+  });
+
+  it("returns action: cancel when ready-delay has elapsed", async () => {
+    mockRunCheck.mockResolvedValue(blockedApprovalReport);
+    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: true, remainingSeconds: 0 });
+
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("cancel");
+    expect(result.shouldCancel).toBe(true);
+  });
+});
+
 describe("runIterate — malformed repo format", () => {
   it("throws when report.repo has no slash (e.g. 'badformat')", async () => {
     mockRunCheck.mockResolvedValue(makeReport({ repo: "badformat" }));

--- a/src/commands/resolve.mts
+++ b/src/commands/resolve.mts
@@ -65,7 +65,7 @@ export async function runResolveFetch(opts: ResolveCommandOptions): Promise<Fetc
   const activeThreads = unresolvedThreads.filter((t) => !t.isOutdated);
 
   return {
-    actionableThreads: activeThreads.map(({ isResolved, isOutdated, ...rest }) => rest),
+    actionableThreads: activeThreads.map(({ isResolved: _r, isOutdated: _o, ...rest }) => rest),
     actionableComments: visibleComments,
     changesRequestedReviews: data.changesRequestedReviews,
   };


### PR DESCRIPTION
## Summary

- When a PR has green CI, no unresolved threads/comments/changes-requested, and is `BLOCKED` solely because `reviewDecision === REVIEW_REQUIRED`, `computeStatus` now returns `READY` instead of `FAILING`
- This feeds the existing ready-delay timer, so the monitor loop cancels after 10 minutes (same as a fully-clean READY PR) rather than polling every 4 minutes until the 8-hour expiry
- `mergeStatus.status` in the report remains `BLOCKED` (truthful about GitHub's merge state); only the top-level `ShepherdStatus` is remapped

Closes #48 

## Test plan

- [ ] `npm run build && npm test` — 5 new test cases covering READY path, CI-also-failing, copilot-also-blocking, reviewDecision null, and iterate cancel
- [ ] Manual: open a PR on a repo requiring approval; run `npx pr-shepherd check <pr> --format=json` and confirm `status: "READY"`, `mergeStatus.status: "BLOCKED"`, `mergeStatus.reviewDecision: "REVIEW_REQUIRED"`
- [ ] Manual: run `npx pr-shepherd iterate <pr> --ready-delay 1m --format=json` twice 60s apart — first returns `action: "wait"`, second returns `action: "cancel"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)