### PR TITLE
feat: remind auto-fix flows to keep PR title and description current

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -289,7 +289,7 @@ Actionable work needs a code fix, commit, and push.
 - `Commit changed files:` is only emitted when there are actual code changes to commit (threads/comments/checks/reviews present). A `CONFLICTS`-only state skips this step.
 - `Keep the PR title and description current:` is emitted immediately after the commit step and uses the same gate (`hasCodeChanges`). A `CONFLICTS`-only dispatch (no code to commit) omits it.
 - The rebase step switches wording based on `mergeStatus.status`. When conflicts are present it emits "Rebase with conflict resolution" and walks through `git rebase --continue` loops; otherwise it emits the clean one-liner `git fetch origin && git rebase origin/<base> && git push --force-with-lease`.
-- `Run the \`resolve:\` command`is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A`CONFLICTS`-only dispatch omits it.
+- The `resolve:` instruction is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A `CONFLICTS`-only dispatch omits it.
 
 The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled`.
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -289,7 +289,7 @@ Actionable work needs a code fix, commit, and push.
 - `Commit changed files:` is only emitted when there are actual code changes to commit (threads/comments/checks/reviews present). A `CONFLICTS`-only state skips this step.
 - `Keep the PR title and description current:` is emitted immediately after the commit step and uses the same gate (`hasCodeChanges`). A `CONFLICTS`-only dispatch (no code to commit) omits it.
 - The rebase step switches wording based on `mergeStatus.status`. When conflicts are present it emits "Rebase with conflict resolution" and walks through `git rebase --continue` loops; otherwise it emits the clean one-liner `git fetch origin && git rebase origin/<base> && git push --force-with-lease`.
-- `Run the \`resolve:\` command` is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A `CONFLICTS`-only dispatch omits it.
+- `Run the \`resolve:\` command`is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A`CONFLICTS`-only dispatch omits it.
 
 The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled`.
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -259,8 +259,9 @@ Actionable work needs a code fix, commit, and push.
 2. For each bullet in `## Failing checks` whose backticked locator is a numeric runId (GitHub Actions): run `gh run view <runId> --log-failed`, identify the failure, and apply the fix.
 3. For each bullet under `## Changes-requested reviews` above: read the review body and apply the requested changes.
 4. Commit changed files: `git add <files> && git commit -m "<descriptive message>"`
-5. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`
-6. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
+5. Keep the PR title and description current: if the changes alter the PR's scope or intent, run `gh pr edit 42 --title "<new title>" --body "<new body>"` to reflect them. Skip if the existing title/body still accurately describe the PR.
+6. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`
+7. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
 ```
 
 **Section order:**
@@ -286,8 +287,9 @@ Actionable work needs a code fix, commit, and push.
 **Instruction variants:**
 
 - `Commit changed files:` is only emitted when there are actual code changes to commit (threads/comments/checks/reviews present). A `CONFLICTS`-only state skips this step.
+- `Keep the PR title and description current:` is emitted immediately after the commit step and uses the same gate (`hasCodeChanges`). A `CONFLICTS`-only dispatch (no code to commit) omits it.
 - The rebase step switches wording based on `mergeStatus.status`. When conflicts are present it emits "Rebase with conflict resolution" and walks through `git rebase --continue` loops; otherwise it emits the clean one-liner `git fetch origin && git rebase origin/<base> && git push --force-with-lease`.
-- `Run the \`resolve:\` command`is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A`CONFLICTS`-only dispatch omits it.
+- `Run the \`resolve:\` command` is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A `CONFLICTS`-only dispatch omits it.
 
 The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled`.
 

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -63,7 +63,7 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
 5. **Commit and push** (only if code was changed):
    - `git add <file1> <file2> …` (NOT `git add -A`)
    - `git commit -m "<appropriate commit message>"`
-   - If the fixes alter the PR's scope or intent, run `gh pr edit <N> --title "<new>" --body "<new>"` to keep the PR title and description in sync with what was committed. Skip if the existing text still accurately describes the PR.
+   - If the fixes alter the PR's scope or intent, run `gh pr edit <N> --title "<new title>" --body "<new body>"` to keep the PR title and description in sync with what was committed. Skip if the existing text still accurately describes the PR.
    - `git fetch origin && git rebase origin/$BASE_BRANCH && git push --force-with-lease`
    - Cancel stale CI runs: `gh run list --branch "$BRANCH" --status in_progress --json databaseId --jq '.[].databaseId' | xargs -I{} gh run cancel {}`
 

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -63,6 +63,7 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
 5. **Commit and push** (only if code was changed):
    - `git add <file1> <file2> …` (NOT `git add -A`)
    - `git commit -m "<appropriate commit message>"`
+   - If the fixes alter the PR's scope or intent, run `gh pr edit <N> --title "<new>" --body "<new>"` to keep the PR title and description in sync with what was committed. Skip if the existing text still accurately describes the PR.
    - `git fetch origin && git rebase origin/$BASE_BRANCH && git push --force-with-lease`
    - Cancel stale CI runs: `gh run list --branch "$BRANCH" --status in_progress --json databaseId --jq '.[].databaseId' | xargs -I{} gh run cancel {}`
 

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -961,6 +961,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
       // emit a rebase-with-conflict-resolution instruction and no resolve step.
       const joined = result.fix.instructions.join("\n");
       expect(joined).not.toContain("git commit");
+      expect(joined).not.toContain("gh pr edit");
       expect(joined).toContain("Rebase with conflict resolution");
       expect(joined).toContain("git rebase --continue");
       expect(joined).toContain("git push --force-with-lease");
@@ -1011,6 +1012,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
       // the clean `&& git push` one-liner), and resolve step all present.
       const joined = result.fix.instructions.join("\n");
       expect(joined).toContain("git commit");
+      expect(joined).toContain("gh pr edit");
       expect(joined).toContain("Rebase with conflict resolution");
       expect(joined).toContain("git rebase --continue");
       expect(joined).not.toMatch(/rebase origin\/\w+ && git push/);

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -270,6 +270,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       baseLookup.branch,
       resolveCommand,
       hasConflicts,
+      prNumber,
     );
 
     return {
@@ -633,6 +634,7 @@ function buildFixInstructions(
   baseBranch: string,
   resolveCommand: ResolveCommand,
   hasConflicts: boolean,
+  prNumber: number,
 ): string[] {
   const instructions: string[] = [];
 
@@ -675,6 +677,9 @@ function buildFixInstructions(
   if (hasCodeChanges) {
     instructions.push(
       `Commit changed files: \`git add <files> && git commit -m "<descriptive message>"\``,
+    );
+    instructions.push(
+      `Keep the PR title and description current: if the changes alter the PR's scope or intent, run \`gh pr edit ${prNumber} --title "<new title>" --body "<new body>"\` to reflect them. Skip if the existing title/body still accurately describe the PR.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Adds a conditional `gh pr edit` instruction to `[FIX_CODE]` iterations: after committing code changes, the agent is told to update the PR title/body if the fixes altered the PR's scope or intent
- Same guidance added to step 5 of the `/pr-shepherd:resolve` skill
- Instruction is gated on `hasCodeChanges` — CONFLICTS-only dispatches (rebase without file edits) skip it
- `docs/actions.md` updated: sample output renumbered and Instruction variants section extended

## Test plan

- [ ] `npm run build && npm test` — all 395 tests pass
- [ ] CONFLICTS-only test now also asserts `gh pr edit` is absent from instructions
- [ ] Threads + CONFLICTS test now also asserts `gh pr edit` is present in instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)