### PR TITLE
ci(release): use RELEASE_TOKEN to bypass branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@v6
         with:
@@ -66,7 +67,7 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh release create "v${{ steps.bump.outputs.version }}" \
             --title "v${{ steps.bump.outputs.version }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
           - prerelease
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 concurrency:
@@ -29,6 +29,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Check RELEASE_TOKEN is set
+        run: |
+          if [ -z "${{ secrets.RELEASE_TOKEN }}" ]; then
+            echo "::error::RELEASE_TOKEN secret is not set. This workflow requires a PAT whose owner is in the main branch ruleset bypass list." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- The `main` ruleset requires PRs + status checks, and `github-actions[bot]` isn't a selectable bypass actor, so `git push origin HEAD:main` in the release workflow was rejected (see [run 24711414351](https://github.com/jonathanong/pr-shepherd/actions/runs/24711414351/job/72276762810)).
- Use a PAT stored as `RELEASE_TOKEN` (whose owner is in the ruleset bypass list) for the checkout push and `gh release create` so the release job can push the version-bump commit + tag to `main`.

## Test plan
- [ ] Add **Repository admin** to the `main` ruleset bypass list (if not already done)
- [ ] Confirm `RELEASE_TOKEN` secret is populated with a PAT that has `Contents: read/write` on this repo
- [ ] After merge, run the `Release` workflow manually and confirm the push + tag + npm publish + GitHub release all succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)