### PR TITLE
feat: add PENDING status for merge-blocked PRs with passing CI

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -96,7 +96,7 @@ Re-triggers CI runs that failed due to transient infrastructure or timeout issue
 ```markdown
 # PR #42 [RERUN_CI]
 
-**status** `FAILING` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
+**status** `PENDING` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 0 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
 
 RERAN 2 CI runs: 24697658766 (lint / typecheck / test (22.x) — timeout), 24697658767 (build — infrastructure)
@@ -177,7 +177,7 @@ Rebases the branch on top of its base to clear flaky failures caused by being be
 ````markdown
 # PR #42 [REBASE]
 
-**status** `FAILING` · **merge** `BEHIND` · **state** `OPEN` · **repo** `owner/repo`
+**status** `PENDING` · **merge** `BEHIND` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 2 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
 
 Branch is behind main — rebasing to pick up latest changes and clear flaky failures

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -96,7 +96,7 @@ Re-triggers CI runs that failed due to transient infrastructure or timeout issue
 ```markdown
 # PR #42 [RERUN_CI]
 
-**status** `PENDING` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
+**status** `FAILING` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 0 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
 
 RERAN 2 CI runs: 24697658766 (lint / typecheck / test (22.x) — timeout), 24697658767 (build — infrastructure)
@@ -177,7 +177,7 @@ Rebases the branch on top of its base to clear flaky failures caused by being be
 ````markdown
 # PR #42 [REBASE]
 
-**status** `PENDING` · **merge** `BEHIND` · **state** `OPEN` · **repo** `owner/repo`
+**status** `FAILING` · **merge** `BEHIND` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 2 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
 
 Branch is behind main — rebasing to pick up latest changes and clear flaky failures

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -54,7 +54,7 @@ GitHub sometimes updates `mergeStateStatus` to `'DRAFT'` before the `isDraft` bo
 
 In this case `mergeStatus.status` in the report is still `BLOCKED` (truthful about the GitHub merge state), but the top-level `ShepherdStatus` is `READY`, signalling that shepherd has nothing more to do. The ready-delay timer starts, and `action: cancel` is emitted after it elapses.
 
-Any BLOCKED case that does not satisfy all of the above conditions (e.g. Copilot review in progress, unresolved threads, or `reviewDecision` is null) maps to `ShepherdStatus: "PENDING"` rather than `"FAILING"`. `FAILING` is reserved for red CI checks and merge conflicts.
+Any `BLOCKED` case that does not satisfy all of the above conditions (e.g. Copilot review in progress, unresolved threads, or `reviewDecision` is null) maps to `ShepherdStatus: "PENDING"` rather than `"FAILING"`. The same applies to `UNSTABLE` (non-required checks are red but merge is not fully blocked) and `BEHIND` (head branch is out of date). `FAILING` is reserved for red CI checks (`verdict.anyFailing`) and merge conflicts (`CONFLICTS`).
 
 ## Copilot detection
 

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -54,6 +54,8 @@ GitHub sometimes updates `mergeStateStatus` to `'DRAFT'` before the `isDraft` bo
 
 In this case `mergeStatus.status` in the report is still `BLOCKED` (truthful about the GitHub merge state), but the top-level `ShepherdStatus` is `READY`, signalling that shepherd has nothing more to do. The ready-delay timer starts, and `action: cancel` is emitted after it elapses.
 
+Any BLOCKED case that does not satisfy all of the above conditions (e.g. Copilot review in progress, unresolved threads, or `reviewDecision` is null) maps to `ShepherdStatus: "PENDING"` rather than `"FAILING"`. `FAILING` is reserved for red CI checks and merge conflicts.
+
 ## Copilot detection
 
 `detectCopilotReview(pr)` returns true when:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ pr-shepherd check 42 --format=json
 pr-shepherd check 42 --no-cache
 ```
 
-**Exit codes:** 0=READY, 1=FAILING/BLOCKED/CONFLICTS/UNKNOWN, 2=IN_PROGRESS, 3=UNRESOLVED_COMMENTS
+**Exit codes:** 0=READY, 1=FAILING/PENDING/UNKNOWN, 2=IN_PROGRESS, 3=UNRESOLVED_COMMENTS
 
 ### `pr-shepherd resolve [PR]`
 

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -246,7 +246,7 @@ describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () =
     expect(report.status).toBe("FAILING");
   });
 
-  it("returns FAILING when an unresolved thread also exists (iterate handles it via actionable check)", async () => {
+  it("returns PENDING when an unresolved thread also exists (iterate handles it via actionable check)", async () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({
         mergeStateStatus: "BLOCKED",
@@ -267,10 +267,10 @@ describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () =
       }),
     });
     const report = await runCheck(BASE_OPTS);
-    expect(report.status).toBe("FAILING");
+    expect(report.status).toBe("PENDING");
   });
 
-  it("returns FAILING when copilot review is also in progress", async () => {
+  it("returns PENDING when copilot review is also in progress", async () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({
         mergeStateStatus: "BLOCKED",
@@ -279,15 +279,15 @@ describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () =
       }),
     });
     const report = await runCheck(BASE_OPTS);
-    expect(report.status).toBe("FAILING");
+    expect(report.status).toBe("PENDING");
   });
 
-  it("returns FAILING when BLOCKED but reviewDecision is null (other branch protection)", async () => {
+  it("returns PENDING when BLOCKED but reviewDecision is null (other branch protection)", async () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: null }),
     });
     const report = await runCheck(BASE_OPTS);
-    expect(report.status).toBe("FAILING");
+    expect(report.status).toBe("PENDING");
   });
 });
 

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -6,10 +6,11 @@
  *
  * Exit codes:
  *   0  READY — all checks passed, no unresolved threads, CLEAN merge status.
- *   1  FAILING — one or more CI checks failed.
+ *   1  FAILING — CI has red checks, or merge has conflicts.
+ *   1  PENDING — CI passing but merge blocked (BLOCKED, UNSTABLE, or BEHIND).
+ *   1  UNKNOWN — merge state unresolvable.
  *   2  IN_PROGRESS — CI checks still running.
  *   3  UNRESOLVED_COMMENTS — CI ok but actionable threads remain.
- *   1  (also) BLOCKED/CONFLICTS/UNKNOWN merge status.
  */
 
 import { fetchPrBatch } from "../github/batch.mts";

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -177,6 +177,7 @@ function computeStatus(
   if (mergeStatus.status === "CONFLICTS") return "FAILING";
   // Check CI state before merge-blocking states: BLOCKED/UNSTABLE/BEHIND are
   // often caused by CI not having passed yet, so they shouldn't mask IN_PROGRESS.
+  // These merge-blocking states become PENDING (not FAILING) once CI is resolved.
   if (verdict.anyFailing) return "FAILING";
   if (verdict.anyInProgress) return "IN_PROGRESS";
   // BLOCKED solely because a human reviewer hasn't approved yet — shepherd is done, hand off.
@@ -197,7 +198,7 @@ function computeStatus(
     mergeStatus.status === "UNSTABLE" ||
     mergeStatus.status === "BEHIND"
   )
-    return "FAILING";
+    return "PENDING";
   if (mergeStatus.status === "UNKNOWN") return "UNKNOWN";
   if (changesRequestedReviews > 0) return "UNRESOLVED_COMMENTS";
   if (unresolvedThreads > 0 || unresolvedComments > 0) return "UNRESOLVED_COMMENTS";

--- a/src/types.mts
+++ b/src/types.mts
@@ -150,6 +150,7 @@ export interface BatchPrData {
 export type ShepherdStatus =
   | "READY"
   | "FAILING"
+  | "PENDING"
   | "IN_PROGRESS"
   | "UNRESOLVED_COMMENTS"
   | "UNKNOWN";


### PR DESCRIPTION
## Summary

- Introduces a new `ShepherdStatus` value `PENDING` for PRs where CI is passing but the merge is blocked by a non-CI condition (BLOCKED, UNSTABLE, or BEHIND merge state).
- `FAILING` now means only: CI has a red check (`verdict.anyFailing`) or there are merge conflicts (`CONFLICTS`).
- Exit codes are unchanged — `PENDING` falls through to exit code 1 (same as `FAILING` today for these cases).

Fixes #56

## Test plan

- [ ] `npm test` passes (395 tests)
- [ ] `npm run build` passes
- [ ] PR #53's scenario (CI passing, `copilotReviewInProgress: true`, merge BLOCKED) now reports `PENDING` instead of `FAILING`
- [ ] A PR with a failing CI check still reports `FAILING`
- [ ] A PR with merge conflicts still reports `FAILING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)