### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ On each tick (4-minute default, tunable via `watch.interval`): fetch PR state in
 ## CLI
 
 ```sh
+pr-shepherd --version                                 # print installed version
 pr-shepherd check [PR]                                # read-only PR status snapshot
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids …]
 pr-shepherd iterate [PR] [--cooldown-seconds N] [--ready-delay Nm] [--last-push-time N]

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ On each tick (4-minute default, tunable via `watch.interval`): fetch PR state in
 ## CLI
 
 ```sh
-pr-shepherd --version                                 # print installed version
+pr-shepherd -v|--version                              # print installed version
 pr-shepherd check [PR]                                # read-only PR status snapshot
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids …]
 pr-shepherd iterate [PR] [--cooldown-seconds N] [--ready-delay Nm] [--last-push-time N]

--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -565,3 +565,23 @@ describe("main — unknown subcommand", () => {
     expect(process.exitCode).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// --version / -v
+// ---------------------------------------------------------------------------
+
+describe("main — --version", () => {
+  it("prints the package.json version and exits cleanly for --version", async () => {
+    await main(["node", "shepherd", "--version"]);
+    const out = getStdout().trim();
+    expect(out).toMatch(/^\d+\.\d+\.\d+/);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("also accepts -v", async () => {
+    await main(["node", "shepherd", "-v"]);
+    const out = getStdout().trim();
+    expect(out).toMatch(/^\d+\.\d+\.\d+/);
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
@@ -571,17 +573,21 @@ describe("main — unknown subcommand", () => {
 // ---------------------------------------------------------------------------
 
 describe("main — --version", () => {
-  it("prints the package.json version and exits cleanly for --version", async () => {
+  const pkgVersion = (
+    JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+      version: string;
+    }
+  ).version;
+
+  it("prints the exact package.json version followed by a newline for --version", async () => {
     await main(["node", "shepherd", "--version"]);
-    const out = getStdout().trim();
-    expect(out).toMatch(/^\d+\.\d+\.\d+/);
+    expect(getStdout()).toBe(`${pkgVersion}\n`);
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("also accepts -v", async () => {
+  it("also accepts -v with identical output", async () => {
     await main(["node", "shepherd", "-v"]);
-    const out = getStdout().trim();
-    expect(out).toMatch(/^\d+\.\d+\.\d+/);
+    expect(getStdout()).toBe(`${pkgVersion}\n`);
     expect(process.exitCode).toBeUndefined();
   });
 });

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -2,6 +2,7 @@
  * CLI argument parsing and subcommand dispatch for pr-shepherd.
  *
  * Usage:
+ *   pr-shepherd --version
  *   pr-shepherd check [PR] [--format text|json] [--no-cache] [--cache-ttl N]
  *   pr-shepherd resolve [PR] [--fetch] [--resolve-thread-ids A,B] [--minimize-comment-ids X,Y]
  *                            [--dismiss-review-ids Q] [--message MSG] [--require-sha SHA]
@@ -9,6 +10,8 @@
  *   pr-shepherd iterate [PR] [--format text|json] [--cooldown-seconds N] [--ready-delay Nm] [--last-push-time N]
  *   pr-shepherd status PR1 [PR2 …]
  */
+
+import { readFileSync } from "node:fs";
 
 import { runCheck } from "./commands/check.mts";
 import { runResolveFetch, runResolveMutate } from "./commands/resolve.mts";
@@ -40,6 +43,11 @@ export async function main(argv: string[]): Promise<void> {
 
   const subcommand = args[0];
 
+  if (subcommand === "--version" || subcommand === "-v") {
+    process.stdout.write(`${readVersion()}\n`);
+    return;
+  }
+
   switch (subcommand) {
     case "check":
       await handleCheck(args.slice(1));
@@ -59,6 +67,12 @@ export async function main(argv: string[]): Promise<void> {
       process.exitCode = 1;
       return;
   }
+}
+
+function readVersion(): string {
+  const pkgUrl = new URL("../package.json", import.meta.url);
+  const pkg = JSON.parse(readFileSync(pkgUrl, "utf8")) as { version: string };
+  return pkg.version;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -63,7 +63,10 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       process.stderr.write(`Unknown subcommand: ${subcommand ?? "(none)"}\n`);
-      process.stderr.write("Usage: pr-shepherd <check|resolve|iterate|status> [options]\n");
+      process.stderr.write(
+        "Usage: pr-shepherd <check|resolve|iterate|status> [options]\n" +
+          "       pr-shepherd --version | -v\n",
+      );
       process.exitCode = 1;
       return;
   }


### PR DESCRIPTION
## Summary
- Add `--version` / `-v` to `pr-shepherd`, reading the version from `package.json` at runtime.
- Version lookup uses `new URL("../package.json", import.meta.url)` so it works in both the source (`src/`) and built (`bin/`) layouts without needing a build-time constant.
- README usage block updated; unit tests cover both flag spellings.

## Test plan
- [x] `npm test` — 438 passing
- [x] `npm run typecheck` — clean
- [x] `npm run build && node bin/index.mjs --version` prints `0.7.0`
- [x] `node bin/index.mjs -v` prints `0.7.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)