### PR TITLE
feat: replace gh CLI with native fetch for all GitHub API calls

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"27b46d8c-71fc-44e1-8a18-5fd91ef277b5","pid":53157,"acquiredAt":1776754981951}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"27b46d8c-71fc-44e1-8a18-5fd91ef277b5","pid":53157,"acquiredAt":1776754981951}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 *.log
 .pr-shepherdrc.yml
 .claude/worktrees/
+.claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ See [docs/configuration.md](docs/configuration.md) for all options.
 ## Requirements
 
 - Node.js ≥ 22.0.0
-- `gh` CLI authenticated (`gh auth login`); `repo` scope is required for private repositories (public repositories may not need it)
+- A GitHub token: set `GH_TOKEN` or `GITHUB_TOKEN`, **or** install and authenticate the `gh` CLI (`gh auth login`) — pr-shepherd uses `gh auth token` as a fallback. The `repo` scope is required for private repositories.
 - `git`
 
 ## Docs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,29 +209,29 @@ Disable if your team uses the draft state as a deliberate gate that requires a h
 
 ## Environment variables
 
-| Variable                        | Effect                                                                                                 |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `PR_SHEPHERD_CACHE_DIR`         | Override the cache base directory (default `$TMPDIR/pr-shepherd-cache`)                                |
-| `PR_SHEPHERD_CACHE_TTL_SECONDS` | Override `cache.ttlSeconds`; takes precedence over both the RC file and `--cache-ttl`                  |
+| Variable                        | Effect                                                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `PR_SHEPHERD_CACHE_DIR`         | Override the cache base directory (default `$TMPDIR/pr-shepherd-cache`)                                          |
+| `PR_SHEPHERD_CACHE_TTL_SECONDS` | Override `cache.ttlSeconds`; takes precedence over both the RC file and `--cache-ttl`                            |
 | `GH_TOKEN` / `GITHUB_TOKEN`     | GitHub auth token. Resolution order: `GH_TOKEN` → `GITHUB_TOKEN` → `gh auth token` fallback (requires `gh` CLI). |
 
 ## Deprecated keys
 
 The following keys from earlier versions are still accepted but emit a deprecation warning to stderr. They will be removed in v0.3.0.
 
-| Old key                          | New key                             |
-| -------------------------------- | ----------------------------------- |
-| `iterate.maxFixAttempts`         | `iterate.fixAttemptsPerThread`      |
-| `watch.intervalDefault`          | `watch.interval`                    |
-| `watch.readyDelayMinutesDefault` | `watch.readyDelayMinutes`           |
-| `watch.expiresHoursDefault`      | `watch.expiresHours`                |
-| `resolve.shaPollIntervalMs`      | `resolve.shaPoll.intervalMs`        |
-| `resolve.shaPollMaxAttempts`     | `resolve.shaPoll.maxAttempts`       |
-| `checks.relevantEvents`          | `checks.ciTriggerEvents`            |
-| `checks.logLinesKept`            | `checks.logMaxLines`                |
-| `checks.logExcerptMaxChars`      | `checks.logMaxChars`                |
-| `baseBranch`                     | _(removed — auto-detected from PR)_ |
-| `minimizeBots`                   | _(removed)_                         |
+| Old key                          | New key                                                   |
+| -------------------------------- | --------------------------------------------------------- |
+| `iterate.maxFixAttempts`         | `iterate.fixAttemptsPerThread`                            |
+| `watch.intervalDefault`          | `watch.interval`                                          |
+| `watch.readyDelayMinutesDefault` | `watch.readyDelayMinutes`                                 |
+| `watch.expiresHoursDefault`      | `watch.expiresHours`                                      |
+| `resolve.shaPollIntervalMs`      | `resolve.shaPoll.intervalMs`                              |
+| `resolve.shaPollMaxAttempts`     | `resolve.shaPoll.maxAttempts`                             |
+| `checks.relevantEvents`          | `checks.ciTriggerEvents`                                  |
+| `checks.logLinesKept`            | `checks.logMaxLines`                                      |
+| `checks.logExcerptMaxChars`      | `checks.logMaxChars`                                      |
+| `baseBranch`                     | _(removed — auto-detected from PR)_                       |
+| `minimizeBots`                   | _(removed)_                                               |
 | `cancelCiOnFailure`              | _(removed)_                                               |
 | `execution.maxBufferMb`          | _(removed — no subprocess buffer caps with native fetch)_ |
 | `execution.triageLogBufferMb`    | _(removed — no subprocess buffer caps with native fetch)_ |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,10 +40,6 @@ mergeStatus:
     - copilot
     - sonar # add other review bots here
 
-execution:
-  maxBufferMb: 10
-  triageLogBufferMb: 5
-
 actions:
   autoResolveOutdated: true
   autoRebase: true
@@ -189,18 +185,6 @@ Add other review bots (e.g. `sonar`, `codeclimate`, `reviewdog`) if they submit 
 
 ---
 
-## `execution`
-
-### `execution.maxBufferMb` — default `10`
-
-Maximum output buffer size (in megabytes) for `gh` CLI calls. Increase if shepherd throws `stdout maxBuffer exceeded` on large GraphQL responses (e.g. PRs with thousands of threads).
-
-### `execution.triageLogBufferMb` — default `5`
-
-Maximum output buffer size (in megabytes) for `gh run view --log-failed` calls. Increase if shepherd throws `stdout maxBuffer exceeded` when fetching CI failure logs.
-
----
-
 ## `actions`
 
 These flags control whether shepherd automatically performs each class of mutation during an `iterate` tick. The corresponding `--no-auto-*` CLI flags provide per-invocation overrides.
@@ -229,7 +213,7 @@ Disable if your team uses the draft state as a deliberate gate that requires a h
 | ------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `PR_SHEPHERD_CACHE_DIR`         | Override the cache base directory (default `$TMPDIR/pr-shepherd-cache`)                                |
 | `PR_SHEPHERD_CACHE_TTL_SECONDS` | Override `cache.ttlSeconds`; takes precedence over both the RC file and `--cache-ttl`                  |
-| `GH_TOKEN` / `GITHUB_TOKEN`     | Read by the `gh` CLI for authentication — see [`gh` docs](https://cli.github.com/manual/gh_auth_login) |
+| `GH_TOKEN` / `GITHUB_TOKEN`     | GitHub auth token. Resolution order: `GH_TOKEN` → `GITHUB_TOKEN` → `gh auth token` fallback (requires `gh` CLI). |
 
 ## Deprecated keys
 
@@ -248,4 +232,6 @@ The following keys from earlier versions are still accepted but emit a deprecati
 | `checks.logExcerptMaxChars`      | `checks.logMaxChars`                |
 | `baseBranch`                     | _(removed — auto-detected from PR)_ |
 | `minimizeBots`                   | _(removed)_                         |
-| `cancelCiOnFailure`              | _(removed)_                         |
+| `cancelCiOnFailure`              | _(removed)_                                               |
+| `execution.maxBufferMb`          | _(removed — no subprocess buffer caps with native fetch)_ |
+| `execution.triageLogBufferMb`    | _(removed — no subprocess buffer caps with native fetch)_ |

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -1,28 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Hoist mock BEFORE any imports so node:child_process is replaced before
-// triage.mts captures a reference to execFile via promisify().
+// Stub fetch globally so http.mts uses our mock.
 // ---------------------------------------------------------------------------
 
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    _cmd: string,
-    _args: string[],
-    _opts: Record<string, unknown>,
-    cb: (err: Error | null, result: { stdout: string }) => void,
-  ) => {
-    // Simulate promisify-compatible callback shape.
-    mockExecFile(_cmd, _args, _opts)
-      .then((result: { stdout: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "" }));
-  },
-}));
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
 
 import { triageFailingChecks } from "./triage.mts";
 import type { ClassifiedCheck } from "../types.mts";
+
+const REPO = { owner: "owner", name: "repo" };
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,160 +29,199 @@ function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
   };
 }
 
+function makeJobsResponse(
+  jobs: Array<{ id: number; name: string; conclusion: string }>,
+): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve({ jobs }),
+    text: () => Promise.resolve(JSON.stringify({ jobs })),
+  } as unknown as Response;
+}
+
+function makeLogsResponse(text: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: () => Promise.resolve(text),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    headers: new Headers(),
+    text: () => Promise.resolve("error"),
+  } as unknown as Response;
+}
+
+function setupFetch(logs: string, conclusion = "failure"): void {
+  // First call: list jobs
+  mockFetch.mockResolvedValueOnce(
+    makeJobsResponse([{ id: 42, name: "test-job", conclusion }]),
+  );
+  // Second call: fetch logs for that job
+  mockFetch.mockResolvedValueOnce(makeLogsResponse(logs));
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  mockExecFile.mockReset();
+  mockFetch.mockReset();
+  // Provide a token so auth doesn't shell out to `gh auth token`
+  process.env["GH_TOKEN"] = "test-token";
 });
 
 describe("triageFailingChecks — no runId", () => {
   it("skips log fetch and returns actionable when runId is null", async () => {
     const check = makeCheck({ runId: null });
-    const [result] = await triageFailingChecks([check]);
+    const [result] = await triageFailingChecks([check], REPO);
     expect(result!.failureKind).toBe("actionable");
-    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });
 
 describe("triageFailingChecks — TIMED_OUT", () => {
   it("returns timeout for TIMED_OUT conclusion regardless of logs", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "test output: all good\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "TIMED_OUT" })]);
+    setupFetch("test output: all good\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "TIMED_OUT" })], REPO);
     expect(result!.failureKind).toBe("timeout");
   });
 
   it('returns timeout when logs contain "exceeded the maximum execution time"', async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Run exceeded the maximum execution time\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("Run exceeded the maximum execution time\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("timeout");
   });
 
   it('returns timeout when logs contain "cancel timeout"', async () => {
-    mockExecFile.mockResolvedValue({ stdout: "cancel timeout after 6 hours\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("cancel timeout after 6 hours\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("timeout");
   });
 
   it('returns timeout when logs contain "job was cancelled"', async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Job was cancelled due to timeout\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })]);
+    setupFetch("Job was cancelled due to timeout\n", "cancelled");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
     expect(result!.failureKind).toBe("timeout");
   });
 });
 
 describe("triageFailingChecks — infrastructure", () => {
   it("returns infrastructure for CANCELLED + runner error logs", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Runner error: the runner crashed\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })]);
+    setupFetch("Runner error: the runner crashed\n", "cancelled");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
     expect(result!.failureKind).toBe("infrastructure");
   });
 
   it("returns infrastructure for CANCELLED + ECONNRESET logs", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Error: ECONNRESET connection reset\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })]);
+    setupFetch("Error: ECONNRESET connection reset\n", "cancelled");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
     expect(result!.failureKind).toBe("infrastructure");
   });
 
   it('returns infrastructure for CANCELLED + "lost communication with the server"', async () => {
-    mockExecFile.mockResolvedValue({
-      stdout: "The runner has lost communication with the server\n",
-    });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })]);
+    setupFetch("The runner has lost communication with the server\n", "cancelled");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
     expect(result!.failureKind).toBe("infrastructure");
   });
 
-  it("returns infrastructure when gh run view fails (empty logs)", async () => {
-    mockExecFile.mockRejectedValue(new Error("exit 1"));
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+  it("returns infrastructure when jobs fetch fails (empty logs)", async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(500));
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("infrastructure");
   });
 
   it("returns infrastructure for blank logs even with FAILURE conclusion", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "   \n  \n  " });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("   \n  \n  ");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("infrastructure");
   });
 });
 
 describe("triageFailingChecks — flaky", () => {
   it('returns flaky when logs contain "flaky"', async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Test is flaky: TestFooBar failed 1/3 runs\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("Test is flaky: TestFooBar failed 1/3 runs\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("flaky");
   });
 
   it('returns flaky when logs contain "race condition"', async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Detected race condition in TestBar\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("Detected race condition in TestBar\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("flaky");
   });
 
   it('returns flaky when logs contain "retry"', async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Attempt 3/3 failed, no retry left\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("Attempt 3/3 failed, no retry left\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("flaky");
   });
 });
 
 describe("triageFailingChecks — actionable", () => {
   it("returns actionable for compile errors", async () => {
-    mockExecFile.mockResolvedValue({
-      stdout: "error TS2345: Argument of type 'string' is not assignable\n",
-    });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("error TS2345: Argument of type 'string' is not assignable\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("actionable");
   });
 
   it("returns actionable for test assertion failures", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "AssertionError: expected 42 to equal 43\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("AssertionError: expected 42 to equal 43\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("actionable");
   });
 
   it("returns actionable for lint violations", async () => {
-    mockExecFile.mockResolvedValue({
-      stdout: "no-unused-vars: variable `foo` is defined but never used\n",
-    });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("no-unused-vars: variable `foo` is defined but never used\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("actionable");
   });
 });
 
 describe("triageFailingChecks — logExcerpt", () => {
   it("attaches logExcerpt for actionable failures", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "Error: test failed\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("Error: test failed\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.logExcerpt).toBeDefined();
     expect(result!.logExcerpt).toContain("Error: test failed");
   });
 
   it("truncates logExcerpt to 3000 chars", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "x".repeat(10_000) });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
+    setupFetch("x".repeat(10_000));
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect((result!.logExcerpt?.length ?? 0) <= 3000).toBe(true);
   });
 
   it("strips ANSI escape codes from logs", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "\u001B[31mERROR\u001B[0m: something failed\n" });
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })]);
-    expect(result!.logExcerpt).not.toContain("\u001B");
+    setupFetch("[31mERROR[0m: something failed\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
+    expect(result!.logExcerpt).not.toContain("");
     expect(result!.logExcerpt).toContain("ERROR: something failed");
   });
 });
 
 describe("triageFailingChecks — batch", () => {
   it("triages multiple checks in parallel", async () => {
-    mockExecFile
-      .mockResolvedValueOnce({ stdout: "AssertionError: expected 1 to equal 2\n" })
-      .mockResolvedValueOnce({ stdout: "Runner error: crashed\n" });
+    // check 1: jobs + logs
+    mockFetch
+      .mockResolvedValueOnce(makeJobsResponse([{ id: 1, name: "tests", conclusion: "failure" }]))
+      .mockResolvedValueOnce(makeLogsResponse("AssertionError: expected 1 to equal 2\n"))
+      // check 2: jobs + logs
+      .mockResolvedValueOnce(makeJobsResponse([{ id: 2, name: "build", conclusion: "cancelled" }]))
+      .mockResolvedValueOnce(makeLogsResponse("Runner error: crashed\n"));
 
     const checks: ClassifiedCheck[] = [
       makeCheck({ name: "tests", runId: "run-1", conclusion: "FAILURE" }),
       makeCheck({ name: "build", runId: "run-2", conclusion: "CANCELLED" }),
     ];
-    const results = await triageFailingChecks(checks);
+    const results = await triageFailingChecks(checks, REPO);
     expect(results).toHaveLength(2);
     expect(results[0]!.failureKind).toBe("actionable");
     expect(results[1]!.failureKind).toBe("infrastructure");

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -29,9 +29,7 @@ function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
   };
 }
 
-function makeJobsResponse(
-  jobs: Array<{ id: number; name: string; conclusion: string }>,
-): Response {
+function makeJobsResponse(jobs: Array<{ id: number; name: string; conclusion: string }>): Response {
   return {
     ok: true,
     status: 200,
@@ -61,9 +59,7 @@ function makeErrorResponse(status: number): Response {
 
 function setupFetch(logs: string, conclusion = "failure"): void {
   // First call: list jobs
-  mockFetch.mockResolvedValueOnce(
-    makeJobsResponse([{ id: 42, name: "test-job", conclusion }]),
-  );
+  mockFetch.mockResolvedValueOnce(makeJobsResponse([{ id: 42, name: "test-job", conclusion }]));
   // Second call: fetch logs for that job
   mockFetch.mockResolvedValueOnce(makeLogsResponse(logs));
 }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -87,8 +87,7 @@ async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
     );
 
     const combined = logParts.filter(Boolean).join("\n");
-    // eslint-disable-next-line no-control-regex
-    const ansiEscapes = /\[[0-9;]*m/g;
+    const ansiEscapes = /\u001B\[[0-9;]*m/g;
     return combined
       .replace(ansiEscapes, "")
       .split("\n")

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -78,10 +78,7 @@ async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
     const logParts = await Promise.all(
       failedJobs.map(async (job) => {
         try {
-          const logs = await restText(
-            "GET",
-            `/repos/${owner}/${name}/actions/jobs/${job.id}/logs`,
-          );
+          const logs = await restText("GET", `/repos/${owner}/${name}/actions/jobs/${job.id}/logs`);
           return logs.trim() ? `===== job: ${job.name} =====\n${logs}` : "";
         } catch {
           return "";

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -78,6 +78,8 @@ async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
     const logParts = await Promise.all(
       failedJobs.map(async (job) => {
         try {
+          // Job-level endpoint (jobs/{id}/logs) redirects to plain text, unlike
+          // run-level (runs/{id}/logs) which returns a ZIP archive.
           const logs = await restText("GET", `/repos/${owner}/${name}/actions/jobs/${job.id}/logs`);
           return logs.trim() ? `===== job: ${job.name} =====\n${logs}` : "";
         } catch {

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -9,12 +9,10 @@
  * downstream callers or slash-command logic to consume.
  */
 
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
+import { rest, restText } from "../github/http.mts";
 import type { ClassifiedCheck, TriagedCheck, FailureKind } from "../types.mts";
+import type { RepoInfo } from "../github/client.mts";
 import { loadConfig } from "../config/load.mts";
-
-const execFile = promisify(execFileCb);
 
 const config = loadConfig();
 const TIMEOUT_PATTERNS = config.checks.timeoutPatterns.map((p) => new RegExp(p, "i"));
@@ -29,20 +27,23 @@ const INFRA_PATTERNS = config.checks.infraPatterns.map((p) => new RegExp(p, "i")
  *
  * Fetching logs is skipped for checks that have no `runId` (e.g. StatusContext nodes).
  */
-export function triageFailingChecks(failingChecks: ClassifiedCheck[]): Promise<TriagedCheck[]> {
-  return Promise.all(failingChecks.map((c) => triageCheck(c)));
+export function triageFailingChecks(
+  failingChecks: ClassifiedCheck[],
+  repo: RepoInfo,
+): Promise<TriagedCheck[]> {
+  return Promise.all(failingChecks.map((c) => triageCheck(c, repo)));
 }
 
 // ---------------------------------------------------------------------------
 // Internal
 // ---------------------------------------------------------------------------
 
-async function triageCheck(check: ClassifiedCheck): Promise<TriagedCheck> {
+async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<TriagedCheck> {
   if (check.runId === null) {
     return { ...check, failureKind: "actionable" };
   }
 
-  const logExcerpt = await fetchFailedLogs(check.runId);
+  const logExcerpt = await fetchFailedLogs(check.runId, repo);
   const failureKind = classifyLogs(check, logExcerpt);
 
   return {
@@ -52,37 +53,66 @@ async function triageCheck(check: ClassifiedCheck): Promise<TriagedCheck> {
   };
 }
 
-async function fetchFailedLogs(runId: string): Promise<string> {
+interface JobsResponse {
+  jobs: Array<{
+    id: number;
+    name: string;
+    conclusion: string | null;
+  }>;
+}
+
+async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
   try {
-    const { stdout } = await execFile("gh", ["run", "view", runId, "--log-failed"], {
-      maxBuffer: config.execution.triageLogBufferMb * 1024 * 1024,
-    });
-    // Strip ANSI escape codes.
+    const { owner, name } = repo;
+    const jobsData = await rest<JobsResponse>(
+      "GET",
+      `/repos/${owner}/${name}/actions/runs/${runId}/jobs?filter=latest&per_page=100`,
+    );
+
+    const failedJobs = jobsData.jobs.filter((j) =>
+      ["failure", "timed_out", "cancelled"].includes(j.conclusion ?? ""),
+    );
+
+    if (failedJobs.length === 0) return "";
+
+    const logParts = await Promise.all(
+      failedJobs.map(async (job) => {
+        try {
+          const logs = await restText(
+            "GET",
+            `/repos/${owner}/${name}/actions/jobs/${job.id}/logs`,
+          );
+          return logs.trim() ? `===== job: ${job.name} =====\n${logs}` : "";
+        } catch {
+          return "";
+        }
+      }),
+    );
+
+    const combined = logParts.filter(Boolean).join("\n");
     // eslint-disable-next-line no-control-regex
-    const ansiEscapes = /\u001B\[[0-9;]*m/g;
-    return stdout.replace(ansiEscapes, "").split("\n").slice(-config.checks.logMaxLines).join("\n");
+    const ansiEscapes = /\[[0-9;]*m/g;
+    return combined
+      .replace(ansiEscapes, "")
+      .split("\n")
+      .slice(-config.checks.logMaxLines)
+      .join("\n");
   } catch {
     return "";
   }
 }
 
 function classifyLogs(check: ClassifiedCheck, logs: string): FailureKind {
-  // Timed out — check conclusion first, then logs.
   if (check.conclusion === "TIMED_OUT") return "timeout";
   if (TIMEOUT_PATTERNS.some((re) => re.test(logs))) return "timeout";
 
-  // Infrastructure error — typically CANCELLED with infra markers in logs.
   if (check.conclusion === "CANCELLED" && INFRA_PATTERNS.some((re) => re.test(logs))) {
     return "infrastructure";
   }
 
-  // No logs at all — treat as infrastructure.
   if (!logs.trim()) return "infrastructure";
 
-  // Heuristic: if the failure is in a file the PR likely didn't touch
-  // and the message contains "flaky" or timing language, call it flaky.
   if (/flaky|timing|race condition|retry/i.test(logs)) return "flaky";
 
-  // Default: assume actionable.
   return "actionable";
 }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -64,12 +64,19 @@ interface JobsResponse {
 async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
   try {
     const { owner, name } = repo;
-    const jobsData = await rest<JobsResponse>(
-      "GET",
-      `/repos/${owner}/${name}/actions/runs/${runId}/jobs?filter=latest&per_page=100`,
-    );
+    const perPage = 100;
+    const allJobs: JobsResponse["jobs"] = [];
 
-    const failedJobs = jobsData.jobs.filter((j) =>
+    for (let page = 1; ; page++) {
+      const jobsData = await rest<JobsResponse>(
+        "GET",
+        `/repos/${owner}/${name}/actions/runs/${runId}/jobs?filter=latest&per_page=${perPage}&page=${page}`,
+      );
+      allJobs.push(...jobsData.jobs);
+      if (jobsData.jobs.length < perPage) break;
+    }
+
+    const failedJobs = allJobs.filter((j) =>
       ["failure", "timed_out", "cancelled"].includes(j.conclusion ?? ""),
     );
 
@@ -80,7 +87,7 @@ async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
         try {
           // Job-level endpoint (jobs/{id}/logs) redirects to plain text, unlike
           // run-level (runs/{id}/logs) which returns a ZIP archive.
-          const logs = await restText("GET", `/repos/${owner}/${name}/actions/jobs/${job.id}/logs`);
+          const logs = await restText(`/repos/${owner}/${name}/actions/jobs/${job.id}/logs`);
           return logs.trim() ? `===== job: ${job.name} =====\n${logs}` : "";
         } catch {
           return "";

--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -41,6 +41,7 @@ let stderrSpy: any;
 function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
   return {
     pr: 42,
+    nodeId: "PR_kgDOAAA",
     repo: "owner/repo",
     status: "READY",
     baseBranch: "main",

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -45,6 +45,7 @@ function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
 
 function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
   return {
+    nodeId: "PR_kgDOAAA",
     number: 42,
     state: "OPEN",
     isDraft: false,

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -94,7 +94,7 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
 
   // Triage failures (fetch logs) — skipped when caller will short-circuit before needing failureKind.
   const triaged =
-    failing.length > 0 && !opts.skipTriage ? await triageFailingChecks(failing) : failing;
+    failing.length > 0 && !opts.skipTriage ? await triageFailingChecks(failing, repo) : failing;
 
   // Resolve threads and comments.
   const unresolvedThreads = batchData.reviewThreads.filter((t) => !t.isResolved && !t.isMinimized);
@@ -137,6 +137,7 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
 
   return {
     pr: prNumber,
+    nodeId: batchData.nodeId,
     repo: `${repo.owner}/${repo.name}`,
     status,
     baseBranch: batchData.baseRefName,

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoist mocks BEFORE any imports so modules capture the mocked versions.
+// child_process is still used by iterate.mts for `git` calls only.
+// GitHub API mutations now go through fetch (http.mts).
 // ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
 
 const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
 
@@ -64,6 +69,7 @@ const mockWriteFixAttempts = vi.mocked(writeFixAttempts);
 function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
   return {
     pr: 42,
+    nodeId: "PR_kgDOAAA",
     repo: "owner/repo",
     status: "READY",
     baseBranch: "main",
@@ -128,6 +134,7 @@ const READY_STATE_DEFAULT = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env["GH_TOKEN"] = "test-token";
   // Default: last commit was 60s ago (outside cooldown)
   mockExecFile.mockImplementation((cmd: string, args: string[]) => {
     if (cmd === "git" && args[0] === "log") {
@@ -137,6 +144,14 @@ beforeEach(() => {
       return Promise.resolve({ stdout: "abc123", stderr: "" });
     }
     return Promise.resolve({ stdout: "", stderr: "" });
+  });
+  // Default: all fetch calls succeed (mutations return 2xx with no body)
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 204,
+    headers: new Headers(),
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(""),
   });
   vi.useFakeTimers();
   vi.setSystemTime(NOW * 1000);
@@ -295,7 +310,11 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       expect(result.fix.checks).toHaveLength(1);
       expect(result.cancelled).toEqual(["run-99"]);
     }
-    expect(mockExecFile).toHaveBeenCalledWith("gh", ["run", "cancel", "run-99"]);
+    const cancelCall = (mockFetch.mock.calls as Array<[string, RequestInit]>).find(([url]) =>
+      url.includes("run-99/cancel"),
+    );
+    expect(cancelCall).toBeDefined();
+    expect(cancelCall![1].method).toBe("POST");
   });
 
   it("returns fix_code with partial cancelled when one gh run cancel fails", async () => {
@@ -320,14 +339,16 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
-      if (args[0] === "run" && args[1] === "cancel" && args[2] === "run-100") {
-        return Promise.reject(new Error("run already completed"));
+    mockFetch.mockImplementation((url: string) => {
+      if ((url as string).includes("run-100/cancel")) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          headers: new Headers(),
+          text: () => Promise.resolve("Cannot cancel a workflow run that is completed"),
+        });
       }
-      if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-        return Promise.resolve({ stdout: "main\n", stderr: "" });
-      }
-      return Promise.resolve({ stdout: "", stderr: "" });
+      return Promise.resolve({ ok: true, status: 202, headers: new Headers(), text: () => Promise.resolve("") });
     });
 
     const result = await runIterate(makeOpts());
@@ -360,11 +381,11 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-        return Promise.resolve({ stdout: "main\n", stderr: "" });
-      }
-      return Promise.reject(new Error("this run has already completed"));
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      headers: new Headers(),
+      text: () => Promise.resolve("Cannot cancel a workflow run that is completed"),
     });
 
     const result = await runIterate(makeOpts());
@@ -398,14 +419,11 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockExecFile.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "run" && args[1] === "cancel") {
-        return Promise.reject(new Error("Cannot cancel a workflow run that is completed"));
-      }
-      if (args[0] === "pr" && args[1] === "view") {
-        return Promise.resolve({ stdout: "main\n", stderr: "" });
-      }
-      return Promise.resolve({ stdout: "", stderr: "" });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      headers: new Headers(),
+      text: () => Promise.resolve("Cannot cancel a workflow run that is completed"),
     });
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
@@ -443,13 +461,18 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockExecFile.mockRejectedValue(new Error("HTTP 403 Forbidden"));
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers(),
+      text: () => Promise.resolve("Forbidden"),
+    });
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
       await runIterate(makeOpts());
       expect(stderrSpy).toHaveBeenCalledWith(
-        expect.stringContaining("gh run cancel run-401 failed (ignored)"),
+        expect.stringContaining("cancel run run-401 failed (ignored)"),
       );
     } finally {
       stderrSpy.mockRestore();
@@ -488,8 +511,8 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       expect(result.fix.checks[0]?.runId).toBe("run-300");
       expect(result.cancelled).toEqual(["run-300"]);
     }
-    const cancelCalls = mockExecFile.mock.calls.filter(
-      (call) => call[1]?.[0] === "run" && call[1]?.[1] === "cancel",
+    const cancelCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(([url]) =>
+      url.includes("/cancel"),
     );
     expect(cancelCalls).toHaveLength(1);
   });
@@ -823,9 +846,10 @@ describe("runIterate — rerun_ci", () => {
       expect(result.reran.find((r) => r.runId === "run-10")?.failureKind).toBe("timeout");
     }
 
-    // Verify gh run rerun was called for both
-    expect(mockExecFile).toHaveBeenCalledWith("gh", ["run", "rerun", "run-10", "--failed"]);
-    expect(mockExecFile).toHaveBeenCalledWith("gh", ["run", "rerun", "run-11", "--failed"]);
+    // Verify rerun-failed-jobs was called for both via fetch
+    const fetchUrls = (mockFetch.mock.calls as Array<[string, RequestInit]>).map(([url]) => url);
+    expect(fetchUrls.some((u) => u.includes("run-10/rerun-failed-jobs"))).toBe(true);
+    expect(fetchUrls.some((u) => u.includes("run-11/rerun-failed-jobs"))).toBe(true);
   });
 
   it("deduplicates runIds when multiple failing steps share the same run", async () => {
@@ -1050,7 +1074,11 @@ describe("runIterate — mark_ready", () => {
       expect(result.markedReady).toBe(true);
     }
 
-    expect(mockExecFile).toHaveBeenCalledWith("gh", ["pr", "ready", "42"]);
+    // markPullRequestReadyForReview is a GraphQL mutation — verify a /graphql fetch was made
+    const graphqlCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(([url]) =>
+      url.endsWith("/graphql"),
+    );
+    expect(graphqlCalls).toHaveLength(1);
   });
 
   it("does NOT mark ready when copilotReviewInProgress", async () => {
@@ -1077,7 +1105,10 @@ describe("runIterate — mark_ready", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("wait");
-    expect(mockExecFile).not.toHaveBeenCalledWith("gh", expect.arrayContaining(["pr", "ready"]));
+    const graphqlCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(([url]) =>
+      url.endsWith("/graphql"),
+    );
+    expect(graphqlCalls).toHaveLength(0);
   });
 });
 

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -348,7 +348,12 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
           text: () => Promise.resolve("Cannot cancel a workflow run that is completed"),
         });
       }
-      return Promise.resolve({ ok: true, status: 202, headers: new Headers(), text: () => Promise.resolve("") });
+      return Promise.resolve({
+        ok: true,
+        status: 202,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      });
     });
 
     const result = await runIterate(makeOpts());

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -28,6 +28,8 @@ import { runCheck } from "./check.mts";
 import { triageFailingChecks } from "../checks/triage.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { getCurrentPrNumber } from "../github/client.mts";
+import { rest, graphql } from "../github/http.mts";
+import { MARK_PR_READY_MUTATION } from "../github/queries.mts";
 import { readFixAttempts, writeFixAttempts } from "../cache/fix-attempts.mts";
 import { toAgentThread, toAgentComment, toAgentChecks } from "../reporters/agent.mts";
 import type {
@@ -153,7 +155,10 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
 
   // Triage failing checks now that we know we need failureKind for steps 4–6.
   if (report.checks.failing.length > 0) {
-    const triaged = await triageFailingChecks(report.checks.failing);
+    const triaged = await triageFailingChecks(report.checks.failing, {
+      owner: repoOwner,
+      name: repoName,
+    });
     report = { ...report, checks: { ...report.checks, failing: triaged } };
   }
 
@@ -218,7 +223,9 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       const uniqueRunIds = [
         ...new Set(actionableChecks.map((c) => c.runId).filter((id): id is string => id !== null)),
       ];
-      const results = await Promise.all(uniqueRunIds.map((id) => tryCancelRun(id)));
+      const results = await Promise.all(
+        uniqueRunIds.map((id) => tryCancelRun(id, repoOwner, repoName)),
+      );
       cancelled = results.filter((id): id is string => id !== null);
     }
 
@@ -311,7 +318,11 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       }
     }
     const reran = [...runMap.values()];
-    await Promise.all(reran.map(({ runId }) => runGhCommand(["run", "rerun", runId, "--failed"])));
+    await Promise.all(
+      reran.map(({ runId }) =>
+        rest("POST", `/repos/${repoOwner}/${repoName}/actions/runs/${runId}/rerun-failed-jobs`),
+      ),
+    );
     const runSummaries = reran.map(
       ({ runId, checkNames, failureKind }) =>
         `${runId} (${checkNames.join(", ")} — ${failureKind})`,
@@ -370,7 +381,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     report.mergeStatus.isDraft;
 
   if (canMarkReady && !opts.noAutoMarkReady && config.actions.autoMarkReady) {
-    await runGhCommand(["pr", "ready", String(report.pr)]);
+    await graphql(MARK_PR_READY_MUTATION, { pullRequestId: report.nodeId });
     return {
       ...base,
       action: "mark_ready",
@@ -409,25 +420,17 @@ async function getLastCommitTime(): Promise<number> {
   }
 }
 
-async function runGhCommand(args: string[]): Promise<void> {
-  try {
-    await execFile("gh", args);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`gh ${args.join(" ")} failed: ${msg}`, { cause: err });
-  }
-}
-
 // Best-effort: cancelling a completed run is a no-op, not an error.
-async function tryCancelRun(runId: string): Promise<string | null> {
+async function tryCancelRun(runId: string, owner: string, repo: string): Promise<string | null> {
   try {
-    await execFile("gh", ["run", "cancel", runId]);
+    await rest("POST", `/repos/${owner}/${repo}/actions/runs/${runId}/cancel`);
     return runId;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // gh returns this when the run reached a terminal state — expected, not worth logging.
-    if (/already completed|cannot cancel a workflow run that is completed/i.test(msg)) return null;
-    process.stderr.write(`pr-shepherd: gh run cancel ${runId} failed (ignored): ${msg}\n`);
+    // GitHub returns 409 when the run reached a terminal state — expected, not worth logging.
+    if (/409|already completed|cannot cancel a workflow run that is completed/i.test(msg))
+      return null;
+    process.stderr.write(`pr-shepherd: cancel run ${runId} failed (ignored): ${msg}\n`);
     return null;
   }
 }

--- a/src/commands/resolve.mock.test.mts
+++ b/src/commands/resolve.mock.test.mts
@@ -41,6 +41,7 @@ const BASE_OPTS = { format: "text" as const, noCache: false, cacheTtlSeconds: 30
 
 function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
   return {
+    nodeId: "PR_kgDOAAA",
     number: 42,
     state: "OPEN",
     isDraft: false,

--- a/src/config.json
+++ b/src/config.json
@@ -41,10 +41,6 @@
   "mergeStatus": {
     "blockingReviewerLogins": ["copilot"]
   },
-  "execution": {
-    "maxBufferMb": 10,
-    "triageLogBufferMb": 5
-  },
   "actions": {
     "autoResolveOutdated": true,
     "autoRebase": true,

--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -37,10 +37,6 @@ export interface PrShepherdConfig {
   mergeStatus: {
     blockingReviewerLogins: string[];
   };
-  execution: {
-    maxBufferMb: number;
-    triageLogBufferMb: number;
-  };
   actions: {
     autoResolveOutdated: boolean;
     autoRebase: boolean;
@@ -96,6 +92,14 @@ function deepMerge(
 
 function applyCompat(raw: Record<string, unknown>): Record<string, unknown> {
   const out = { ...raw };
+
+  // Removed top-level sections — warn and strip.
+  if ("execution" in out) {
+    process.stderr.write(
+      `pr-shepherd: config section "execution" (maxBufferMb, triageLogBufferMb) has been removed and has no effect.\n`,
+    );
+    delete out["execution"];
+  }
 
   // Removed keys — warn and strip.
   for (const gone of ["baseBranch", "minimizeBots", "cancelCiOnFailure", "autoMinimize"]) {

--- a/src/github/batch.mock.test.mts
+++ b/src/github/batch.mock.test.mts
@@ -19,6 +19,7 @@ const REPO = { owner: "owner", name: "repo" };
 
 function makeRawPr(overrides: Record<string, unknown> = {}) {
   return {
+    id: "PR_kgDOAAA",
     number: 42,
     state: "OPEN",
     isDraft: false,
@@ -26,6 +27,7 @@ function makeRawPr(overrides: Record<string, unknown> = {}) {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "abc123",
+    baseRefName: "main",
     reviewRequests: { nodes: [] },
     latestReviews: { nodes: [] },
     reviewThreads: {
@@ -583,5 +585,236 @@ describe("fetchPrBatch — reviewSummaries pagination", () => {
 
     const { data } = await fetchPrBatch(42, REPO);
     expect(data.reviewSummaries.map((r) => r.id)).toEqual(["PRR_1", "PRR_2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination — comments backward
+// ---------------------------------------------------------------------------
+
+describe("fetchPrBatch — comment pagination", () => {
+  it("paginates backward when hasPreviousPage is true", async () => {
+    const makeComment = (id: string) => ({
+      id,
+      isMinimized: false,
+      author: { login: "alice" },
+      body: "body",
+      createdAt: "2024-01-01T00:00:00Z",
+    });
+    const firstPage = makeRawPr({
+      comments: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-c1" },
+        nodes: [makeComment("c-2")],
+      },
+    });
+    const prevPage = makeRawPr({
+      comments: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [makeComment("c-1")],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(prevPage));
+
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.comments.map((c) => c.id)).toEqual(["c-1", "c-2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination — checks forward
+// ---------------------------------------------------------------------------
+
+describe("fetchPrBatch — checks pagination", () => {
+  it("paginates forward when hasNextPage is true", async () => {
+    const makeCheckNode = (name: string) => ({
+      __typename: "CheckRun",
+      name,
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      detailsUrl: null,
+      checkSuite: null,
+    });
+    const firstPage = makeRawPr({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: { hasNextPage: true, endCursor: "cursor-ch1" },
+                  nodes: [makeCheckNode("check-1")],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const nextPage = makeRawPr({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [makeCheckNode("check-2")],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(nextPage));
+
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.checks.map((c) => c.name)).toEqual(["check-1", "check-2"]);
+  });
+
+  it("falls back to empty page when statusCheckRollup is null in callback", async () => {
+    const firstPage = makeRawPr({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: { hasNextPage: true, endCursor: "cur-1" },
+                  nodes: [
+                    {
+                      __typename: "CheckRun",
+                      name: "check-1",
+                      status: "COMPLETED",
+                      conclusion: "SUCCESS",
+                      detailsUrl: null,
+                      checkSuite: null,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const nullRollupPage = makeRawPr({
+      commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(nullRollupPage));
+
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.checks.map((c) => c.name)).toEqual(["check-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination — PR not found errors in callbacks
+// ---------------------------------------------------------------------------
+
+describe("fetchPrBatch — PR not found in pagination callbacks", () => {
+  it("throws when thread pagination callback receives null PR", async () => {
+    const firstPage = makeRawPr({
+      reviewThreads: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-t" },
+        nodes: [{ id: "t-2", isResolved: false, isOutdated: false, comments: { nodes: [] } }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(null));
+    await expect(fetchPrBatch(42, REPO)).rejects.toThrow("PR #42 not found");
+  });
+
+  it("throws when comment pagination callback receives null PR", async () => {
+    const firstPage = makeRawPr({
+      comments: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-c" },
+        nodes: [],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(null));
+    await expect(fetchPrBatch(42, REPO)).rejects.toThrow("PR #42 not found");
+  });
+
+  it("throws when changesRequestedReviews pagination callback receives null PR", async () => {
+    const firstPage = makeRawPr({
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-cr" },
+        nodes: [],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(null));
+    await expect(fetchPrBatch(42, REPO)).rejects.toThrow("PR #42 not found");
+  });
+
+  it("throws when reviewSummaries pagination callback receives null PR", async () => {
+    const firstPage = makeRawPr({
+      reviewSummaries: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-rs" },
+        nodes: [],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(null));
+    await expect(fetchPrBatch(42, REPO)).rejects.toThrow("PR #42 not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRawPr — null author fallbacks and reviewDecision null
+// ---------------------------------------------------------------------------
+
+describe("fetchPrBatch — null author fallbacks", () => {
+  it("defaults latestReview author to 'unknown' when null", async () => {
+    const pr = makeRawPr({
+      latestReviews: { nodes: [{ author: null, state: "APPROVED" }] },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.latestReviews[0]!.login).toBe("unknown");
+  });
+
+  it("defaults comment author to 'unknown' when null", async () => {
+    const pr = makeRawPr({
+      comments: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          {
+            id: "c-1",
+            isMinimized: false,
+            author: null,
+            body: "hello",
+            createdAt: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.comments[0]!.author).toBe("unknown");
+  });
+
+  it("defaults changesRequestedReview author to 'unknown' when null", async () => {
+    const pr = makeRawPr({
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "r-1", author: null, body: "needs work" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.changesRequestedReviews[0]!.author).toBe("unknown");
+  });
+
+  it("maps reviewDecision: null to null", async () => {
+    const pr = makeRawPr({ reviewDecision: null });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.reviewDecision).toBeNull();
   });
 });

--- a/src/github/batch.mts
+++ b/src/github/batch.mts
@@ -241,6 +241,7 @@ function parseRawPr(
   });
 
   return {
+    nodeId: raw.id,
     number: raw.number,
     state: raw.state as BatchPrData["state"],
     isDraft: raw.isDraft,
@@ -299,6 +300,7 @@ interface RawBatchResponse {
 }
 
 interface RawPr {
+  id: string;
   number: number;
   state: string;
   isDraft: boolean;

--- a/src/github/client.mock.test.mts
+++ b/src/github/client.mock.test.mts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Hoist mock BEFORE any imports so node:child_process is replaced before
-// client.mts captures execFile via promisify().
+// Stub fetch globally so http.mts uses our mock.
+// child_process is still used by client.mts for `git` calls, so mock those too.
 // ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
 
 const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
 
@@ -29,22 +32,51 @@ import {
   getCurrentPrNumber,
   getMergeableState,
   getPrHeadSha,
+  getRepoInfo,
 } from "./client.mts";
+import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function ghJson(data: unknown): { stdout: string } {
-  return { stdout: JSON.stringify({ data }) };
+function gqlOk(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({
+      "content-type": "application/json",
+    }),
+    json: () => Promise.resolve({ data }),
+    text: () => Promise.resolve(JSON.stringify({ data })),
+  } as unknown as Response;
 }
 
-function ghJsonErrors(errors: Array<{ message: string }>): { stdout: string } {
-  return { stdout: JSON.stringify({ data: null, errors }) };
+function gqlErrors(errors: Array<{ message: string }>): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve({ data: null, errors }),
+    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
+  } as unknown as Response;
+}
+
+function restOk(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as unknown as Response;
 }
 
 beforeEach(() => {
+  mockFetch.mockReset();
   mockExecFile.mockReset();
+  _resetTokenCache();
+  process.env["GH_TOKEN"] = "test-token";
 });
 
 // ---------------------------------------------------------------------------
@@ -52,37 +84,37 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("graphql — arg building", () => {
-  it("passes string vars with -f", async () => {
-    mockExecFile.mockResolvedValue(ghJson({ repository: null }));
+  it("sends query as JSON body to /graphql", async () => {
+    mockFetch.mockResolvedValue(gqlOk({ repository: null }));
     await graphql("{ q }", { owner: "acme", repo: "widget" });
-    const [, args] = mockExecFile.mock.calls[0] as [string, string[]];
-    expect(args).toContain("-f");
-    expect(args).toContain("owner=acme");
-    expect(args).toContain("repo=widget");
-    expect(args).not.toContain("-F");
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/graphql");
+    const body = JSON.parse(init.body as string) as { variables: Record<string, unknown> };
+    expect(body.variables).toMatchObject({ owner: "acme", repo: "widget" });
   });
 
-  it("passes number vars with -F", async () => {
-    mockExecFile.mockResolvedValue(ghJson({ repository: null }));
+  it("includes string vars in variables", async () => {
+    mockFetch.mockResolvedValue(gqlOk({}));
+    await graphql("{ q }", { owner: "acme", repo: "widget" });
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { variables: Record<string, unknown> };
+    expect(body.variables["owner"]).toBe("acme");
+  });
+
+  it("includes number vars in variables", async () => {
+    mockFetch.mockResolvedValue(gqlOk({}));
     await graphql("{ q }", { pr: 42 });
-    const [, args] = mockExecFile.mock.calls[0] as [string, string[]];
-    expect(args).toContain("-F");
-    expect(args).toContain("pr=42");
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { variables: Record<string, unknown> };
+    expect(body.variables["pr"]).toBe(42);
   });
 
-  it("passes boolean vars with -F", async () => {
-    mockExecFile.mockResolvedValue(ghJson({}));
-    await graphql("{ q }", { dry: true });
-    const [, args] = mockExecFile.mock.calls[0] as [string, string[]];
-    expect(args).toContain("-F");
-    expect(args).toContain("dry=true");
-  });
-
-  it("embeds the query as -f query=…", async () => {
-    mockExecFile.mockResolvedValue(ghJson({}));
+  it("embeds the query string in the body", async () => {
+    mockFetch.mockResolvedValue(gqlOk({}));
     await graphql("query MyQ { viewer { login } }");
-    const [, args] = mockExecFile.mock.calls[0] as [string, string[]];
-    expect(args).toContain("query=query MyQ { viewer { login } }");
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { query: string };
+    expect(body.query).toContain("query MyQ");
   });
 });
 
@@ -92,19 +124,22 @@ describe("graphql — arg building", () => {
 
 describe("graphql — error handling", () => {
   it("throws when response contains errors[]", async () => {
-    mockExecFile.mockResolvedValue(
-      ghJsonErrors([{ message: "Field does not exist" }, { message: "Syntax error" }]),
+    mockFetch.mockResolvedValue(
+      gqlErrors([{ message: "Field does not exist" }, { message: "Syntax error" }]),
     );
     await expect(graphql("{ q }")).rejects.toThrow("Field does not exist; Syntax error");
   });
 
-  it("wraps gh exec failure as 'gh api failed: …'", async () => {
-    const cause = new Error("exit status 1");
-    mockExecFile.mockRejectedValue(cause);
+  it("wraps fetch failure as 'GitHub GraphQL request failed'", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+      text: () => Promise.resolve("Unauthorized"),
+    });
     const err = await graphql("{ q }").catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(/^gh api failed:/);
-    expect((err as Error & { cause: unknown }).cause).toBe(cause);
+    expect((err as Error).message).toMatch(/GitHub GraphQL request failed: 401/);
   });
 });
 
@@ -113,42 +148,55 @@ describe("graphql — error handling", () => {
 // ---------------------------------------------------------------------------
 
 describe("graphqlWithRateLimit — header parsing", () => {
-  function makeRawWithCRLF(remaining: number, limit: number, reset: number, data: unknown): string {
-    const headers = [
-      "HTTP/1.1 200 OK",
-      `x-ratelimit-remaining: ${remaining}`,
-      `x-ratelimit-limit: ${limit}`,
-      `x-ratelimit-reset: ${reset}`,
-    ].join("\r\n");
-    return `${headers}\r\n\r\n${JSON.stringify({ data })}`;
-  }
-
-  function makeRawWithLF(remaining: number, limit: number, reset: number, data: unknown): string {
-    const headers = [
-      "HTTP/1.1 200 OK",
-      `x-ratelimit-remaining: ${remaining}`,
-      `x-ratelimit-limit: ${limit}`,
-      `x-ratelimit-reset: ${reset}`,
-    ].join("\n");
-    return `${headers}\n\n${JSON.stringify({ data })}`;
-  }
-
-  it("parses rateLimit when headers use CRLF separator", async () => {
-    mockExecFile.mockResolvedValue({ stdout: makeRawWithCRLF(50, 5000, 1700000000, {}) });
+  it("parses x-ratelimit-* response headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        "content-type": "application/json",
+        "x-ratelimit-remaining": "50",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-reset": "1700000000",
+      }),
+      json: () => Promise.resolve({ data: {} }),
+    });
     const result = await graphqlWithRateLimit("{ q }");
     expect(result.rateLimit).toEqual({ remaining: 50, limit: 5000, resetAt: 1700000000 });
   });
 
-  it("parses rateLimit when headers use LF separator", async () => {
-    mockExecFile.mockResolvedValue({ stdout: makeRawWithLF(100, 5000, 1700000001, {}) });
-    const result = await graphqlWithRateLimit("{ q }");
-    expect(result.rateLimit).toEqual({ remaining: 100, limit: 5000, resetAt: 1700000001 });
-  });
-
-  it("returns rateLimit: undefined when no headers are present", async () => {
-    mockExecFile.mockResolvedValue({ stdout: JSON.stringify({ data: {} }) });
+  it("returns rateLimit: undefined when no rate-limit headers present", async () => {
+    mockFetch.mockResolvedValue(gqlOk({}));
     const result = await graphqlWithRateLimit("{ q }");
     expect(result.rateLimit).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRepoInfo — remote URL parsing
+// ---------------------------------------------------------------------------
+
+describe("getRepoInfo — remote URL parsing", () => {
+  it("parses git@github.com:owner/repo.git", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "git@github.com:owner/repo.git\n", stderr: "" });
+    expect(await getRepoInfo()).toEqual({ owner: "owner", name: "repo" });
+  });
+
+  it("parses https://github.com/owner/repo.git", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "https://github.com/owner/repo.git\n", stderr: "" });
+    expect(await getRepoInfo()).toEqual({ owner: "owner", name: "repo" });
+  });
+
+  it("parses https://github.com/owner/repo (no .git)", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "https://github.com/owner/repo\n", stderr: "" });
+    expect(await getRepoInfo()).toEqual({ owner: "owner", name: "repo" });
+  });
+
+  it("parses ssh://git@github.com/owner/repo.git", async () => {
+    mockExecFile.mockResolvedValue({
+      stdout: "ssh://git@github.com/owner/repo.git\n",
+      stderr: "",
+    });
+    expect(await getRepoInfo()).toEqual({ owner: "owner", name: "repo" });
   });
 });
 
@@ -158,33 +206,31 @@ describe("graphqlWithRateLimit — header parsing", () => {
 
 describe("getCurrentPrNumber", () => {
   it("returns null when branch is HEAD (detached)", async () => {
-    // First call: git rev-parse
-    mockExecFile.mockResolvedValueOnce({ stdout: "HEAD\n" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "HEAD\n", stderr: "" });
     expect(await getCurrentPrNumber()).toBeNull();
   });
 
-  it("returns null when gh pr list returns empty string", async () => {
+  it("returns null when GraphQL returns no PR for branch", async () => {
     mockExecFile
-      .mockResolvedValueOnce({ stdout: "my-branch\n" })
-      .mockResolvedValueOnce({ stdout: "\n" });
-    expect(await getCurrentPrNumber()).toBeNull();
-  });
-
-  it("returns null when gh pr list returns 'null'", async () => {
-    mockExecFile
-      .mockResolvedValueOnce({ stdout: "my-branch\n" })
-      .mockResolvedValueOnce({ stdout: "null\n" });
+      .mockResolvedValueOnce({ stdout: "my-branch\n", stderr: "" }) // rev-parse
+      .mockResolvedValueOnce({ stdout: "https://github.com/owner/repo.git\n", stderr: "" }); // remote get-url
+    mockFetch.mockResolvedValue(
+      gqlOk({ repository: { pullRequests: { nodes: [] } } }),
+    );
     expect(await getCurrentPrNumber()).toBeNull();
   });
 
   it("returns PR number on success", async () => {
     mockExecFile
-      .mockResolvedValueOnce({ stdout: "my-branch\n" })
-      .mockResolvedValueOnce({ stdout: "123\n" });
+      .mockResolvedValueOnce({ stdout: "my-branch\n", stderr: "" }) // rev-parse
+      .mockResolvedValueOnce({ stdout: "https://github.com/owner/repo.git\n", stderr: "" }); // remote get-url
+    mockFetch.mockResolvedValue(
+      gqlOk({ repository: { pullRequests: { nodes: [{ number: 123 }] } } }),
+    );
     expect(await getCurrentPrNumber()).toBe(123);
   });
 
-  it("returns null when any exec call throws", async () => {
+  it("returns null when any call throws", async () => {
     mockExecFile.mockRejectedValue(new Error("not authenticated"));
     expect(await getCurrentPrNumber()).toBeNull();
   });
@@ -195,11 +241,22 @@ describe("getCurrentPrNumber", () => {
 // ---------------------------------------------------------------------------
 
 describe("getMergeableState", () => {
-  it("returns parsed mergeable and mergeStateStatus", async () => {
-    const payload = { mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" };
-    mockExecFile.mockResolvedValue({ stdout: JSON.stringify(payload) });
+  it("maps REST true/clean to MERGEABLE/CLEAN", async () => {
+    mockFetch.mockResolvedValue(restOk({ mergeable: true, mergeable_state: "clean" }));
     const result = await getMergeableState(42, "owner", "repo");
-    expect(result).toEqual(payload);
+    expect(result).toEqual({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" });
+  });
+
+  it("maps REST false/dirty to CONFLICTING/DIRTY", async () => {
+    mockFetch.mockResolvedValue(restOk({ mergeable: false, mergeable_state: "dirty" }));
+    const result = await getMergeableState(42, "owner", "repo");
+    expect(result).toEqual({ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" });
+  });
+
+  it("maps REST null to UNKNOWN", async () => {
+    mockFetch.mockResolvedValue(restOk({ mergeable: null, mergeable_state: "unknown" }));
+    const result = await getMergeableState(42, "owner", "repo");
+    expect(result).toEqual({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" });
   });
 });
 
@@ -208,8 +265,8 @@ describe("getMergeableState", () => {
 // ---------------------------------------------------------------------------
 
 describe("getPrHeadSha", () => {
-  it("trims whitespace from stdout", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "  abc123def456  \n" });
+  it("returns head.sha from REST response", async () => {
+    mockFetch.mockResolvedValue(restOk({ head: { sha: "abc123def456" } }));
     const sha = await getPrHeadSha(42, "owner", "repo");
     expect(sha).toBe("abc123def456");
   });

--- a/src/github/client.mock.test.mts
+++ b/src/github/client.mock.test.mts
@@ -214,9 +214,7 @@ describe("getCurrentPrNumber", () => {
     mockExecFile
       .mockResolvedValueOnce({ stdout: "my-branch\n", stderr: "" }) // rev-parse
       .mockResolvedValueOnce({ stdout: "https://github.com/owner/repo.git\n", stderr: "" }); // remote get-url
-    mockFetch.mockResolvedValue(
-      gqlOk({ repository: { pullRequests: { nodes: [] } } }),
-    );
+    mockFetch.mockResolvedValue(gqlOk({ repository: { pullRequests: { nodes: [] } } }));
     expect(await getCurrentPrNumber()).toBeNull();
   });
 

--- a/src/github/client.mts
+++ b/src/github/client.mts
@@ -1,89 +1,30 @@
 /**
- * Thin wrapper around the `gh` CLI for GraphQL and REST calls.
+ * High-level GitHub client — wraps http.mts for application-level concerns.
+ *
+ * All GitHub I/O goes through native fetch (via http.mts); the `gh` CLI is no
+ * longer used for any runtime call.
  */
 
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
+import {
+  graphql as httpGraphql,
+  rest,
+  type RateLimitInfo,
+  type GraphQlResult,
+} from "./http.mts";
+import { PR_NUMBER_BY_BRANCH_QUERY } from "./queries.mts";
 import type { MergeableState, MergeStateStatus } from "../types.mts";
-import { loadConfig } from "../config/load.mts";
+
+export type { RateLimitInfo, GraphQlResult };
 
 const execFile = promisify(execFileCb);
 
-export interface RateLimitInfo {
-  remaining: number;
-  limit: number;
-  resetAt: number;
-}
-
-export interface GraphQlResult<T = unknown> {
-  data: T;
-  rateLimit?: RateLimitInfo;
-}
-
 // ---------------------------------------------------------------------------
-// GraphQL
+// GraphQL — thin re-exports so callers don't need to import http.mts directly
 // ---------------------------------------------------------------------------
 
-/**
- * Execute a GraphQL query via `gh api graphql`.
- *
- * @param query   The full GraphQL query/mutation string.
- * @param vars    Key-value pairs forwarded as `-f key=value` or `-F key=value`.
- *                Numeric values are passed with `-F`; everything else with `-f`.
- */
-export async function graphql<T = unknown>(
-  query: string,
-  vars: Record<string, string | number | boolean> = {},
-): Promise<GraphQlResult<T>> {
-  const args = buildGraphqlArgs(query, vars);
-  const raw = await runGh(args);
-  const parsed = JSON.parse(raw) as { data: T; errors?: Array<{ message: string }> };
-
-  if (parsed.errors?.length) {
-    const messages = parsed.errors.map((e) => e.message).join("; ");
-    throw new Error(`GitHub GraphQL error: ${messages}`);
-  }
-
-  return { data: parsed.data };
-}
-
-/** Like {@link graphql} but also returns the `x-ratelimit-remaining` header. */
-export async function graphqlWithRateLimit<T = unknown>(
-  query: string,
-  vars: Record<string, string | number | boolean> = {},
-): Promise<GraphQlResult<T>> {
-  // --include must come after 'api' (it's a flag for `gh api`, not for `gh`).
-  const [api, ...extraArgs] = buildGraphqlArgs(query, vars);
-  const args = [api!, "--include", ...extraArgs];
-  const raw = await runGh(args);
-
-  // `gh api -i` prepends HTTP headers before the JSON body.
-  // Handle both CRLF (\r\n\r\n) and LF-only (\n\n) header separators.
-  const crlfEnd = raw.indexOf("\r\n\r\n");
-  const lfEnd = raw.indexOf("\n\n");
-  const headerEnd = crlfEnd >= 0 ? crlfEnd : lfEnd;
-  const headerSection = headerEnd >= 0 ? raw.slice(0, headerEnd) : "";
-  const body = headerEnd >= 0 ? raw.slice(headerEnd + (crlfEnd >= 0 ? 4 : 2)) : raw;
-
-  const remaining = parseHeaderNumber(headerSection, "x-ratelimit-remaining");
-  const limit = parseHeaderNumber(headerSection, "x-ratelimit-limit");
-  const resetAt = parseHeaderNumber(headerSection, "x-ratelimit-reset");
-
-  const parsed = JSON.parse(body) as { data: T; errors?: Array<{ message: string }> };
-
-  if (parsed.errors?.length) {
-    const messages = parsed.errors.map((e) => e.message).join("; ");
-    throw new Error(`GitHub GraphQL error: ${messages}`);
-  }
-
-  return {
-    data: parsed.data,
-    rateLimit:
-      remaining !== null && limit !== null && resetAt !== null
-        ? { remaining, limit, resetAt }
-        : undefined,
-  };
-}
+export { graphql, graphqlWithRateLimit } from "./http.mts";
 
 // ---------------------------------------------------------------------------
 // Repo / PR lookup helpers
@@ -94,11 +35,14 @@ export interface RepoInfo {
   name: string;
 }
 
-/** Returns the current repo's owner and name from `gh repo view`. */
+/**
+ * Returns the current repo's owner and name by parsing `git remote get-url origin`.
+ * Handles https://, git@, and ssh:// remote URL formats.
+ */
 export async function getRepoInfo(): Promise<RepoInfo> {
-  const raw = await runGh(["repo", "view", "--json", "owner,name"]);
-  const parsed = JSON.parse(raw) as { owner: { login: string }; name: string };
-  return { owner: parsed.owner.login, name: parsed.name };
+  const { stdout } = await execFile("git", ["remote", "get-url", "origin"]);
+  const url = stdout.trim();
+  return parseRemoteUrl(url);
 }
 
 /**
@@ -108,40 +52,25 @@ export async function getRepoInfo(): Promise<RepoInfo> {
 export async function getCurrentPrNumber(): Promise<number | null> {
   try {
     const branch = await getCurrentBranch();
-    // In detached HEAD state git returns "HEAD" — no branch name to look up.
     if (branch === "HEAD") return null;
-    const raw = await runGh([
-      "pr",
-      "list",
-      "--head",
-      branch,
-      "--json",
-      "number",
-      "--jq",
-      ".[0].number",
-    ]);
-    const trimmed = raw.trim();
-    if (!trimmed || trimmed === "null") return null;
-    return parseInt(trimmed, 10);
+    const repo = await getRepoInfo();
+    const result = await httpGraphql<{
+      repository: { pullRequests: { nodes: Array<{ number: number }> } } | null;
+    }>(PR_NUMBER_BY_BRANCH_QUERY, { owner: repo.owner, repo: repo.name, branch });
+    return result.data.repository?.pullRequests.nodes[0]?.number ?? null;
   } catch {
     return null;
   }
 }
 
-async function getCurrentBranch(): Promise<string> {
-  // Use git directly for branch name — gh doesn't expose it.
-  const { stdout } = await execFile("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
-  return stdout.trim();
-}
-
 /** Returns the `headRefOid` (commit SHA) of the given PR as reported by GitHub. */
 export async function getPrHeadSha(pr: number, owner: string, name: string): Promise<string> {
-  const raw = await runGh(["api", `repos/${owner}/${name}/pulls/${pr}`, "--jq", ".head.sha"]);
-  return raw.trim();
+  const data = await rest<{ head: { sha: string } }>("GET", `/repos/${owner}/${name}/pulls/${pr}`);
+  return data.head.sha;
 }
 
 /**
- * Fetches `mergeable` and `mergeStateStatus` via the REST API (`gh pr view`).
+ * Fetches `mergeable` and `mergeStateStatus` via the REST API.
  *
  * Used as a fallback when the GraphQL API returns `UNKNOWN` for these fields —
  * a known GitHub quirk where GraphQL lags behind the REST layer.
@@ -151,56 +80,43 @@ export async function getMergeableState(
   owner: string,
   repo: string,
 ): Promise<{ mergeable: MergeableState; mergeStateStatus: MergeStateStatus }> {
-  const raw = await runGh([
-    "pr",
-    "view",
-    String(pr),
-    "--repo",
-    `${owner}/${repo}`,
-    "--json",
-    "mergeable,mergeStateStatus",
-  ]);
-  const parsed = JSON.parse(raw) as {
-    mergeable: MergeableState;
-    mergeStateStatus: MergeStateStatus;
-  };
-  return parsed;
+  const data = await rest<{ mergeable: boolean | null; mergeable_state: string }>(
+    "GET",
+    `/repos/${owner}/${repo}/pulls/${pr}`,
+  );
+
+  const mergeable: MergeableState =
+    data.mergeable === true ? "MERGEABLE" : data.mergeable === false ? "CONFLICTING" : "UNKNOWN";
+
+  const mergeStateStatus = data.mergeable_state.toUpperCase() as MergeStateStatus;
+
+  return { mergeable, mergeStateStatus };
 }
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function buildGraphqlArgs(
-  query: string,
-  vars: Record<string, string | number | boolean>,
-): string[] {
-  const args = ["api", "graphql", "-f", `query=${query}`];
-  for (const [k, v] of Object.entries(vars)) {
-    if (typeof v === "number" || typeof v === "boolean") {
-      args.push("-F", `${k}=${String(v)}`);
-    } else {
-      args.push("-f", `${k}=${v}`);
-    }
-  }
-  return args;
+async function getCurrentBranch(): Promise<string> {
+  const { stdout } = await execFile("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  return stdout.trim();
 }
 
-async function runGh(args: string[]): Promise<string> {
-  try {
-    const { stdout } = await execFile("gh", args, {
-      maxBuffer: loadConfig().execution.maxBufferMb * 1024 * 1024,
-    });
-    return stdout;
-  } catch (err) {
-    // Re-throw with a more useful message
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`gh ${args[0] ?? ""} failed: ${msg}`, { cause: err });
-  }
-}
+function parseRemoteUrl(url: string): RepoInfo {
+  // Strip trailing .git
+  const stripped = url.replace(/\.git$/, "");
 
-function parseHeaderNumber(headers: string, name: string): number | null {
-  const re = new RegExp(`^${name}:\\s*(\\d+)`, "im");
-  const m = re.exec(headers);
-  return m ? parseInt(m[1]!, 10) : null;
+  // ssh: git@host:owner/repo
+  const sshMatch = /^git@[^:]+:([^/]+)\/(.+)$/.exec(stripped);
+  if (sshMatch) {
+    return { owner: sshMatch[1]!, name: sshMatch[2]! };
+  }
+
+  // https or ssh://: https://host/owner/repo  or  ssh://git@host/owner/repo
+  const httpsMatch = /^(?:https?|ssh):\/\/[^/]+\/([^/]+)\/(.+)$/.exec(stripped);
+  if (httpsMatch) {
+    return { owner: httpsMatch[1]!, name: httpsMatch[2]! };
+  }
+
+  throw new Error(`Cannot parse GitHub remote URL: ${url}`);
 }

--- a/src/github/client.mts
+++ b/src/github/client.mts
@@ -7,12 +7,7 @@
 
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import {
-  graphql as httpGraphql,
-  rest,
-  type RateLimitInfo,
-  type GraphQlResult,
-} from "./http.mts";
+import { graphql as httpGraphql, rest, type RateLimitInfo, type GraphQlResult } from "./http.mts";
 import { PR_NUMBER_BY_BRANCH_QUERY } from "./queries.mts";
 import type { MergeableState, MergeStateStatus } from "../types.mts";
 

--- a/src/github/client.mts
+++ b/src/github/client.mts
@@ -2,7 +2,8 @@
  * High-level GitHub client — wraps http.mts for application-level concerns.
  *
  * All GitHub I/O goes through native fetch (via http.mts); the `gh` CLI is no
- * longer used for any runtime call.
+ * longer used for GitHub API calls, but may be invoked as an auth-token
+ * fallback via `gh auth token` when neither GH_TOKEN nor GITHUB_TOKEN is set.
  */
 
 import { execFile as execFileCb } from "node:child_process";
@@ -98,8 +99,8 @@ async function getCurrentBranch(): Promise<string> {
 }
 
 function parseRemoteUrl(url: string): RepoInfo {
-  // Strip trailing .git
-  const stripped = url.replace(/\.git$/, "");
+  // Strip trailing .git and trailing slash
+  const stripped = url.replace(/\.git$/, "").replace(/\/$/, "");
 
   // ssh: git@host:owner/repo
   const sshMatch = /^git@[^:]+:([^/]+)\/(.+)$/.exec(stripped);

--- a/src/github/gql/batch-pr.gql
+++ b/src/github/gql/batch-pr.gql
@@ -10,6 +10,7 @@ query BatchPr(
 ) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
+      id
       number
       state
       isDraft

--- a/src/github/gql/mark-pr-ready.gql
+++ b/src/github/gql/mark-pr-ready.gql
@@ -1,0 +1,7 @@
+mutation MarkPrReady($pullRequestId: ID!) {
+  markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+    pullRequest {
+      isDraft
+    }
+  }
+}

--- a/src/github/gql/pr-number-by-branch.gql
+++ b/src/github/gql/pr-number-by-branch.gql
@@ -1,0 +1,9 @@
+query PrNumberByBranch($owner: String!, $repo: String!, $branch: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(headRefName: $branch, states: OPEN, first: 1) {
+      nodes {
+        number
+      }
+    }
+  }
+}

--- a/src/github/http.mock.test.mts
+++ b/src/github/http.mock.test.mts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Stub fetch and child_process globally before any imports.
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    optsOrCb:
+      | Record<string, unknown>
+      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
+    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
+    mockExecFile(cmd, args)
+      .then((result: { stdout: string; stderr: string }) => cb(null, result))
+      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+  },
+}));
+
+import { graphql, graphqlWithRateLimit, rest, restText, _resetTokenCache } from "./http.mts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonOk(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as unknown as Response;
+}
+
+function gqlOk(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve({ data }),
+    text: () => Promise.resolve(JSON.stringify({ data })),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockExecFile.mockReset();
+  _resetTokenCache();
+  delete process.env["GH_TOKEN"];
+  delete process.env["GITHUB_TOKEN"];
+});
+
+// ---------------------------------------------------------------------------
+// Token resolution
+// ---------------------------------------------------------------------------
+
+describe("token resolution", () => {
+  it("uses GH_TOKEN when set", async () => {
+    process.env["GH_TOKEN"] = "my-gh-token";
+    mockFetch.mockResolvedValue(gqlOk({}));
+    await graphql("{ q }");
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer my-gh-token");
+  });
+
+  it("falls back to GITHUB_TOKEN when GH_TOKEN is absent", async () => {
+    process.env["GITHUB_TOKEN"] = "my-github-token";
+    mockFetch.mockResolvedValue(gqlOk({}));
+    await graphql("{ q }");
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer my-github-token",
+    );
+  });
+
+  it("falls back to `gh auth token` when no env var is set", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "fallback-token\n", stderr: "" });
+    mockFetch.mockResolvedValue(gqlOk({}));
+    await graphql("{ q }");
+    expect(mockExecFile).toHaveBeenCalledWith("gh", ["auth", "token"]);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer fallback-token");
+  });
+
+  it("throws a helpful error when no token is available", async () => {
+    mockExecFile.mockRejectedValue(new Error("not authenticated"));
+    await expect(graphql("{ q }")).rejects.toThrow(/No GitHub token found/);
+  });
+
+  it("caches the resolved token across calls", async () => {
+    process.env["GH_TOKEN"] = "cached-token";
+    mockFetch.mockResolvedValue(gqlOk({}));
+    await graphql("{ q }");
+    await graphql("{ q }");
+    // execFile should never be called — token came from env
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// graphql — error handling
+// ---------------------------------------------------------------------------
+
+describe("graphql — error handling", () => {
+  it("throws on non-2xx responses", async () => {
+    process.env["GH_TOKEN"] = "tok";
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+      text: () => Promise.resolve("Unauthorized"),
+    });
+    await expect(graphql("{ q }")).rejects.toThrow(/GitHub GraphQL request failed: 401/);
+  });
+
+  it("throws on GraphQL errors[] in payload", async () => {
+    process.env["GH_TOKEN"] = "tok";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: () => Promise.resolve({ data: null, errors: [{ message: "bad field" }] }),
+    });
+    await expect(graphql("{ q }")).rejects.toThrow(/bad field/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// graphqlWithRateLimit — header parsing
+// ---------------------------------------------------------------------------
+
+describe("graphqlWithRateLimit — header parsing", () => {
+  beforeEach(() => {
+    process.env["GH_TOKEN"] = "tok";
+  });
+
+  it("returns rateLimit when headers are present", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        "content-type": "application/json",
+        "x-ratelimit-remaining": "42",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-reset": "1700000000",
+      }),
+      json: () => Promise.resolve({ data: {} }),
+    });
+    const result = await graphqlWithRateLimit("{ q }");
+    expect(result.rateLimit).toEqual({ remaining: 42, limit: 5000, resetAt: 1700000000 });
+  });
+
+  it("returns rateLimit: undefined when rate-limit headers are absent", async () => {
+    mockFetch.mockResolvedValue(gqlOk({}));
+    const result = await graphqlWithRateLimit("{ q }");
+    expect(result.rateLimit).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rest — JSON parsing and error handling
+// ---------------------------------------------------------------------------
+
+describe("rest", () => {
+  beforeEach(() => {
+    process.env["GH_TOKEN"] = "tok";
+  });
+
+  it("returns parsed JSON when content-type is application/json", async () => {
+    mockFetch.mockResolvedValue(jsonOk({ id: 1, name: "widget" }));
+    const data = await rest<{ id: number; name: string }>("GET", "/repos/o/r/pulls/1");
+    expect(data).toEqual({ id: 1, name: "widget" });
+  });
+
+  it("returns undefined when no content-type header", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+      text: () => Promise.resolve(""),
+    });
+    const result = await rest("POST", "/repos/o/r/actions/runs/1/cancel");
+    expect(result).toBeUndefined();
+  });
+
+  it("throws on non-2xx with method and path in message", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      headers: new Headers(),
+      text: () => Promise.resolve("conflict"),
+    });
+    await expect(rest("POST", "/repos/o/r/actions/runs/1/cancel")).rejects.toThrow(
+      /GitHub REST POST \/repos\/o\/r\/actions\/runs\/1\/cancel failed: 409/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// restText — redirect handling
+// ---------------------------------------------------------------------------
+
+describe("restText — redirect handling", () => {
+  beforeEach(() => {
+    process.env["GH_TOKEN"] = "tok";
+  });
+
+  it("follows 302 redirect and returns text from redirect target", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: "https://storage.example.com/logs/job-1.txt" }),
+        text: () => Promise.resolve(""),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve("log content here"),
+      });
+    const text = await restText("GET", "/repos/o/r/actions/jobs/1/logs");
+    expect(text).toBe("log content here");
+  });
+
+  it("returns text directly for 200 responses", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: () => Promise.resolve("direct log content"),
+    });
+    const text = await restText("GET", "/repos/o/r/actions/jobs/1/logs");
+    expect(text).toBe("direct log content");
+  });
+});

--- a/src/github/http.mock.test.mts
+++ b/src/github/http.mock.test.mts
@@ -242,4 +242,35 @@ describe("restText — redirect handling", () => {
     const text = await restText("GET", "/repos/o/r/actions/jobs/1/logs");
     expect(text).toBe("direct log content");
   });
+
+  it("throws when redirect target returns non-2xx", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: "https://storage.example.com/logs/job-1.txt" }),
+        text: () => Promise.resolve(""),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        text: () => Promise.resolve("Forbidden"),
+      });
+    await expect(restText("GET", "/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
+      /redirect target.*failed: 403/,
+    );
+  });
+
+  it("throws on non-2xx non-redirect responses", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      headers: new Headers(),
+      text: () => Promise.resolve("Not Found"),
+    });
+    await expect(restText("GET", "/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
+      /GitHub REST GET.*failed: 404/,
+    );
+  });
 });

--- a/src/github/http.mock.test.mts
+++ b/src/github/http.mock.test.mts
@@ -228,7 +228,7 @@ describe("restText — redirect handling", () => {
         headers: new Headers(),
         text: () => Promise.resolve("log content here"),
       });
-    const text = await restText("GET", "/repos/o/r/actions/jobs/1/logs");
+    const text = await restText("/repos/o/r/actions/jobs/1/logs");
     expect(text).toBe("log content here");
   });
 
@@ -239,7 +239,7 @@ describe("restText — redirect handling", () => {
       headers: new Headers(),
       text: () => Promise.resolve("direct log content"),
     });
-    const text = await restText("GET", "/repos/o/r/actions/jobs/1/logs");
+    const text = await restText("/repos/o/r/actions/jobs/1/logs");
     expect(text).toBe("direct log content");
   });
 
@@ -257,7 +257,7 @@ describe("restText — redirect handling", () => {
         headers: new Headers(),
         text: () => Promise.resolve("Forbidden"),
       });
-    await expect(restText("GET", "/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
+    await expect(restText("/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
       /redirect target.*failed: 403/,
     );
   });
@@ -269,7 +269,7 @@ describe("restText — redirect handling", () => {
       headers: new Headers(),
       text: () => Promise.resolve("Not Found"),
     });
-    await expect(restText("GET", "/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
+    await expect(restText("/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
       /GitHub REST GET.*failed: 404/,
     );
   });

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -143,13 +143,13 @@ export async function rest<T = unknown>(method: string, path: string, body?: unk
 }
 
 /**
- * REST request that returns plain text.
+ * GET request that returns plain text.
  * Handles the 302 redirect pattern used by the GitHub Actions job-logs endpoint —
  * the redirect target (a signed storage URL) is fetched without auth headers.
  */
-export async function restText(method: string, path: string): Promise<string> {
+export async function restText(path: string): Promise<string> {
   const res = await fetch(`${BASE_URL}${path}`, {
-    method,
+    method: "GET",
     headers: await makeHeaders(),
     redirect: "manual",
   });
@@ -167,7 +167,7 @@ export async function restText(method: string, path: string): Promise<string> {
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`);
+    throw new Error(`GitHub REST GET ${path} failed: ${res.status} ${text.slice(0, 300)}`);
   }
 
   return res.text();

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -1,0 +1,202 @@
+/**
+ * Thin native-fetch HTTP client for the GitHub API.
+ * Replaces the previous `gh` CLI shell-out on every code path.
+ *
+ * Token resolution order:
+ *   1. GH_TOKEN env
+ *   2. GITHUB_TOKEN env
+ *   3. `gh auth token` (fallback for users who have run `gh auth login`)
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+const BASE_URL = "https://api.github.com";
+
+export interface RateLimitInfo {
+  remaining: number;
+  limit: number;
+  resetAt: number;
+}
+
+export interface GraphQlResult<T = unknown> {
+  data: T;
+  rateLimit?: RateLimitInfo;
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+let _token: string | undefined;
+
+export function _resetTokenCache(): void {
+  _token = undefined;
+}
+
+async function resolveToken(): Promise<string> {
+  if (_token) return _token;
+
+  if (process.env["GH_TOKEN"]) {
+    _token = process.env["GH_TOKEN"];
+    return _token;
+  }
+  if (process.env["GITHUB_TOKEN"]) {
+    _token = process.env["GITHUB_TOKEN"];
+    return _token;
+  }
+
+  try {
+    const { stdout } = await execFile("gh", ["auth", "token"]);
+    const token = stdout.trim();
+    if (token) {
+      _token = token;
+      return _token;
+    }
+  } catch {
+    // fall through to error
+  }
+
+  throw new Error(
+    "No GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or run `gh auth login`.",
+  );
+}
+
+async function makeHeaders(): Promise<Record<string, string>> {
+  return {
+    Authorization: `Bearer ${await resolveToken()}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "pr-shepherd",
+    "Content-Type": "application/json",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL
+// ---------------------------------------------------------------------------
+
+async function graphqlInner<T>(
+  query: string,
+  vars: Record<string, string | number | boolean>,
+): Promise<{ data: T; rateLimit: RateLimitInfo | null }> {
+  const res = await fetch(`${BASE_URL}/graphql`, {
+    method: "POST",
+    headers: await makeHeaders(),
+    body: JSON.stringify({ query, variables: vars }),
+  });
+
+  const rateLimit = parseRateLimit(res.headers);
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub GraphQL request failed: ${res.status} ${body.slice(0, 300)}`);
+  }
+
+  const parsed = (await res.json()) as { data: T; errors?: Array<{ message: string }> };
+
+  if (parsed.errors?.length) {
+    const messages = parsed.errors.map((e) => e.message).join("; ");
+    throw new Error(`GitHub GraphQL error: ${messages}`);
+  }
+
+  return { data: parsed.data, rateLimit };
+}
+
+export async function graphql<T = unknown>(
+  query: string,
+  vars: Record<string, string | number | boolean> = {},
+): Promise<GraphQlResult<T>> {
+  const { data } = await graphqlInner<T>(query, vars);
+  return { data };
+}
+
+export async function graphqlWithRateLimit<T = unknown>(
+  query: string,
+  vars: Record<string, string | number | boolean> = {},
+): Promise<GraphQlResult<T>> {
+  const { data, rateLimit } = await graphqlInner<T>(query, vars);
+  return { data, rateLimit: rateLimit ?? undefined };
+}
+
+// ---------------------------------------------------------------------------
+// REST
+// ---------------------------------------------------------------------------
+
+export async function rest<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: await makeHeaders(),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`,
+    );
+  }
+
+  const ct = res.headers.get("content-type") ?? "";
+  if (ct.includes("application/json")) {
+    return res.json() as Promise<T>;
+  }
+  return undefined as T;
+}
+
+/**
+ * REST request that returns plain text.
+ * Handles the 302 redirect pattern used by the GitHub Actions job-logs endpoint —
+ * the redirect target (a signed storage URL) is fetched without auth headers.
+ */
+export async function restText(method: string, path: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: await makeHeaders(),
+    redirect: "manual",
+  });
+
+  if (res.status === 301 || res.status === 302 || res.status === 307 || res.status === 308) {
+    const location = res.headers.get("location");
+    if (location) {
+      const redirectRes = await fetch(location);
+      if (!redirectRes.ok) {
+        throw new Error(`redirect target ${location} failed: ${redirectRes.status}`);
+      }
+      return redirectRes.text();
+    }
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`,
+    );
+  }
+
+  return res.text();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseRateLimit(headers: Headers): RateLimitInfo | null {
+  const rRaw = headers.get("x-ratelimit-remaining");
+  const lRaw = headers.get("x-ratelimit-limit");
+  const tRaw = headers.get("x-ratelimit-reset");
+  if (rRaw === null || lRaw === null || tRaw === null) return null;
+  const remaining = Number(rRaw);
+  const limit = Number(lRaw);
+  const resetAt = Number(tRaw);
+  if (Number.isFinite(remaining) && Number.isFinite(limit) && Number.isFinite(resetAt)) {
+    return { remaining, limit, resetAt };
+  }
+  return null;
+}

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -59,9 +59,7 @@ async function resolveToken(): Promise<string> {
     // fall through to error
   }
 
-  throw new Error(
-    "No GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or run `gh auth login`.",
-  );
+  throw new Error("No GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or run `gh auth login`.");
 }
 
 async function makeHeaders(): Promise<Record<string, string>> {
@@ -125,11 +123,7 @@ export async function graphqlWithRateLimit<T = unknown>(
 // REST
 // ---------------------------------------------------------------------------
 
-export async function rest<T = unknown>(
-  method: string,
-  path: string,
-  body?: unknown,
-): Promise<T> {
+export async function rest<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`, {
     method,
     headers: await makeHeaders(),
@@ -138,9 +132,7 @@ export async function rest<T = unknown>(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(
-      `GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`,
-    );
+    throw new Error(`GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`);
   }
 
   const ct = res.headers.get("content-type") ?? "";
@@ -175,9 +167,7 @@ export async function restText(method: string, path: string): Promise<string> {
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(
-      `GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`,
-    );
+    throw new Error(`GitHub REST ${method} ${path} failed: ${res.status} ${text.slice(0, 300)}`);
   }
 
   return res.text();

--- a/src/github/queries.mts
+++ b/src/github/queries.mts
@@ -28,3 +28,9 @@ export const MULTI_PR_STATUS_QUERY = gql("multi-pr-status.gql");
 
 /** Paginated version — used when reviewThreads is truncated (totalCount > 100). */
 export const MULTI_PR_STATUS_QUERY_WITH_CURSOR = gql("multi-pr-status-paged.gql");
+
+/** Look up PR number by branch name (for getCurrentPrNumber). */
+export const PR_NUMBER_BY_BRANCH_QUERY = gql("pr-number-by-branch.gql");
+
+/** Convert a draft PR to ready for review. */
+export const MARK_PR_READY_MUTATION = gql("mark-pr-ready.gql");

--- a/src/merge-status/derive.test.mts
+++ b/src/merge-status/derive.test.mts
@@ -4,6 +4,7 @@ import type { BatchPrData } from "../types.mts";
 
 function makePr(overrides: Partial<BatchPrData>): BatchPrData {
   return {
+    nodeId: "PR_kgDOAAA",
     number: 42,
     state: "OPEN",
     isDraft: false,

--- a/src/reporters/json.test.mts
+++ b/src/reporters/json.test.mts
@@ -5,6 +5,7 @@ import type { ShepherdReport } from "../types.mts";
 function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
   return {
     pr: 42,
+    nodeId: "PR_kgDOAAA",
     repo: "owner/repo",
     status: "READY",
     baseBranch: "main",

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -40,6 +40,7 @@ function makeThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
 function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
   return {
     pr: 42,
+    nodeId: "PR_kgDOAAA",
     repo: "owner/repo",
     status: "READY",
     baseBranch: "main",

--- a/src/types.mts
+++ b/src/types.mts
@@ -125,6 +125,7 @@ export interface MergeStatusResult {
 // ---------------------------------------------------------------------------
 
 export interface BatchPrData {
+  nodeId: string;
   number: number;
   state: "OPEN" | "CLOSED" | "MERGED";
   isDraft: boolean;
@@ -157,9 +158,11 @@ export type ShepherdStatus =
 
 export interface ShepherdReport {
   pr: number;
+  /** GitHub node ID of the PR — used for mutations (e.g. markPullRequestReadyForReview). */
+  nodeId: string;
   repo: string;
   status: ShepherdStatus;
-  /** PR base branch from the GraphQL batch — used by `iterate` to avoid a second `gh pr view` round-trip. */
+  /** PR base branch from the GraphQL batch. */
   baseBranch: string;
   mergeStatus: MergeStatusResult;
   checks: {


### PR DESCRIPTION
## Summary

- **New `src/github/http.mts`** — shared fetch client with token resolution (`GH_TOKEN` → `GITHUB_TOKEN` → `gh auth token` fallback), GraphQL and REST helpers, rate-limit header parsing
- **`src/github/client.mts` rewrite** — all calls use `http.mts`; `getRepoInfo()` parses `git remote get-url origin` instead of `gh repo view`; `getPrHeadSha` and `getMergeableState` use REST
- **`src/checks/triage.mts` rewrite** — log fetching uses 2-step REST (list jobs → per-job logs) instead of `gh run view --log-failed`; `triageFailingChecks` gains a `repo` parameter
- **`src/commands/iterate.mts`** — rerun-failed and cancel use REST; mark-ready uses the `markPullRequestReadyForReview` GraphQL mutation with the PR node ID; `runGhCommand` deleted
- **`nodeId`** threaded through `batch-pr.gql` → `BatchPrData` → `ShepherdReport` for the mark-ready mutation
- **`execution` config section removed** — `maxBufferMb` and `triageLogBufferMb` no longer needed (no subprocess buffer caps with native fetch); old `.pr-shepherdrc.yml` files emit a one-time deprecation warning and continue to load
- **Docs and README** updated — `gh` is now optional (only needed if neither `GH_TOKEN` nor `GITHUB_TOKEN` is set)
- **New `src/github/http.mock.test.mts`** — token resolution precedence, error handling, rate-limit parsing, redirect following

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` — 25 test files, 413 tests all green
- [ ] End-to-end: `npx pr-shepherd check <PR> --format=json` with `GH_TOKEN` set confirms env-var auth path
- [ ] End-to-end: iterate against a PR with a transient check failure (exercises rerun-failed REST call)
- [ ] End-to-end: iterate against a draft PR with all-green CI (exercises mark-ready GraphQL mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #52 