### PR TITLE
chore: disable Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
## Summary

- Adds `codecov.yml` at the repo root with `comment: false` to suppress the Codecov bot's per-PR coverage-summary comment.
- Coverage and test-results uploads via `.github/workflows/ci.yml` are unchanged — this only disables the PR comment.

Closes #69

## Test plan

- [ ] CI green on this PR
- [ ] Verify on the next PR after merge that Codecov no longer posts a coverage comment
- [ ] Verify the Codecov dashboard still receives coverage/test-results uploads (run visible at app.codecov.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)