### PR TITLE
fix(commit-suggestions): reject nested-fence suggestion bodies (issue #68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Agent-side equivalent of GitHub's "Commit suggestion" and "Add suggestion to bat
 pr-shepherd commit-suggestions 42 --thread-ids PRRT_abc,PRRT_def --format=json
 ```
 
-Requires a clean working tree (errors out if `git status --porcelain` is non-empty). After a successful run, **your local checkout is one commit behind remote** — the output's `postActionInstruction` tells the agent to `git pull --ff-only` before editing anything else. Threads whose body lacks a parseable suggestion, that are already resolved or outdated, or whose line range overlaps another applied suggestion on the same file are reported as `skipped` so callers can fall back to a manual fix.
+Requires a clean working tree (errors out if `git status --porcelain` is non-empty). After a successful run, **your local checkout is one commit behind remote** — the output's `postActionInstruction` tells the agent to `git pull --ff-only` before editing anything else. Threads whose body lacks a parseable suggestion, that are already resolved or outdated, whose body contains a nested ` ```suggestion ` fence (would silently truncate — see issue #68), or whose line range overlaps another applied suggestion on the same file are reported as `skipped` so callers can fall back to a manual fix.
 
 Gated by `actions.commitSuggestions` (default `true`) — `/pr-shepherd:resolve` invokes this automatically for threads that `resolve --fetch` annotates with a `suggestion` field.
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Agent-side equivalent of GitHub's "Commit suggestion" and "Add suggestion to bat
 pr-shepherd commit-suggestions 42 --thread-ids PRRT_abc,PRRT_def --format=json
 ```
 
-Requires a clean working tree (errors out if `git status --porcelain` is non-empty). After a successful run, **your local checkout is one commit behind remote** — the output's `postActionInstruction` tells the agent to `git pull --ff-only` before editing anything else. Threads whose body lacks a parseable suggestion, that are already resolved or outdated, whose body contains a nested ` ```suggestion ` fence (would silently truncate — see issue #68), or whose line range overlaps another applied suggestion on the same file are reported as `skipped` so callers can fall back to a manual fix.
+Requires a clean working tree (errors out if `git status --porcelain` is non-empty). After a successful run, **your local checkout is one commit behind remote** — the output's `postActionInstruction` tells the agent to `git pull --ff-only` before editing anything else. Threads whose body lacks a parseable suggestion, that are already resolved or outdated, whose body contains a nested ` ```suggestion ` fence (would silently truncate — see issue #68), whose replacement text contains an odd number of 3+-backtick runs, or whose line range overlaps another applied suggestion on the same file are reported as `skipped` so callers can fall back to a manual fix.
 
 Gated by `actions.commitSuggestions` (default `true`) — `/pr-shepherd:resolve` invokes this automatically for threads that `resolve --fetch` annotates with a `suggestion` field.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,7 +49,7 @@ Agent-side equivalent of GitHub's "Commit suggestion" and "Add suggestion to bat
 pr-shepherd commit-suggestions 42 --thread-ids PRRT_abc,PRRT_def --format=json
 ```
 
-Requires a clean working tree (the command errors out early if `git status --porcelain` is non-empty). After a successful run **the local checkout is one commit behind remote** — run `git pull --ff-only` before any further local edits. Threads without a parseable suggestion, threads already resolved, suggestions whose body contains a nested ` ```suggestion ` fence, or suggestions whose range overlaps another on the same file are reported as `skipped` so the caller can fall back to a manual fix.
+Requires a clean working tree (the command errors out early if `git status --porcelain` is non-empty). After a successful run **the local checkout is one commit behind remote** — run `git pull --ff-only` before any further local edits. Threads without a parseable suggestion, threads already resolved, suggestions whose body contains a nested ` ```suggestion ` fence, suggestions whose replacement contains an unmatched fenced code block (an odd number of 3+ backtick runs), or suggestions whose range overlaps another on the same file are reported as `skipped` so the caller can fall back to a manual fix.
 
 The resolve skill surfaces this command automatically for threads that carry a `suggestion` block when `actions.commitSuggestions` is `true` (the default — see [configuration.md](configuration.md)).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,7 +49,7 @@ Agent-side equivalent of GitHub's "Commit suggestion" and "Add suggestion to bat
 pr-shepherd commit-suggestions 42 --thread-ids PRRT_abc,PRRT_def --format=json
 ```
 
-Requires a clean working tree (the command errors out early if `git status --porcelain` is non-empty). After a successful run **the local checkout is one commit behind remote** — run `git pull --ff-only` before any further local edits. Threads without a parseable suggestion, threads already resolved, or suggestions whose range overlaps another on the same file are reported as `skipped` so the caller can fall back to a manual fix.
+Requires a clean working tree (the command errors out early if `git status --porcelain` is non-empty). After a successful run **the local checkout is one commit behind remote** — run `git pull --ff-only` before any further local edits. Threads without a parseable suggestion, threads already resolved, suggestions whose body contains a nested ` ```suggestion ` fence, or suggestions whose range overlaps another on the same file are reported as `skipped` so the caller can fall back to a manual fix.
 
 The resolve skill surfaces this command automatically for threads that carry a `suggestion` block when `actions.commitSuggestions` is `true` (the default — see [configuration.md](configuration.md)).
 

--- a/src/commands/commit-suggestions.mock.test.mts
+++ b/src/commands/commit-suggestions.mock.test.mts
@@ -215,7 +215,27 @@ describe("runCommitSuggestions — skipped cases", () => {
     expect(result.applied).toBe(false);
     expect(result.threads[0]).toMatchObject({
       status: "skipped",
-      reason: /nested fence/,
+      reason: /nested suggestion fencing/,
+    });
+    expect(mockGraphql).not.toHaveBeenCalled();
+  });
+
+  it("skips threads whose suggestion body has an unbalanced ``` run (issue #68)", async () => {
+    // Replacement text "foo ``` bar" has one ``` run (odd count) — the guard fires
+    // even though the body contains no nested ```suggestion marker.
+    const oddBacktickBody = ["```suggestion", "foo ``` bar", "```"].join("\n");
+    mockFetchBatch.mockResolvedValue({
+      data: makeBatch([makeThread({ id: "t1", body: oddBacktickBody })]),
+    });
+    const result = await runCommitSuggestions({
+      ...GLOBAL_OPTS,
+      prNumber: 42,
+      threadIds: ["t1"],
+    });
+    expect(result.applied).toBe(false);
+    expect(result.threads[0]).toMatchObject({
+      status: "skipped",
+      reason: /unbalanced 3\+ backtick fences/,
     });
     expect(mockGraphql).not.toHaveBeenCalled();
   });

--- a/src/commands/commit-suggestions.mock.test.mts
+++ b/src/commands/commit-suggestions.mock.test.mts
@@ -203,11 +203,7 @@ describe("runCommitSuggestions — skipped cases", () => {
   });
 
   it("skips threads whose suggestion body contains a nested fence (issue #68)", async () => {
-    const nestedFenceBody = [
-      "```suggestion",
-      "text with ```suggestion inside",
-      "```",
-    ].join("\n");
+    const nestedFenceBody = ["```suggestion", "text with ```suggestion inside", "```"].join("\n");
     mockFetchBatch.mockResolvedValue({
       data: makeBatch([makeThread({ id: "t1", body: nestedFenceBody })]),
     });

--- a/src/commands/commit-suggestions.mock.test.mts
+++ b/src/commands/commit-suggestions.mock.test.mts
@@ -202,6 +202,28 @@ describe("runCommitSuggestions — skipped cases", () => {
     expect(mockGraphql).not.toHaveBeenCalled();
   });
 
+  it("skips threads whose suggestion body contains a nested fence (issue #68)", async () => {
+    const nestedFenceBody = [
+      "```suggestion",
+      "text with ```suggestion inside",
+      "```",
+    ].join("\n");
+    mockFetchBatch.mockResolvedValue({
+      data: makeBatch([makeThread({ id: "t1", body: nestedFenceBody })]),
+    });
+    const result = await runCommitSuggestions({
+      ...GLOBAL_OPTS,
+      prNumber: 42,
+      threadIds: ["t1"],
+    });
+    expect(result.applied).toBe(false);
+    expect(result.threads[0]).toMatchObject({
+      status: "skipped",
+      reason: /nested fence/,
+    });
+    expect(mockGraphql).not.toHaveBeenCalled();
+  });
+
   it("skips threads without a parseable suggestion block", async () => {
     mockFetchBatch.mockResolvedValue({
       data: makeBatch([makeThread({ id: "t1", body: "just a plain comment, no suggestion" })]),

--- a/src/commands/commit-suggestions.mts
+++ b/src/commands/commit-suggestions.mts
@@ -132,7 +132,7 @@ export async function runCommitSuggestions(
         id,
         status: "skipped",
         reason:
-          "suggestion body contains a nested fence — refusing to apply (would silently truncate)",
+          "suggestion body contains nested suggestion fencing or unbalanced 3+ backtick fences — refusing to apply (could silently truncate)",
       });
       continue;
     }

--- a/src/commands/commit-suggestions.mts
+++ b/src/commands/commit-suggestions.mts
@@ -30,7 +30,11 @@ import {
 import { fetchPrBatch } from "../github/batch.mts";
 import { applyResolveOptions } from "../comments/resolve.mts";
 import { CREATE_COMMIT_ON_BRANCH_MUTATION } from "../github/queries.mts";
-import { parseSuggestion, applySuggestionToFile } from "../suggestions/parse.mts";
+import {
+  parseSuggestion,
+  applySuggestionToFile,
+  isCommittableSuggestion,
+} from "../suggestions/parse.mts";
 import type {
   CommitSuggestionsResult,
   CommitSuggestionThreadResult,
@@ -121,6 +125,15 @@ export async function runCommitSuggestions(
     const parsed = parseSuggestion(thread.body);
     if (!parsed) {
       perThread.push({ id, status: "skipped", reason: "no suggestion block in comment body" });
+      continue;
+    }
+    if (!isCommittableSuggestion(parsed)) {
+      perThread.push({
+        id,
+        status: "skipped",
+        reason:
+          "suggestion body contains a nested fence — refusing to apply (would silently truncate)",
+      });
       continue;
     }
     applicable.push({

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -2462,11 +2462,7 @@ describe("runIterate — fix_code commit-suggestions shortcut", () => {
   });
 
   it("falls back to mode: rebase-and-push when a thread has a non-committable suggestion (nested fence, issue #68)", async () => {
-    const nestedFenceBody = [
-      "```suggestion",
-      "text with ```suggestion inside",
-      "```",
-    ].join("\n");
+    const nestedFenceBody = ["```suggestion", "text with ```suggestion inside", "```"].join("\n");
     const t1 = makeSuggestionThread("PRRT_x", nestedFenceBody);
     mockRunCheck.mockResolvedValue(
       makeReport({

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -2461,6 +2461,32 @@ describe("runIterate — fix_code commit-suggestions shortcut", () => {
     expect(result.fix.mode).toBe("rebase-and-push");
   });
 
+  it("falls back to mode: rebase-and-push when a thread has a non-committable suggestion (nested fence, issue #68)", async () => {
+    const nestedFenceBody = [
+      "```suggestion",
+      "text with ```suggestion inside",
+      "```",
+    ].join("\n");
+    const t1 = makeSuggestionThread("PRRT_x", nestedFenceBody);
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        status: "UNRESOLVED_COMMENTS",
+        threads: { actionable: [t1], autoResolved: [], autoResolveErrors: [] },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(result.action).toBe("fix_code");
+    if (result.action !== "fix_code") return;
+    expect(result.fix.mode).toBe("rebase-and-push");
+  });
+
   it("falls back to mode: rebase-and-push when an actionable comment is also present", async () => {
     const t1 = makeSuggestionThread("PRRT_x");
     const comment = {

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -32,7 +32,7 @@ import { rest, graphql } from "../github/http.mts";
 import { MARK_PR_READY_MUTATION } from "../github/queries.mts";
 import { readFixAttempts, writeFixAttempts } from "../cache/fix-attempts.mts";
 import { toAgentThread, toAgentComment, toAgentChecks } from "../reporters/agent.mts";
-import { parseSuggestion } from "../suggestions/parse.mts";
+import { parseSuggestion, isCommittableSuggestion } from "../suggestions/parse.mts";
 import type {
   AgentComment,
   AgentThread,
@@ -247,7 +247,10 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     // of the gate because there is no minimize-only mutation in this shortcut.
     const allThreadsHaveSuggestions =
       threads.length > 0 &&
-      report.threads.actionable.every((t) => parseSuggestion(t.body) !== null);
+      report.threads.actionable.every((t) => {
+        const p = parseSuggestion(t.body);
+        return p !== null && isCommittableSuggestion(p);
+      });
     const canShortcut =
       config.actions.commitSuggestions &&
       !opts.noCommitSuggestions &&

--- a/src/suggestions/parse.mts
+++ b/src/suggestions/parse.mts
@@ -10,15 +10,6 @@
  * button (this one included) must parse + commit themselves.
  */
 
-// Capture the opening prefix (indent / `>` quote markers) so the same prefix
-// can be required before the closing fence via a backreference. Lazy on the
-// prefix so same-line-indent blocks outside a quote aren't swallowed.
-// Lazy body with no mandatory newline before the closing fence — this lets
-// empty blocks (deletion) match and preserves the body's own trailing \n so
-// the caller can distinguish "delete these lines" from "replace with a blank
-// line" (raw="" vs raw="\n").
-const SUGGESTION_BLOCK = /(^|\n)([ \t>]*?)```suggestion[^\n]*\n([\s\S]*?)\2```/;
-
 export interface ParsedSuggestion {
   /**
    * Replacement lines to splice in. Empty array means "delete these lines".
@@ -35,8 +26,13 @@ export interface ParsedSuggestion {
  * Handles three distinct cases:
  *   - Empty block (` ```suggestion\n``` `) → `lines: []` (deletion).
  *   - Blank-line-only body (` ```suggestion\n\n``` `) → `lines: [""]`.
- *   - Non-empty body → split into lines, dropping the single trailing `\n`
- *     that acts as a line terminator rather than an extra blank line.
+ *   - Non-empty body → split into lines.
+ *
+ * The opening fence may be 3+ backticks; the closing fence must be at least
+ * as many backticks, at the start of a line (after the captured prefix). This
+ * means content lines that contain ` ``` ` in the middle (not at line-start)
+ * are treated as content rather than a closing fence — fixing the silent
+ * truncation in the original regex approach (issue #68).
  *
  * When the block is embedded in a quoted reply (e.g. `> ```suggestion …`),
  * the leading prefix captured from the opening fence is stripped from each
@@ -44,28 +40,70 @@ export interface ParsedSuggestion {
  * characters inside the suggested code survive.
  */
 export function parseSuggestion(body: string): ParsedSuggestion | null {
-  const match = SUGGESTION_BLOCK.exec(body);
-  if (!match) return null;
-  const prefix = match[2] ?? "";
-  const raw = match[3] ?? "";
+  const lines = body.split("\n");
 
-  // Raw truly empty → the block had no body at all, which GitHub treats as
-  // "delete the commented lines".
-  if (raw === "") return { lines: [] };
+  // Find the opening fence: optional prefix + N backticks (N≥3) + "suggestion" + anything.
+  let openIdx = -1;
+  let prefix = "";
+  let fenceLen = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^([ \t>]*?)(`{3,})suggestion[^\n]*$/.exec(lines[i]!);
+    if (m) {
+      openIdx = i;
+      prefix = m[1]!;
+      fenceLen = m[2]!.length;
+      break;
+    }
+  }
+  if (openIdx === -1) return null;
 
-  const unindented =
+  // Find the closing fence: same prefix + N+ backticks at the start of a line.
+  const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const closeRegex = new RegExp(`^${escapedPrefix}\`{${fenceLen},}[ \\t]*$`);
+  let closeIdx = -1;
+  for (let i = openIdx + 1; i < lines.length; i++) {
+    if (closeRegex.test(lines[i]!)) {
+      closeIdx = i;
+      break;
+    }
+  }
+
+  let bodyLines: string[];
+  if (closeIdx !== -1) {
+    bodyLines = lines.slice(openIdx + 1, closeIdx);
+  } else if (prefix === "" && lines.length > openIdx + 1) {
+    // Inline-close fallback: last line ends with N+ backticks (no trailing newline).
+    // Preserves the historical behaviour for bodies like "```suggestion\nfoo```".
+    // Only supported for non-quoted (prefix="") blocks.
+    const last = lines[lines.length - 1]!;
+    const m = new RegExp(`^(.*?)\`{${fenceLen},}$`).exec(last);
+    if (!m) return null;
+    bodyLines = [...lines.slice(openIdx + 1, lines.length - 1), m[1]!];
+  } else {
+    return null;
+  }
+
+  if (bodyLines.length === 0) return { lines: [] };
+
+  const cleaned =
     prefix === ""
-      ? raw
-      : raw
-          .split("\n")
-          .map((line) => (line.startsWith(prefix) ? line.slice(prefix.length) : line))
-          .join("\n");
+      ? bodyLines
+      : bodyLines.map((l) => (l.startsWith(prefix) ? l.slice(prefix.length) : l));
+  return { lines: cleaned };
+}
 
-  // Strip exactly one trailing \n — it's the line terminator of the last body
-  // line, not an extra blank line. An explicit trailing blank is represented
-  // by two trailing \ns, which leave one behind after this strip.
-  const stripped = unindented.endsWith("\n") ? unindented.slice(0, -1) : unindented;
-  return { lines: stripped.split("\n") };
+/**
+ * True when a parsed suggestion's replacement is safe to commit: the joined
+ * replacement contains no nested ` ```suggestion ` marker and no unmatched
+ * ` ``` ` run (odd count). Both shapes previously masked silent truncation
+ * (issue #68). Conservative by design: reviewers whose suggestion content
+ * legitimately includes these markers must apply the change manually.
+ */
+export function isCommittableSuggestion(parsed: ParsedSuggestion): boolean {
+  const replacement = parsed.lines.join("\n");
+  if (replacement.includes("```suggestion")) return false;
+  const fenceRuns = (replacement.match(/`{3,}/g) ?? []).length;
+  return fenceRuns % 2 === 0;
 }
 
 /**

--- a/src/suggestions/parse.test.mts
+++ b/src/suggestions/parse.test.mts
@@ -88,6 +88,12 @@ describe("parseSuggestion", () => {
     const body = ["````suggestion", "body with ``` in it", "````"].join("\n");
     expect(parseSuggestion(body)).toEqual({ lines: ["body with ``` in it"] });
   });
+
+  it("returns null for a quoted suggestion block with no closing fence", () => {
+    // prefix is non-empty but closeIdx is never found → else { return null }
+    const body = ["> ```suggestion", "> const x = 1;"].join("\n");
+    expect(parseSuggestion(body)).toBeNull();
+  });
 });
 
 describe("isCommittableSuggestion", () => {

--- a/src/suggestions/parse.test.mts
+++ b/src/suggestions/parse.test.mts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseSuggestion, applySuggestionToFile } from "./parse.mts";
+import { parseSuggestion, applySuggestionToFile, isCommittableSuggestion } from "./parse.mts";
 
 describe("parseSuggestion", () => {
   it("extracts a single-line suggestion", () => {
@@ -87,6 +87,28 @@ describe("parseSuggestion", () => {
   it("supports a 4-backtick outer fence to wrap content containing ```", () => {
     const body = ["````suggestion", "body with ``` in it", "````"].join("\n");
     expect(parseSuggestion(body)).toEqual({ lines: ["body with ``` in it"] });
+  });
+});
+
+describe("isCommittableSuggestion", () => {
+  it("returns true for a clean suggestion", () => {
+    expect(isCommittableSuggestion({ lines: ["const x = 1;"] })).toBe(true);
+  });
+
+  it("returns true for an empty suggestion (deletion)", () => {
+    expect(isCommittableSuggestion({ lines: [] })).toBe(true);
+  });
+
+  it("returns false when replacement contains a nested ```suggestion marker", () => {
+    expect(isCommittableSuggestion({ lines: ["text with ```suggestion inside"] })).toBe(false);
+  });
+
+  it("returns false when replacement has an odd number of ``` runs (unmatched fence)", () => {
+    expect(isCommittableSuggestion({ lines: ["here is a fence: ```", "no close"] })).toBe(false);
+  });
+
+  it("returns true when replacement contains a balanced pair of ``` runs", () => {
+    expect(isCommittableSuggestion({ lines: ["```js", "code", "```"] })).toBe(true);
   });
 });
 

--- a/src/suggestions/parse.test.mts
+++ b/src/suggestions/parse.test.mts
@@ -65,10 +65,28 @@ describe("parseSuggestion", () => {
   });
 
   it("tolerates a body without a trailing newline before the closing fence", () => {
-    // GitHub renders suggestions when the closing fence is inline — the regex
-    // accepts this and the body is taken verbatim (no trailing \n to strip).
+    // Inline close: the parser's fallback path for bodies like "```suggestion\nfoo```".
     const body = "```suggestion\nfoo```";
     expect(parseSuggestion(body)).toEqual({ lines: ["foo"] });
+  });
+
+  it("preserves a nested ```suggestion substring in the body content (issue #68)", () => {
+    // The old regex stopped at the inner ``` and silently truncated the body.
+    // The new line-based parser treats mid-line ``` as content, not a closer.
+    const body = ["```suggestion", "text with ```suggestion inside", "```"].join("\n");
+    expect(parseSuggestion(body)).toEqual({ lines: ["text with ```suggestion inside"] });
+  });
+
+  it("preserves a stray ``` run mid-line in the body content (issue #68)", () => {
+    const body = ["```suggestion", "here is a fence: ```", "and more text", "```"].join("\n");
+    expect(parseSuggestion(body)).toEqual({
+      lines: ["here is a fence: ```", "and more text"],
+    });
+  });
+
+  it("supports a 4-backtick outer fence to wrap content containing ```", () => {
+    const body = ["````suggestion", "body with ``` in it", "````"].join("\n");
+    expect(parseSuggestion(body)).toEqual({ lines: ["body with ``` in it"] });
   });
 });
 


### PR DESCRIPTION
## Summary

- **Parser rewrite**: Replace the `SUGGESTION_BLOCK` regex in `parse.mts` with a line-by-line scanner that requires the closing fence at the *start* of a line. Mid-line ` ``` ` runs are now content, not closers. Reviewers can also use 4+ backtick outer fences to wrap suggestions that contain triple-backtick content.
- **CLI guard**: New `isCommittableSuggestion` export checks the parsed replacement for a nested ` ```suggestion ` marker or an odd count of ` ``` ` runs — skips with an explicit reason rather than committing truncated text.
- **Iterate gate mirror**: `iterate.mts`'s `commit-suggestions` shortcut gate now requires `isCommittableSuggestion`, so a nested-fence thread falls through to the rebase-and-push path instead of looping the monitor with zero-application runs indefinitely.

Fixes #68.

## Test plan

- [x] 3 new `parseSuggestion` tests asserting the corrected (non-truncating) behavior for nested ` ```suggestion `, stray ` ``` ` mid-line, and 4-backtick outer fence
- [x] 1 new `runCommitSuggestions` mock test asserting `status: "skipped"` + `/nested fence/` reason + no GraphQL mutation for a nested-fence thread
- [x] All 513 existing tests continue to pass (`npm test`)
- [x] Docs updated in `docs/usage.md` and `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)