### PR TITLE
fix(index): surface err.cause when printing fetch errors

### DIFF
--- a/src/index.mock.test.mts
+++ b/src/index.mock.test.mts
@@ -41,4 +41,15 @@ describe("index — error exit", () => {
     expect(stderrSpy).toHaveBeenCalledWith("pr-shepherd error: not an error object\n");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it("appends cause when err.cause is set", async () => {
+    const err = new Error("fetch failed");
+    err.cause = new Error("getaddrinfo ENOTFOUND api.github.com");
+    mockMain.mockRejectedValueOnce(err);
+    await loadIndex();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "pr-shepherd error: fetch failed (cause: Error: getaddrinfo ENOTFOUND api.github.com)\n",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/index.mts
+++ b/src/index.mts
@@ -14,7 +14,14 @@ import { main } from "./cli-parser.mts";
 main(process.argv).catch((err) => {
   const msg = err instanceof Error ? err.message : String(err);
   const cause = err instanceof Error && err.cause != null ? err.cause : null;
-  const causeStr = cause instanceof Error ? `${cause.name}: ${cause.message}` : cause !== null ? String(cause) : null;
-  process.stderr.write(`pr-shepherd error: ${msg}${causeStr !== null ? ` (cause: ${causeStr})` : ""}\n`);
+  const causeStr =
+    cause instanceof Error
+      ? `${cause.name}: ${cause.message}`
+      : cause !== null
+        ? String(cause)
+        : null;
+  process.stderr.write(
+    `pr-shepherd error: ${msg}${causeStr !== null ? ` (cause: ${causeStr})` : ""}\n`,
+  );
   process.exit(1);
 });

--- a/src/index.mts
+++ b/src/index.mts
@@ -12,6 +12,9 @@
 import { main } from "./cli-parser.mts";
 
 main(process.argv).catch((err) => {
-  process.stderr.write(`pr-shepherd error: ${err instanceof Error ? err.message : String(err)}\n`);
+  const msg = err instanceof Error ? err.message : String(err);
+  const cause = err instanceof Error && err.cause != null ? err.cause : null;
+  const causeStr = cause instanceof Error ? `${cause.name}: ${cause.message}` : cause !== null ? String(cause) : null;
+  process.stderr.write(`pr-shepherd error: ${msg}${causeStr !== null ? ` (cause: ${causeStr})` : ""}\n`);
   process.exit(1);
 });

--- a/src/index.mts
+++ b/src/index.mts
@@ -13,13 +13,7 @@ import { main } from "./cli-parser.mts";
 
 main(process.argv).catch((err) => {
   const msg = err instanceof Error ? err.message : String(err);
-  const cause = err instanceof Error && err.cause != null ? err.cause : null;
-  const causeStr =
-    cause instanceof Error
-      ? `${cause.name}: ${cause.message}`
-      : cause !== null
-        ? String(cause)
-        : null;
+  const causeStr = err instanceof Error && err.cause != null ? String(err.cause) : null;
   process.stderr.write(
     `pr-shepherd error: ${msg}${causeStr !== null ? ` (cause: ${causeStr})` : ""}\n`,
   );


### PR DESCRIPTION
## Summary

- `fetch failed` from Node's built-in `fetch()` (undici) is the generic wrapper — the real diagnostic (`ENOTFOUND`, `ECONNRESET`, `ETIMEDOUT`, etc.) lives on `err.cause`, which the top-level catch in `src/index.mts` was silently discarding
- Now appends ` (cause: <ErrorName>: <message>)` to stderr when cause is present, so transient network blips are identifiable in logs
- No behavior change for errors without a cause; no retries added (the 4-min cron cadence handles that)

## Test plan

- [x] `npx vitest run src/index.mock.test.mts` — 3 tests pass (existing 2 + new `err.cause` case)
- [x] `npm run build` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)