### PR TITLE
fix(iterate): auto-minimize review summaries in monitor loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,9 @@ All supported keys:
 | `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                   |
 | `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                  |
 | `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                             |
-| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors (Copilot, Gemini, `*[bot]`)                |
-| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors (surfaced instead when `false`)          |
-| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Auto-minimize APPROVED-state reviews (off by default — approvals usually stay visible)               |
+| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`       |
+| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                   |
+| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                     |
 | `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                     |
 | `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                            |
 | `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                   |

--- a/README.md
+++ b/README.md
@@ -406,29 +406,32 @@ actions:
 
 All supported keys:
 
-| Key                                  | Default                                   | Purpose                                                                                              |
-| ------------------------------------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `cache.ttlSeconds`                   | `300`                                     | File-cache TTL for read operations                                                                   |
-| `iterate.cooldownSeconds`            | `30`                                      | Wait after a push before reading CI                                                                  |
-| `iterate.fixAttemptsPerThread`       | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                             |
-| `watch.interval`                     | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                     |
-| `watch.readyDelayMinutes`            | `10`                                      | Settle window after READY before the monitor loop cancels                                            |
-| `watch.expiresHours`                 | `8`                                       | Max lifetime of a monitor cron job                                                                   |
-| `watch.maxTurns`                     | `50`                                      | Max monitor ticks per session                                                                        |
-| `resolve.concurrency`                | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                       |
-| `resolve.shaPoll.intervalMs`         | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                     |
-| `resolve.shaPoll.maxAttempts`        | `10`                                      | Max `--require-sha` polls before giving up                                                           |
-| `resolve.fetchReviewSummaries`       | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                     |
-| `checks.ciTriggerEvents`             | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                     |
-| `checks.timeoutPatterns`             | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `timeout`                                                    |
-| `checks.infraPatterns`               | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `infrastructure`                                             |
-| `checks.logMaxLines`                 | `50`                                      | Max log lines kept per failing check                                                                 |
-| `checks.logMaxChars`                 | `3000`                                    | Max log characters kept per failing check                                                            |
-| `mergeStatus.blockingReviewerLogins` | `["copilot"]`                             | Reviewer logins whose pending review blocks `mark_ready`                                             |
-| `actions.autoResolveOutdated`        | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                     |
-| `actions.autoRebase`                 | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                      |
-| `actions.autoMarkReady`              | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                    |
-| `actions.commitSuggestions`          | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestions` for threads with a ` ```suggestion ` block |
+| Key                                         | Default                                   | Purpose                                                                                              |
+| ------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                   |
+| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                  |
+| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                             |
+| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors (Copilot, Gemini, `*[bot]`)                |
+| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors (surfaced instead when `false`)          |
+| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Auto-minimize APPROVED-state reviews (off by default — approvals usually stay visible)               |
+| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                     |
+| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                            |
+| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                   |
+| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                        |
+| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                       |
+| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                     |
+| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                           |
+| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                     |
+| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                     |
+| `checks.timeoutPatterns`                    | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `timeout`                                                    |
+| `checks.infraPatterns`                      | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `infrastructure`                                             |
+| `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                 |
+| `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                            |
+| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review blocks `mark_ready`                                             |
+| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                     |
+| `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                      |
+| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                    |
+| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestions` for threads with a ` ```suggestion ` block |
 
 Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_CACHE_DIR` (override cache base dir), `PR_SHEPHERD_CACHE_TTL_SECONDS` (override cache TTL; `--cache-ttl` takes precedence over this env var, which in turn takes precedence over the RC/config value).
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -314,7 +314,7 @@ The JSON payload for this variant carries `fix.mode === "commit-suggestions"` pl
 5. `## Changes-requested reviews` — one bullet per `CHANGES_REQUESTED` review: ``- `<reviewId>` (@<author>)``.
 6. `## Noise (minimize only)` — backticked IDs of bot-noise comments (quota warnings, rate-limit acks). Minimize on GitHub but do not act on them.
 7. `## Review summaries (minimize only)` — backticked review IDs (`PRR_…`) of `COMMENTED` review summaries (and, if `iterate.minimizeReviewSummaries.approvals` is `true`, `APPROVED` reviews) that will be minimized by the resolve command. Gated by `iterate.minimizeReviewSummaries.{bots, humans, approvals}`. Not emitted if the list is empty.
-8. `## Review summaries (surfaced — not minimized)` — only emitted when `iterate.minimizeReviewSummaries.humans` is `false` and a human-authored summary exists. Same H3-plus-blockquote shape as `## Review threads`; surfaced for human visibility, but NOT included in `--minimize-comment-ids`.
+8. `## Review summaries (surfaced — not minimized)` — emitted when a summary falls through to the "surface" bucket (the author's toggle — `bots` or `humans` — is `false`). Same H3-plus-blockquote shape as `## Review threads`; surfaced for visibility, but NOT included in `--minimize-comment-ids`.
 9. `## Cancelled runs` — backticked IDs, emitted only when CLI-side `gh run cancel` succeeded for at least one run.
 10. `## Post-fix push`:
     - ``- base: `<branch>` `` — rebase target for the push step.
@@ -331,7 +331,7 @@ The JSON payload for this variant carries `fix.mode === "commit-suggestions"` pl
 - The `resolve:` instruction is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A `CONFLICTS`-only dispatch omits it.
 - The commit-suggestions variant always emits exactly two instructions: run the `commit-suggestions:` command, then `git pull --ff-only`.
 
-The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, reviewSummaryIds, surfacedHumanSummaries, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled` for the rebase-and-push variant; the commit-suggestions variant carries `fix.{mode, threads, commitSuggestionsCommand, instructions}` plus `cancelled: []`. `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `surfacedHumanSummaries` are informational only.
+The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, reviewSummaryIds, surfacedSummaries, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled` for the rebase-and-push variant; the commit-suggestions variant carries `fix.{mode, threads, commitSuggestionsCommand, instructions}` plus `cancelled: []`. `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `surfacedSummaries` are informational only.
 
 **Flags:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -313,11 +313,13 @@ The JSON payload for this variant carries `fix.mode === "commit-suggestions"` pl
 
 5. `## Changes-requested reviews` — one bullet per `CHANGES_REQUESTED` review: ``- `<reviewId>` (@<author>)``.
 6. `## Noise (minimize only)` — backticked IDs of bot-noise comments (quota warnings, rate-limit acks). Minimize on GitHub but do not act on them.
-7. `## Cancelled runs` — backticked IDs, emitted only when CLI-side `gh run cancel` succeeded for at least one run.
-8. `## Post-fix push`:
-   - ``- base: `<branch>` `` — rebase target for the push step.
-   - ``- resolve: `<argv>` `` — fully-quoted resolve command. `$DISMISS_MESSAGE` and `$HEAD_SHA` are always quoted so substituting a multi-word sentence keeps it as one argument. `--require-sha "$HEAD_SHA"` is appended only when a push is expected (threads/actionableComments/checks/reviews present); noise-only dispatches omit it.
-9. `## Instructions` — numbered list to execute in order. The final instruction always refers back to the `resolve:` bullet rather than duplicating the command — that single source of truth is what the monitor executes.
+7. `## Review summaries (minimize only)` — backticked review IDs (`PRR_…`) of `COMMENTED` review summaries (and, if `iterate.minimizeReviewSummaries.approvals` is `true`, `APPROVED` reviews) that will be minimized by the resolve command. Gated by `iterate.minimizeReviewSummaries.{bots, humans, approvals}`. Not emitted if the list is empty.
+8. `## Review summaries (surfaced — not minimized)` — only emitted when `iterate.minimizeReviewSummaries.humans` is `false` and a human-authored summary exists. Same H3-plus-blockquote shape as `## Review threads`; surfaced for human visibility, but NOT included in `--minimize-comment-ids`.
+9. `## Cancelled runs` — backticked IDs, emitted only when CLI-side `gh run cancel` succeeded for at least one run.
+10. `## Post-fix push`:
+    - ``- base: `<branch>` `` — rebase target for the push step.
+    - ``- resolve: `<argv>` `` — fully-quoted resolve command. `$DISMISS_MESSAGE` and `$HEAD_SHA` are always quoted so substituting a multi-word sentence keeps it as one argument. `--require-sha "$HEAD_SHA"` is appended only when a push is expected (threads/actionableComments/checks/reviews present); noise/summary-only dispatches omit it.
+11. `## Instructions` — numbered list to execute in order. The final instruction always refers back to the `resolve:` bullet rather than duplicating the command — that single source of truth is what the monitor executes.
 
 **Section order (commit-suggestions variant):** only `## Review threads`, `## Commit suggestions`, and `## Instructions` — by gate, no comments / checks / reviews / noise / cancelled.
 
@@ -329,7 +331,7 @@ The JSON payload for this variant carries `fix.mode === "commit-suggestions"` pl
 - The `resolve:` instruction is only emitted when the resolve command actually mutates GitHub state (at least one of threads/comments/reviews is non-empty). A `CONFLICTS`-only dispatch omits it.
 - The commit-suggestions variant always emits exactly two instructions: run the `commit-suggestions:` command, then `git pull --ff-only`.
 
-The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled` for the rebase-and-push variant; the commit-suggestions variant carries `fix.{mode, threads, commitSuggestionsCommand, instructions}` plus `cancelled: []`.
+The JSON payload exposes the same data under `fix.{threads, actionableComments, noiseCommentIds, reviewSummaryIds, surfacedHumanSummaries, checks, changesRequestedReviews, baseBranch, resolveCommand, instructions}` plus top-level `cancelled` for the rebase-and-push variant; the commit-suggestions variant carries `fix.{mode, threads, commitSuggestionsCommand, instructions}` plus `cancelled: []`. `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `surfacedHumanSummaries` are informational only.
 
 **Flags:**
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -10,7 +10,7 @@
 | PR comment     | Top-level comment on the PR (not attached to a file)    | `pullRequest.comments`                         |
 | Review summary | PR-level body of a COMMENTED review (e.g. bot overview) | `pullRequest.reviews(states: COMMENTED)` (new) |
 
-Shepherd surfaces review threads and PR comments in the `report.threads` and `report.comments` fields respectively. Review summaries are not part of the `ShepherdReport` — they are surfaced only via `resolve --fetch` in the `reviewSummaries` array.
+Shepherd surfaces review threads and PR comments in the `report.threads` and `report.comments` fields respectively. Review summaries are also surfaced on `ShepherdReport` — as `reviewSummaries` (COMMENTED reviews) and `approvedReviews` (APPROVED-state reviews) — so the `iterate` / monitor loop can auto-minimize them via `--minimize-comment-ids`. The exposure is gated by [`iterate.minimizeReviewSummaries.{bots, humans, approvals}`](configuration.md#iterateminimizereviewsummaries). The manual `/pr-shepherd:resolve` skill reads summaries from `resolve --fetch`'s `reviewSummaries` array, which in turn is gated by `resolve.fetchReviewSummaries`.
 
 ## `isOutdated` flag
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -10,7 +10,7 @@
 | PR comment     | Top-level comment on the PR (not attached to a file)    | `pullRequest.comments`                         |
 | Review summary | PR-level body of a COMMENTED review (e.g. bot overview) | `pullRequest.reviews(states: COMMENTED)` (new) |
 
-Shepherd surfaces review threads and PR comments in the `report.threads` and `report.comments` fields respectively. Review summaries are also surfaced on `ShepherdReport` — as `reviewSummaries` (COMMENTED reviews) and `approvedReviews` (APPROVED-state reviews) — so the `iterate` / monitor loop can auto-minimize them via `--minimize-comment-ids`. The exposure is gated by [`iterate.minimizeReviewSummaries.{bots, humans, approvals}`](configuration.md#iterateminimizereviewsummaries). The manual `/pr-shepherd:resolve` skill reads summaries from `resolve --fetch`'s `reviewSummaries` array, which in turn is gated by `resolve.fetchReviewSummaries`.
+Shepherd surfaces review threads and PR comments in the `report.threads` and `report.comments` fields respectively. Review summaries are also surfaced on `ShepherdReport` — as `reviewSummaries` (COMMENTED reviews) and `approvedReviews` (APPROVED-state reviews). [`iterate.minimizeReviewSummaries.{bots, humans, approvals}`](configuration.md#iterateminimizereviewsummaries) gates the `iterate` / monitor loop's auto-minimize behavior for those surfaced reviews via `--minimize-comment-ids`; it does not gate whether those fields are present on `ShepherdReport`. The manual `/pr-shepherd:resolve` skill reads summaries from `resolve --fetch`'s `reviewSummaries` array, which is separately gated by `resolve.fetchReviewSummaries`.
 
 ## `isOutdated` flag
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,15 +93,17 @@ Controls which review IDs the monitor / `iterate` loop includes in `--minimize-c
 
 #### `iterate.minimizeReviewSummaries.bots` — default `true`
 
-Auto-minimize `COMMENTED` review summaries whose author is a known bot (`copilot-pull-request-reviewer`, `gemini-code-assist`, `coderabbitai`, or any `*[bot]` login). Set `false` to leave bot summaries visible.
+Auto-minimize `COMMENTED` review summaries whose author is a known bot (`copilot-pull-request-reviewer`, `gemini-code-assist`, `coderabbitai`, or any `*[bot]` login). When `false`, bot summaries render under `## Review summaries (surfaced — not minimized)` in the iterate output instead (same treatment as the `humans` toggle) — not dropped.
 
 #### `iterate.minimizeReviewSummaries.humans` — default `true`
 
-Auto-minimize `COMMENTED` review summaries from non-bot authors. When `false`, human summaries are rendered under `## Review summaries (surfaced — not minimized)` in the iterate output so you see them, but they are not passed to `--minimize-comment-ids`.
+Auto-minimize `COMMENTED` review summaries from non-bot authors. When `false`, human summaries render under `## Review summaries (surfaced — not minimized)` in the iterate output so you see them, but they are not passed to `--minimize-comment-ids`.
 
 #### `iterate.minimizeReviewSummaries.approvals` — default `false`
 
 Opt in to minimize `APPROVED`-state reviews (`pr approve` clicks with or without a body). Off by default because approvals are usually an affirmative signal you want to keep visible. Flip to `true` for long-running PRs where stale approvals pile up.
+
+> Perf note: when this is `false` (default), `fetchPrBatch` does not paginate beyond the first 50 approved reviews. Turn it on to fetch all approvals.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,12 @@ actions:
   autoRebase: true
   autoMarkReady: true
   commitSuggestions: true
+
+iterate:
+  minimizeReviewSummaries:
+    bots: true
+    humans: true
+    approvals: false
 ```
 
 ---
@@ -80,6 +86,22 @@ The counter resets automatically when a new commit is pushed (HEAD SHA change).
 
 - **Raise** for complex threads that may require multiple fix-push-review cycles.
 - **Lower** if you want to escalate to human review sooner.
+
+### `iterate.minimizeReviewSummaries`
+
+Controls which review IDs the monitor / `iterate` loop includes in `--minimize-comment-ids` when it emits `fix_code`. Review summary IDs ride along inside the existing resolve command — no code change needed to minimize them. Rendered under `## Review summaries (minimize only)` in the iterate markdown output.
+
+#### `iterate.minimizeReviewSummaries.bots` — default `true`
+
+Auto-minimize `COMMENTED` review summaries whose author is a known bot (`copilot-pull-request-reviewer`, `gemini-code-assist`, `coderabbitai`, or any `*[bot]` login). Set `false` to leave bot summaries visible.
+
+#### `iterate.minimizeReviewSummaries.humans` — default `true`
+
+Auto-minimize `COMMENTED` review summaries from non-bot authors. When `false`, human summaries are rendered under `## Review summaries (surfaced — not minimized)` in the iterate output so you see them, but they are not passed to `--minimize-comment-ids`.
+
+#### `iterate.minimizeReviewSummaries.approvals` — default `false`
+
+Opt in to minimize `APPROVED`-state reviews (`pr approve` clicks with or without a body). Off by default because approvals are usually an affirmative signal you want to keep visible. Flip to `true` for long-running PRs where stale approvals pile up.
 
 ---
 

--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -73,6 +73,8 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     threads: { actionable: [], autoResolved: [], autoResolveErrors: [] },
     comments: { actionable: [] },
     changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
     ...overrides,
   };
 }
@@ -116,6 +118,8 @@ function makeIterateResult(action: IterateResult["action"] = "wait"): IterateRes
         threads: [],
         actionableComments: [],
         noiseCommentIds: [],
+        reviewSummaryIds: [],
+        surfacedHumanSummaries: [],
         checks: [],
         changesRequestedReviews: [],
         resolveCommand: {
@@ -456,6 +460,8 @@ describe("main — iterate text format", () => {
       ],
       actionableComments: [{ id: "PRRC_1", author: "bot", body: "please address" }],
       noiseCommentIds: ["c-noise-1", "c-noise-2"],
+      reviewSummaryIds: [],
+      surfacedHumanSummaries: [],
       checks: [
         { name: "lint", runId: "run-42", detailsUrl: "https://x", failureKind: "actionable" },
         {
@@ -531,6 +537,47 @@ describe("main — iterate text format", () => {
     // Instructions are numbered.
     expect(out).toContain("1. step one");
     expect(out).toContain("2. step two");
+  });
+
+  it("fix_code: renders '## Review summaries (minimize only)' section when reviewSummaryIds is non-empty", async () => {
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
+    result.fix.reviewSummaryIds = ["PRR_BOT", "PRR_AP"];
+    result.fix.resolveCommand = {
+      argv: ["npx", "pr-shepherd", "resolve", "42", "--minimize-comment-ids", "PRR_BOT,PRR_AP"],
+      requiresHeadSha: false,
+      requiresDismissMessage: false,
+      hasMutations: true,
+    };
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+
+    expect(out).toContain("## Review summaries (minimize only)");
+    expect(out).toContain("`PRR_BOT`, `PRR_AP`");
+    expect(out).toContain(
+      "- resolve: `npx pr-shepherd resolve 42 --minimize-comment-ids PRR_BOT,PRR_AP`",
+    );
+    expect(out).not.toContain("## Review summaries (surfaced");
+  });
+
+  it("fix_code: renders '## Review summaries (surfaced — not minimized)' with H3 + blockquote", async () => {
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
+    result.fix.surfacedHumanSummaries = [
+      { id: "PRR_HUMAN", author: "alice", body: "Looks reasonable but please double-check X." },
+    ];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+
+    expect(out).toContain("## Review summaries (surfaced — not minimized)");
+    expect(out).toContain("### `PRR_HUMAN` (@alice)");
+    expect(out).toContain("> Looks reasonable but please double-check X.");
   });
 
   it("fix_code: multi-paragraph thread body is preserved verbatim in the blockquote", async () => {

--- a/src/cli.mock.test.mts
+++ b/src/cli.mock.test.mts
@@ -119,7 +119,7 @@ function makeIterateResult(action: IterateResult["action"] = "wait"): IterateRes
         actionableComments: [],
         noiseCommentIds: [],
         reviewSummaryIds: [],
-        surfacedHumanSummaries: [],
+        surfacedSummaries: [],
         checks: [],
         changesRequestedReviews: [],
         resolveCommand: {
@@ -461,7 +461,7 @@ describe("main — iterate text format", () => {
       actionableComments: [{ id: "PRRC_1", author: "bot", body: "please address" }],
       noiseCommentIds: ["c-noise-1", "c-noise-2"],
       reviewSummaryIds: [],
-      surfacedHumanSummaries: [],
+      surfacedSummaries: [],
       checks: [
         { name: "lint", runId: "run-42", detailsUrl: "https://x", failureKind: "actionable" },
         {
@@ -567,7 +567,7 @@ describe("main — iterate text format", () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
     if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
-    result.fix.surfacedHumanSummaries = [
+    result.fix.surfacedSummaries = [
       { id: "PRR_HUMAN", author: "alice", body: "Looks reasonable but please double-check X." },
     ];
     mockRunIterate.mockResolvedValue(result);

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -446,9 +446,9 @@ function formatFixCodeResult(
     sections.push(result.fix.reviewSummaryIds.map((id) => `\`${id}\``).join(", "));
   }
 
-  if (result.fix.surfacedHumanSummaries.length > 0) {
+  if (result.fix.surfacedSummaries.length > 0) {
     sections.push("## Review summaries (surfaced — not minimized)");
-    for (const r of result.fix.surfacedHumanSummaries) {
+    for (const r of result.fix.surfacedSummaries) {
       sections.push(`### \`${r.id}\` (@${r.author})`);
       sections.push(blockquote(r.body));
     }

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -441,6 +441,19 @@ function formatFixCodeResult(
     sections.push(result.fix.noiseCommentIds.map((id) => `\`${id}\``).join(", "));
   }
 
+  if (result.fix.reviewSummaryIds.length > 0) {
+    sections.push("## Review summaries (minimize only)");
+    sections.push(result.fix.reviewSummaryIds.map((id) => `\`${id}\``).join(", "));
+  }
+
+  if (result.fix.surfacedHumanSummaries.length > 0) {
+    sections.push("## Review summaries (surfaced — not minimized)");
+    for (const r of result.fix.surfacedHumanSummaries) {
+      sections.push(`### \`${r.id}\` (@${r.author})`);
+      sections.push(blockquote(r.body));
+    }
+  }
+
   if (result.cancelled.length > 0) {
     sections.push("## Cancelled runs");
     sections.push(result.cancelled.map((id) => `\`${id}\``).join(", "));

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -60,6 +60,7 @@ function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
     comments: [],
     changesRequestedReviews: [],
     reviewSummaries: [],
+    approvedReviews: [],
     checks: [makeCheck()],
     ...overrides,
   };
@@ -296,6 +297,29 @@ describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () =
 // ---------------------------------------------------------------------------
 // Thread minimization filtering
 // ---------------------------------------------------------------------------
+
+describe("runCheck — reviewSummaries + approvedReviews pass-through", () => {
+  it("surfaces reviewSummaries and approvedReviews on the report", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        reviewSummaries: [{ id: "PRR_SUM", author: "copilot", body: "overview" }],
+        approvedReviews: [{ id: "PRR_AP", author: "alice", body: "" }],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.reviewSummaries).toEqual([
+      { id: "PRR_SUM", author: "copilot", body: "overview" },
+    ]);
+    expect(report.approvedReviews).toEqual([{ id: "PRR_AP", author: "alice", body: "" }]);
+  });
+
+  it("defaults to empty arrays when batch has none", async () => {
+    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData() });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.reviewSummaries).toEqual([]);
+    expect(report.approvedReviews).toEqual([]);
+  });
+});
 
 describe("runCheck — minimized thread filtering", () => {
   it("excludes threads whose top comment is minimized from actionable threads", async () => {

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -21,6 +21,7 @@ import { triageFailingChecks } from "../checks/triage.mts";
 import { getOutdatedThreads } from "../comments/outdated.mts";
 import { autoResolveOutdated } from "../comments/resolve.mts";
 import { deriveMergeStatus } from "../merge-status/derive.mts";
+import { loadConfig } from "../config/load.mts";
 import type {
   GlobalOptions,
   MergeStatusResult,
@@ -62,7 +63,10 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
   let batchData = await cacheGet<BatchPrData>(cacheKey, cacheOpts);
 
   if (batchData === null) {
-    const result = await fetchPrBatch(prNumber, repo);
+    // Only paginate APPROVED reviews when the caller will actually minimize them.
+    // Otherwise the first-page cap of 50 (already in the batch) is plenty — no extra round-trip.
+    const paginateApprovedReviews = loadConfig().iterate.minimizeReviewSummaries.approvals;
+    const result = await fetchPrBatch(prNumber, repo, { paginateApprovedReviews });
     batchData = result.data;
     // Don't cache UNKNOWN merge state — it's transient and would poison the
     // cache for the full TTL window, causing stale UNKNOWN on the next sweep.

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -160,6 +160,8 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
       actionable: actionableComments,
     },
     changesRequestedReviews: batchData.changesRequestedReviews,
+    reviewSummaries: batchData.reviewSummaries,
+    approvedReviews: batchData.approvedReviews,
     lastPushTime: opts.lastPushTime,
   };
 }

--- a/src/commands/commit-suggestions.mock.test.mts
+++ b/src/commands/commit-suggestions.mock.test.mts
@@ -92,6 +92,7 @@ function makeBatch(threads: ReviewThread[]): BatchPrData {
     comments: [],
     changesRequestedReviews: [],
     reviewSummaries: [],
+    approvedReviews: [],
     checks: [],
   };
 }

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -107,6 +107,8 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     threads: { actionable: [], autoResolved: [], autoResolveErrors: [] },
     comments: { actionable: [] },
     changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
     lastPushTime: undefined,
     ...overrides,
   };
@@ -138,7 +140,11 @@ const READY_STATE_DEFAULT = {
 function defaultConfig() {
   return {
     cache: { ttlSeconds: 300 },
-    iterate: { cooldownSeconds: 30, fixAttemptsPerThread: 3 },
+    iterate: {
+      cooldownSeconds: 30,
+      fixAttemptsPerThread: 3,
+      minimizeReviewSummaries: { bots: true, humans: true, approvals: false },
+    },
     watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
     resolve: {
       concurrency: 4,
@@ -2561,5 +2567,179 @@ describe("runIterate — fix_code commit-suggestions shortcut", () => {
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
     expect(result.fix.mode).toBe("rebase-and-push");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review summary minimize — issue #70
+// ---------------------------------------------------------------------------
+
+describe("runIterate — review summary auto-minimize", () => {
+  const botSummary = { id: "PRR_BOT", author: "copilot-pull-request-reviewer", body: "overview" };
+  const genericBotSummary = { id: "PRR_GEM", author: "gemini-code-assist", body: "overview" };
+  const bracketBotSummary = { id: "PRR_BRK", author: "github-actions[bot]", body: "overview" };
+  const humanSummary = { id: "PRR_HUMAN", author: "alice", body: "nice work" };
+
+  it("emits fix_code with reviewSummaryIds when only a bot summary exists", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [botSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(result.action).toBe("fix_code");
+    if (result.action !== "fix_code") return;
+    expect(result.fix.mode).toBe("rebase-and-push");
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
+    expect(result.fix.surfacedHumanSummaries).toEqual([]);
+    expect(result.fix.resolveCommand.argv).toContain("--minimize-comment-ids");
+    expect(result.fix.resolveCommand.argv).toContain("PRR_BOT");
+    expect(result.fix.resolveCommand.requiresHeadSha).toBe(false);
+  });
+
+  it("classifies the `*[bot]` login suffix as a bot", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [bracketBotSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_BRK"]);
+  });
+
+  it("classifies known bot logins (gemini-code-assist) as bots", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [genericBotSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_GEM"]);
+  });
+
+  it("auto-minimizes human summaries when cfg.humans is true (default)", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [humanSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_HUMAN"]);
+    expect(result.fix.surfacedHumanSummaries).toEqual([]);
+  });
+
+  it("surfaces (without minimizing) human summaries when cfg.humans is false", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeReviewSummaries.humans = false;
+    mockLoadConfig.mockReturnValue(cfg);
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [botSummary, humanSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
+    expect(result.fix.surfacedHumanSummaries).toEqual([humanSummary]);
+  });
+
+  it("does not minimize bots when cfg.bots is false", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeReviewSummaries.bots = false;
+    mockLoadConfig.mockReturnValue(cfg);
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [botSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    // No actionable work anywhere → wait.
+    expect(result.action).toBe("wait");
+  });
+
+  it("omits APPROVED reviews from minimize list by default (approvals: false)", async () => {
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        approvedReviews: [{ id: "PRR_AP", author: "alice", body: "" }],
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("wait");
+  });
+
+  it("includes APPROVED reviews in minimize list when cfg.approvals is true", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeReviewSummaries.approvals = true;
+    mockLoadConfig.mockReturnValue(cfg);
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        approvedReviews: [{ id: "PRR_AP", author: "alice", body: "" }],
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_AP"]);
+  });
+
+  it("summary-only PR triggers fix_code (not wait) so the summary can be minimized", async () => {
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [botSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("fix_code");
+  });
+
+  it("blocks the commit-suggestions shortcut when a bot summary is pending", async () => {
+    const t1 = makeSuggestionThread("PRRT_x");
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        status: "UNRESOLVED_COMMENTS",
+        threads: { actionable: [t1], autoResolved: [], autoResolveErrors: [] },
+        reviewSummaries: [botSummary],
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(result.action).toBe("fix_code");
+    if (result.action !== "fix_code") return;
+    expect(result.fix.mode).toBe("rebase-and-push");
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
   });
 });

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -2595,7 +2595,7 @@ describe("runIterate — review summary auto-minimize", () => {
     expect(result.fix.mode).toBe("rebase-and-push");
     if (result.fix.mode !== "rebase-and-push") return;
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
-    expect(result.fix.surfacedHumanSummaries).toEqual([]);
+    expect(result.fix.surfacedSummaries).toEqual([]);
     expect(result.fix.resolveCommand.argv).toContain("--minimize-comment-ids");
     expect(result.fix.resolveCommand.argv).toContain("PRR_BOT");
     expect(result.fix.resolveCommand.requiresHeadSha).toBe(false);
@@ -2638,7 +2638,7 @@ describe("runIterate — review summary auto-minimize", () => {
     if (result.action !== "fix_code") return;
     if (result.fix.mode !== "rebase-and-push") return;
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_HUMAN"]);
-    expect(result.fix.surfacedHumanSummaries).toEqual([]);
+    expect(result.fix.surfacedSummaries).toEqual([]);
   });
 
   it("surfaces (without minimizing) human summaries when cfg.humans is false", async () => {
@@ -2655,10 +2655,10 @@ describe("runIterate — review summary auto-minimize", () => {
     if (result.action !== "fix_code") return;
     if (result.fix.mode !== "rebase-and-push") return;
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
-    expect(result.fix.surfacedHumanSummaries).toEqual([humanSummary]);
+    expect(result.fix.surfacedSummaries).toEqual([humanSummary]);
   });
 
-  it("does not minimize bots when cfg.bots is false", async () => {
+  it("surfaces (without minimizing) bot summaries when cfg.bots is false", async () => {
     const cfg = defaultConfig();
     cfg.iterate.minimizeReviewSummaries.bots = false;
     mockLoadConfig.mockReturnValue(cfg);
@@ -2669,8 +2669,31 @@ describe("runIterate — review summary auto-minimize", () => {
       remainingSeconds: 600,
     });
     const result = await runIterate(makeOpts());
-    // No actionable work anywhere → wait.
-    expect(result.action).toBe("wait");
+    expect(result.action).toBe("fix_code");
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual([]);
+    expect(result.fix.surfacedSummaries).toEqual([botSummary]);
+  });
+
+  it("emits fix_code with only surfaced summaries (no minimize, no push) when both toggles are off", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeReviewSummaries.bots = false;
+    cfg.iterate.minimizeReviewSummaries.humans = false;
+    mockLoadConfig.mockReturnValue(cfg);
+    mockRunCheck.mockResolvedValue(makeReport({ reviewSummaries: [botSummary, humanSummary] }));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("fix_code");
+    if (result.action !== "fix_code") return;
+    if (result.fix.mode !== "rebase-and-push") return;
+    expect(result.fix.reviewSummaryIds).toEqual([]);
+    expect(result.fix.surfacedSummaries).toEqual([botSummary, humanSummary]);
+    expect(result.fix.resolveCommand.hasMutations).toBe(false);
   });
 
   it("omits APPROVED reviews from minimize list by default (approvals: false)", async () => {

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -168,7 +168,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   // already runs fetch+rebase+push, so conflicts are resolved as part of that flow.
   const actionableChecks = report.checks.failing.filter((f) => f.failureKind === "actionable");
   // Classify review summaries upfront so summary-only PRs still trigger fix_code and get minimized.
-  const { minimizeIds: reviewSummaryIds, surfacedHumanSummaries } = classifyReviewSummaries(
+  const { minimizeIds: reviewSummaryIds, surfacedSummaries } = classifyReviewSummaries(
     report.reviewSummaries,
     report.approvedReviews,
     config.iterate.minimizeReviewSummaries,
@@ -179,7 +179,8 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     report.changesRequestedReviews.length > 0 ||
     actionableChecks.length > 0 ||
     report.mergeStatus.status === "CONFLICTS" ||
-    reviewSummaryIds.length > 0;
+    reviewSummaryIds.length > 0 ||
+    surfacedSummaries.length > 0;
 
   if (hasActionableWork) {
     // Load fix-attempt counts, resetting if HEAD SHA changed (new commit pushed).
@@ -351,7 +352,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
         actionableComments,
         noiseCommentIds,
         reviewSummaryIds,
-        surfacedHumanSummaries,
+        surfacedSummaries,
         checks,
         changesRequestedReviews,
         resolveCommand,
@@ -622,22 +623,18 @@ export function classifyReviewSummaries(
   summaries: Review[],
   approvals: Review[],
   cfg: { bots: boolean; humans: boolean; approvals: boolean },
-): { minimizeIds: string[]; surfacedHumanSummaries: Review[] } {
+): { minimizeIds: string[]; surfacedSummaries: Review[] } {
   const minimizeIds: string[] = [];
-  const surfacedHumanSummaries: Review[] = [];
+  const surfacedSummaries: Review[] = [];
   for (const r of summaries) {
-    if (isBotAuthor(r.author)) {
-      if (cfg.bots) minimizeIds.push(r.id);
-    } else if (cfg.humans) {
-      minimizeIds.push(r.id);
-    } else {
-      surfacedHumanSummaries.push(r);
-    }
+    const enabled = isBotAuthor(r.author) ? cfg.bots : cfg.humans;
+    if (enabled) minimizeIds.push(r.id);
+    else surfacedSummaries.push(r);
   }
   if (cfg.approvals) {
     for (const r of approvals) minimizeIds.push(r.id);
   }
-  return { minimizeIds, surfacedHumanSummaries };
+  return { minimizeIds, surfacedSummaries };
 }
 
 // Patterns that indicate a comment is bot-generated noise rather than actionable feedback.

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -167,12 +167,19 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   // conflicts all in one push. CONFLICTS is included here because the fix_code handler
   // already runs fetch+rebase+push, so conflicts are resolved as part of that flow.
   const actionableChecks = report.checks.failing.filter((f) => f.failureKind === "actionable");
+  // Classify review summaries upfront so summary-only PRs still trigger fix_code and get minimized.
+  const { minimizeIds: reviewSummaryIds, surfacedHumanSummaries } = classifyReviewSummaries(
+    report.reviewSummaries,
+    report.approvedReviews,
+    config.iterate.minimizeReviewSummaries,
+  );
   const hasActionableWork =
     report.threads.actionable.length > 0 ||
     report.comments.actionable.length > 0 ||
     report.changesRequestedReviews.length > 0 ||
     actionableChecks.length > 0 ||
-    report.mergeStatus.status === "CONFLICTS";
+    report.mergeStatus.status === "CONFLICTS" ||
+    reviewSummaryIds.length > 0;
 
   if (hasActionableWork) {
     // Load fix-attempt counts, resetting if HEAD SHA changed (new commit pushed).
@@ -256,7 +263,11 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       noiseCommentIds.length === 0 &&
       changesRequestedReviews.length === 0 &&
       checks.length === 0 &&
-      !hasConflicts;
+      !hasConflicts &&
+      // Block the shortcut when any review summary still needs minimizing — the
+      // commit-suggestions path emits no resolve command, so summary IDs would
+      // be orphaned. Falling through to rebase-and-push keeps them included.
+      reviewSummaryIds.length === 0;
 
     if (canShortcut) {
       return {
@@ -282,7 +293,12 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       };
     }
 
-    const allCommentIds = [...actionableComments.map((c) => c.id), ...noiseCommentIds];
+    // Review summary IDs ride in the minimize bucket — they have no code-fix counterpart.
+    const allCommentIds = [
+      ...actionableComments.map((c) => c.id),
+      ...noiseCommentIds,
+      ...reviewSummaryIds,
+    ];
     const resolveCommand = buildResolveCommand(
       threads,
       actionableComments,
@@ -334,6 +350,8 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
         threads,
         actionableComments,
         noiseCommentIds,
+        reviewSummaryIds,
+        surfacedHumanSummaries,
         checks,
         changesRequestedReviews,
         resolveCommand,
@@ -584,6 +602,42 @@ function buildRebaseShellScript(baseBranch: string): string {
     `fi`,
     `git fetch origin && git rebase origin/${baseBranch} && git push --force-with-lease`,
   ].join("\n");
+}
+
+// Logins treated as bot authors regardless of the GitHub Bot/User user type.
+// Mirrors plugin/skills/resolve/SKILL.md §3 — kept in sync with the resolve triage guidance.
+const KNOWN_BOT_LOGINS = new Set([
+  "copilot-pull-request-reviewer",
+  "gemini-code-assist",
+  "coderabbitai",
+]);
+
+function isBotAuthor(login: string): boolean {
+  const bare = login.replace(/\[bot\]$/, "");
+  if (bare !== login) return true;
+  return KNOWN_BOT_LOGINS.has(bare);
+}
+
+export function classifyReviewSummaries(
+  summaries: Review[],
+  approvals: Review[],
+  cfg: { bots: boolean; humans: boolean; approvals: boolean },
+): { minimizeIds: string[]; surfacedHumanSummaries: Review[] } {
+  const minimizeIds: string[] = [];
+  const surfacedHumanSummaries: Review[] = [];
+  for (const r of summaries) {
+    if (isBotAuthor(r.author)) {
+      if (cfg.bots) minimizeIds.push(r.id);
+    } else if (cfg.humans) {
+      minimizeIds.push(r.id);
+    } else {
+      surfacedHumanSummaries.push(r);
+    }
+  }
+  if (cfg.approvals) {
+    for (const r of approvals) minimizeIds.push(r.id);
+  }
+  return { minimizeIds, surfacedHumanSummaries };
 }
 
 // Patterns that indicate a comment is bot-generated noise rather than actionable feedback.

--- a/src/commands/resolve.mock.test.mts
+++ b/src/commands/resolve.mock.test.mts
@@ -62,6 +62,7 @@ function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
     comments: [],
     changesRequestedReviews: [],
     reviewSummaries: [],
+    approvedReviews: [],
     checks: [],
     ...overrides,
   };

--- a/src/config.json
+++ b/src/config.json
@@ -4,7 +4,12 @@
   },
   "iterate": {
     "cooldownSeconds": 30,
-    "fixAttemptsPerThread": 3
+    "fixAttemptsPerThread": 3,
+    "minimizeReviewSummaries": {
+      "bots": true,
+      "humans": true,
+      "approvals": false
+    }
   },
   "watch": {
     "interval": "4m",

--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -11,6 +11,18 @@ export interface PrShepherdConfig {
   iterate: {
     cooldownSeconds: number;
     fixAttemptsPerThread: number;
+    /**
+     * Which review summaries the monitor loop should auto-minimize via `resolve --minimize-comment-ids`.
+     * Bots default on; humans default on; approvals default off (opt-in). See docs/comments.md.
+     */
+    minimizeReviewSummaries: {
+      /** Auto-minimize review summaries from known bot authors (copilot-pull-request-reviewer, `*[bot]`, etc.). */
+      bots: boolean;
+      /** Auto-minimize COMMENTED review summaries from non-bot (human) authors. */
+      humans: boolean;
+      /** Auto-minimize APPROVED-state reviews. Off by default — approvals usually stay visible. */
+      approvals: boolean;
+    };
   };
   watch: {
     interval: string;

--- a/src/config/load.test.mts
+++ b/src/config/load.test.mts
@@ -41,6 +41,27 @@ describe("loadConfig — no rc file", () => {
     expect(result.checks.logMaxLines).toBe(50);
   });
 
+  it("defaults iterate.minimizeReviewSummaries to {bots:true, humans:true, approvals:false}", async () => {
+    const loadConfig = await freshLoadConfig();
+    const result = loadConfig();
+    expect(result.iterate.minimizeReviewSummaries).toEqual({
+      bots: true,
+      humans: true,
+      approvals: false,
+    });
+  });
+
+  it("preserves other iterate.minimizeReviewSummaries defaults when only one key is overridden", async () => {
+    writeFileSync(join(tmpDir, RC), "iterate:\n  minimizeReviewSummaries:\n    approvals: true\n");
+    const loadConfig = await freshLoadConfig();
+    const result = loadConfig();
+    expect(result.iterate.minimizeReviewSummaries).toEqual({
+      bots: true,
+      humans: true,
+      approvals: true,
+    });
+  });
+
   it("returns defaults for empty YAML (yaml.parse returns null)", async () => {
     writeFileSync(join(tmpDir, RC), "");
     const loadConfig = await freshLoadConfig();

--- a/src/github/batch.mock.test.mts
+++ b/src/github/batch.mock.test.mts
@@ -650,7 +650,7 @@ describe("fetchPrBatch — approvedReviews", () => {
     expect(data.approvedReviews[0]!.author).toBe("unknown");
   });
 
-  it("paginates backward when hasPreviousPage is true", async () => {
+  it("paginates backward only when paginateApprovedReviews is set", async () => {
     const firstPage = makeRawPr({
       approvedReviews: {
         pageInfo: { hasPreviousPage: true, startCursor: "cursor-ap" },
@@ -666,8 +666,23 @@ describe("fetchPrBatch — approvedReviews", () => {
     mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
     mockGraphql.mockResolvedValue(makeResponse(prevPage));
 
-    const { data } = await fetchPrBatch(42, REPO);
+    const { data } = await fetchPrBatch(42, REPO, { paginateApprovedReviews: true });
     expect(data.approvedReviews.map((r) => r.id)).toEqual(["PRR_1", "PRR_2"]);
+  });
+
+  it("skips approved-review backward pagination by default (opt-in via paginateApprovedReviews)", async () => {
+    const firstPage = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-ap" },
+        nodes: [{ id: "PRR_2", isMinimized: false, author: { login: "bob" }, body: "" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockClear();
+
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.approvedReviews.map((r) => r.id)).toEqual(["PRR_2"]);
+    expect(mockGraphql).not.toHaveBeenCalled();
   });
 });
 

--- a/src/github/batch.mock.test.mts
+++ b/src/github/batch.mock.test.mts
@@ -46,6 +46,10 @@ function makeRawPr(overrides: Record<string, unknown> = {}) {
       pageInfo: { hasPreviousPage: false, startCursor: null },
       nodes: [],
     },
+    approvedReviews: {
+      pageInfo: { hasPreviousPage: false, startCursor: null },
+      nodes: [],
+    },
     commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
     ...overrides,
   };
@@ -585,6 +589,85 @@ describe("fetchPrBatch — reviewSummaries pagination", () => {
 
     const { data } = await fetchPrBatch(42, REPO);
     expect(data.reviewSummaries.map((r) => r.id)).toEqual(["PRR_1", "PRR_2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approvedReviews — APPROVED-state reviews (opt-in minimize target)
+// ---------------------------------------------------------------------------
+
+describe("fetchPrBatch — approvedReviews", () => {
+  it("surfaces non-minimized APPROVED reviews", async () => {
+    const pr = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "PRR_AP", isMinimized: false, author: { login: "alice" }, body: "LGTM" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.approvedReviews).toHaveLength(1);
+    expect(data.approvedReviews[0]!.id).toBe("PRR_AP");
+    expect(data.approvedReviews[0]!.author).toBe("alice");
+  });
+
+  it("keeps empty-body approvals (clicking Approve without commenting is common)", async () => {
+    const pr = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "PRR_AP", isMinimized: false, author: { login: "alice" }, body: "" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.approvedReviews).toHaveLength(1);
+  });
+
+  it("drops already-minimized APPROVED reviews", async () => {
+    const pr = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          { id: "PRR_H", isMinimized: true, author: { login: "alice" }, body: "" },
+          { id: "PRR_V", isMinimized: false, author: { login: "bob" }, body: "" },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.approvedReviews.map((r) => r.id)).toEqual(["PRR_V"]);
+  });
+
+  it("falls back to 'unknown' when author is null", async () => {
+    const pr = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "PRR_AP", isMinimized: false, author: null, body: "" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.approvedReviews[0]!.author).toBe("unknown");
+  });
+
+  it("paginates backward when hasPreviousPage is true", async () => {
+    const firstPage = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: true, startCursor: "cursor-ap" },
+        nodes: [{ id: "PRR_2", isMinimized: false, author: { login: "bob" }, body: "" }],
+      },
+    });
+    const prevPage = makeRawPr({
+      approvedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "PRR_1", isMinimized: false, author: { login: "alice" }, body: "" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(prevPage));
+
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.approvedReviews.map((r) => r.id)).toEqual(["PRR_1", "PRR_2"]);
   });
 });
 

--- a/src/github/batch.mts
+++ b/src/github/batch.mts
@@ -29,10 +29,26 @@ export interface BatchResult {
   rateLimit?: RateLimitInfo;
 }
 
+export interface FetchPrBatchOptions {
+  /**
+   * When false (default), the first-page approvedReviews are returned but
+   * backward pagination is skipped. Iterate's approvals-minimize flow sets this
+   * to true only when the user opts in, so long-lived PRs with > 50 approvals
+   * don't pay extra GraphQL round-trips per monitor tick for data no consumer
+   * currently uses. The first page is free — already inside the one batch
+   * request — so there's no need to conditionally omit the field itself.
+   */
+  paginateApprovedReviews?: boolean;
+}
+
 /**
  * Fetch all PR data needed for a `shepherd check` in one (or a few, if paginating) GraphQL requests.
  */
-export async function fetchPrBatch(pr: number, repo: RepoInfo): Promise<BatchResult> {
+export async function fetchPrBatch(
+  pr: number,
+  repo: RepoInfo,
+  opts: FetchPrBatchOptions = {},
+): Promise<BatchResult> {
   // First page: no cursor variables.
   const result = await graphqlWithRateLimit<RawBatchResponse>(BATCH_PR_QUERY, {
     owner: repo.owner,
@@ -119,9 +135,14 @@ export async function fetchPrBatch(pr: number, repo: RepoInfo): Promise<BatchRes
     rawReviewSummaryNodes = [...extra, ...rawReviewSummaryNodes];
   }
 
-  // Paginate APPROVED reviews backward if the first page is incomplete.
+  // Paginate APPROVED reviews backward if the first page is incomplete — gated behind
+  // `paginateApprovedReviews` because approvals minimization is opt-in. See FetchPrBatchOptions.
   let rawApprovedReviewNodes = raw.approvedReviews.nodes;
-  if (raw.approvedReviews.pageInfo.hasPreviousPage && raw.approvedReviews.pageInfo.startCursor) {
+  if (
+    opts.paginateApprovedReviews &&
+    raw.approvedReviews.pageInfo.hasPreviousPage &&
+    raw.approvedReviews.pageInfo.startCursor
+  ) {
     const extra = await paginateBackward<RawReviewSummary>(async (cursor) => {
       const res = await graphql<RawBatchResponse>(BATCH_PR_QUERY, {
         owner: repo.owner,

--- a/src/github/batch.mts
+++ b/src/github/batch.mts
@@ -119,6 +119,23 @@ export async function fetchPrBatch(pr: number, repo: RepoInfo): Promise<BatchRes
     rawReviewSummaryNodes = [...extra, ...rawReviewSummaryNodes];
   }
 
+  // Paginate APPROVED reviews backward if the first page is incomplete.
+  let rawApprovedReviewNodes = raw.approvedReviews.nodes;
+  if (raw.approvedReviews.pageInfo.hasPreviousPage && raw.approvedReviews.pageInfo.startCursor) {
+    const extra = await paginateBackward<RawReviewSummary>(async (cursor) => {
+      const res = await graphql<RawBatchResponse>(BATCH_PR_QUERY, {
+        owner: repo.owner,
+        repo: repo.name,
+        pr,
+        ...(cursor ? { approvedReviewsCursor: cursor } : {}),
+      });
+      const pr2 = res.data.repository.pullRequest;
+      if (!pr2) throw new Error(`PR #${pr} not found`);
+      return pr2.approvedReviews;
+    }, raw.approvedReviews.pageInfo.startCursor);
+    rawApprovedReviewNodes = [...extra, ...rawApprovedReviewNodes];
+  }
+
   // Paginate check contexts forward if the first page is incomplete.
   let rawCheckNodes = raw.commits.nodes[0]?.commit.statusCheckRollup?.contexts.nodes ?? [];
   const checksPageInfo = raw.commits.nodes[0]?.commit.statusCheckRollup?.contexts.pageInfo;
@@ -145,6 +162,7 @@ export async function fetchPrBatch(pr: number, repo: RepoInfo): Promise<BatchRes
     rawCommentNodes,
     rawReviewNodes,
     rawReviewSummaryNodes,
+    rawApprovedReviewNodes,
     rawCheckNodes,
   );
   return { data, rateLimit: result.rateLimit };
@@ -160,6 +178,7 @@ function parseRawPr(
   rawCommentNodes: RawComment[],
   rawReviewNodes: RawReview[],
   rawReviewSummaryNodes: RawReviewSummary[],
+  rawApprovedReviewNodes: RawReviewSummary[],
   rawCheckNodes: RawContextNode[],
 ): BatchPrData {
   const reviewRequests = (raw.reviewRequests?.nodes ?? []).flatMap((n) => {
@@ -204,6 +223,17 @@ function parseRawPr(
 
   const reviewSummaries: Review[] = rawReviewSummaryNodes
     .filter((r) => !r.isMinimized && r.body.trim() !== "")
+    .map((r) => ({
+      id: r.id,
+      author: r.author?.login ?? "unknown",
+      body: r.body,
+    }));
+
+  // APPROVED reviews often have empty bodies (clicking "Approve" without a comment), so
+  // we keep them — only the isMinimized filter applies. Monitor/iterate uses these IDs
+  // when the user opts in to minimizing approvals.
+  const approvedReviews: Review[] = rawApprovedReviewNodes
+    .filter((r) => !r.isMinimized)
     .map((r) => ({
       id: r.id,
       author: r.author?.login ?? "unknown",
@@ -257,6 +287,7 @@ function parseRawPr(
     comments,
     changesRequestedReviews,
     reviewSummaries,
+    approvedReviews,
     checks,
   };
 }
@@ -334,6 +365,10 @@ interface RawPr {
     nodes: RawReview[];
   };
   reviewSummaries: {
+    pageInfo: { hasPreviousPage: boolean; startCursor: string | null };
+    nodes: RawReviewSummary[];
+  };
+  approvedReviews: {
     pageInfo: { hasPreviousPage: boolean; startCursor: string | null };
     nodes: RawReviewSummary[];
   };

--- a/src/github/gql/batch-pr.gql
+++ b/src/github/gql/batch-pr.gql
@@ -7,6 +7,7 @@ query BatchPr(
   $commentsCursor: String
   $changesRequestedCursor: String
   $reviewSummariesCursor: String
+  $approvedReviewsCursor: String
 ) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
@@ -102,6 +103,20 @@ query BatchPr(
         }
       }
       reviewSummaries: reviews(states: COMMENTED, last: 50, before: $reviewSummariesCursor) {
+        pageInfo {
+          hasPreviousPage
+          startCursor
+        }
+        nodes {
+          id
+          isMinimized
+          author {
+            login
+          }
+          body
+        }
+      }
+      approvedReviews: reviews(states: APPROVED, last: 50, before: $approvedReviewsCursor) {
         pageInfo {
           hasPreviousPage
           startCursor

--- a/src/merge-status/derive.test.mts
+++ b/src/merge-status/derive.test.mts
@@ -19,6 +19,7 @@ function makePr(overrides: Partial<BatchPrData>): BatchPrData {
     comments: [],
     changesRequestedReviews: [],
     reviewSummaries: [],
+    approvedReviews: [],
     checks: [],
     ...overrides,
   };

--- a/src/reporters/json.test.mts
+++ b/src/reporters/json.test.mts
@@ -30,6 +30,8 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     threads: { actionable: [], autoResolved: [], autoResolveErrors: [] },
     comments: { actionable: [] },
     changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
     ...overrides,
   };
 }

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -66,6 +66,8 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     threads: { actionable: [], autoResolved: [], autoResolveErrors: [] },
     comments: { actionable: [] },
     changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
     ...overrides,
   };
 }

--- a/src/types.mts
+++ b/src/types.mts
@@ -166,6 +166,8 @@ export interface BatchPrData {
   changesRequestedReviews: Review[];
   /** COMMENTED reviews with a non-empty, non-minimized body — surfaced for agent-driven minimize. */
   reviewSummaries: Review[];
+  /** APPROVED reviews that are not minimized — opt-in minimize target for the monitor loop. */
+  approvedReviews: Review[];
   checks: CheckRun[];
 }
 
@@ -209,6 +211,10 @@ export interface ShepherdReport {
     actionable: PrComment[];
   };
   changesRequestedReviews: Review[];
+  /** COMMENTED reviews with a non-empty, non-minimized body — surfaced for agent-driven minimize. */
+  reviewSummaries: Review[];
+  /** APPROVED reviews not yet minimized — opt-in minimize target. */
+  approvedReviews: Review[];
   lastPushTime?: number;
 }
 
@@ -345,6 +351,10 @@ export interface FixRebaseAndPush {
   actionableComments: AgentComment[];
   /** IDs of comments classified as noise (quota warnings, bot acks, etc.) — minimize but do not act on. */
   noiseCommentIds: string[];
+  /** Review IDs (COMMENTED summaries and, if opted in, APPROVED reviews) to minimize — no code change needed. */
+  reviewSummaryIds: string[];
+  /** Human-authored COMMENTED review summaries surfaced for visibility when the humans toggle is off. Not minimized. */
+  surfacedHumanSummaries: Review[];
   checks: AgentCheck[];
   changesRequestedReviews: Review[];
   /** Pre-built resolve command. Run after committing and pushing. */

--- a/src/types.mts
+++ b/src/types.mts
@@ -353,8 +353,8 @@ export interface FixRebaseAndPush {
   noiseCommentIds: string[];
   /** Review IDs (COMMENTED summaries and, if opted in, APPROVED reviews) to minimize — no code change needed. */
   reviewSummaryIds: string[];
-  /** Human-authored COMMENTED review summaries surfaced for visibility when the humans toggle is off. Not minimized. */
-  surfacedHumanSummaries: Review[];
+  /** COMMENTED review summaries surfaced for visibility (author type's toggle is off). Not minimized. */
+  surfacedSummaries: Review[];
   checks: AgentCheck[];
   changesRequestedReviews: Review[];
   /** Pre-built resolve command. Run after committing and pushing. */


### PR DESCRIPTION
Closes #70.

## Summary

- The monitor / iterate flow never threaded COMMENTED review summaries through to the minimize step. PR #55 surfaced them only via `resolve --fetch` (the manual `/pr-shepherd:resolve` skill), so Copilot-style summaries piled up indefinitely on monitored PRs. This change teaches `iterate` to minimize them automatically via the existing `--minimize-comment-ids` path.
- Review summaries are classified by author (known bot logins + `*[bot]` suffix). Bot IDs and, by config, human IDs and APPROVED-state reviews roll into `allCommentIds` so they ride inside the same `resolve:` command the monitor already executes.
- Summary-only PRs (no threads/comments/reviews/checks/conflicts but a pending summary) now trigger `fix_code` instead of `wait`, so the summary actually gets minimized.
- The new commit-suggestions shortcut (PR #67) is blocked when any summary needs minimizing — that path emits no resolve command, so letting it fire with pending summaries would orphan the IDs.
- New config `iterate.minimizeReviewSummaries.{bots, humans, approvals}`:
  - `bots` — default `true`. Auto-minimize Copilot / Gemini / `*[bot]` summaries.
  - `humans` — default `true`. Auto-minimize non-bot COMMENTED summaries. When `false`, they render under a new `## Review summaries (surfaced — not minimized)` section for visibility.
  - `approvals` — default `false`. Opt-in to minimize APPROVED-state reviews. Requires a new `approvedReviews` GQL bucket in the batch query.
- Output: new `## Review summaries (minimize only)` and `## Review summaries (surfaced — not minimized)` sections in iterate's text output; `fix.reviewSummaryIds` and `fix.surfacedHumanSummaries` in JSON.

Docs updated: `README.md` config table, `docs/configuration.md`, `docs/actions.md` (section order), `docs/comments.md`.

## Test plan

- [x] `npm test` — 530 tests pass (21 new: 5 batch, 2 check, 10 iterate, 2 cli, 2 config/load).
- [x] `npm run build` clean.
- [x] `npm run format:check` clean.
- [ ] Smoke on a real PR with a Copilot COMMENTED summary: `npx pr-shepherd iterate <N> --format=json | jq '.fix.reviewSummaryIds'` returns the `PRR_…` ID, and the emitted `resolve:` command includes it under `--minimize-comment-ids`.
- [ ] Set `iterate.minimizeReviewSummaries.approvals: true` in `.pr-shepherdrc.yml` on a PR with an approval; confirm the approval ID appears in the minimize list.
- [ ] On an all-suggestion-threads PR that also has a pending bot summary: the `commit-suggestions` shortcut is suppressed and the standard `rebase-and-push` flow emits the minimize command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)