### PR TITLE
docs(CLAUDE): require docs/ and README updates with every change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,7 @@ The `bin/` directory is gitignored and must be built before `npx pr-shepherd` wo
 During development, run the CLI from this repository root with `npx pr-shepherd` (after `npm install && npm run build`).
 This ensures you are using the built local CLI from this checkout rather than any globally installed version.
 Use it from the same worktree/repository so it picks up the skills and configuration checked into this local checkout.
+
+## Documentation
+
+When making changes, always update [`docs/`](docs/) and [`README.md`](README.md) to reflect the new behavior. Docs and README are part of the change, not a follow-up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,4 +22,4 @@ Use it from the same worktree/repository so it picks up the skills and configura
 
 ## Documentation
 
-When making changes, always update [`docs/`](docs/) and [`README.md`](README.md) to reflect the new behavior. Docs and README are part of the change, not a follow-up.
+When making changes, review [`docs/`](docs/) and [`README.md`](README.md) for impact. Update them when the change affects user-facing behavior, commands, configuration, or workflows so the documentation stays in sync as part of the same change, not as a follow-up. If no documentation updates are needed, it is OK to leave them unchanged (optionally noting `docs: n/a`).


### PR DESCRIPTION
## Summary
- Add a Documentation section to `CLAUDE.md` instructing that any change must also update `docs/` and `README.md` in the same PR, not as a follow-up.

## Test plan
- [ ] Review wording of the new CLAUDE.md section

🤖 Generated with [Claude Code](https://claude.com/claude-code)