### PR TITLE
docs(skills): forbid dead links to docs/** and remove violations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,5 @@ Skills (`plugin/skills/*/SKILL.md`) and `/loop` prompts should be thin dispatche
 Per-action dispatch logic — which command to extract, which tool to call, what variant to run, substitution rules — belongs in the CLI's Markdown output as a `## Instructions` section, not in the skill or the loop prompt.
 
 Rule of thumb: if a skill or loop prompt contains a dispatch table keyed on CLI output shape, that table should live in the CLI's output instead.
+
+Skills must not link to `docs/**` or `README.md`. Those files are not included in the published plugin and will be dead links for consumers. All information a skill consumer needs must come from the CLI output itself or be written inline in the skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,4 +41,4 @@ Per-action dispatch logic — which command to extract, which tool to call, what
 
 Rule of thumb: if a skill or loop prompt contains a dispatch table keyed on CLI output shape, that table should live in the CLI's output instead.
 
-Skills must not link to `docs/**` or `README.md`. Those files are not included in the published plugin and will be dead links for consumers. All information a skill consumer needs must come from the CLI output itself or be written inline in the skill.
+Skills must not link to files outside the `plugin/` directory (such as `docs/**` or `README.md`). Those files are not included in the published plugin and will be dead links for consumers. All information a skill consumer needs must come from the CLI output itself or be written inline in the skill.

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -9,8 +9,6 @@ allowed-tools:
 
 # pr-shepherd monitor — Continuous PR Monitor
 
-> Action reference (all 8 actions, JSON fields, examples): [docs/actions.md](../../../docs/actions.md)
-
 ## Arguments: $ARGUMENTS
 
 ## Resolve PR number
@@ -46,7 +44,7 @@ Run in a single Bash call:
 
 Exit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #<N> [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.
 
-The output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly. See [docs/actions.md](../../../docs/actions.md) for the full output shape of each action.
+The output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.
 
 ```
 


### PR DESCRIPTION
## Summary

- Adds a rule to `CLAUDE.md` banning skills from linking to `docs/**` or `README.md` — those files aren't shipped in the plugin and would be dead links for consumers
- Removes two `docs/actions.md` links from `plugin/skills/monitor/SKILL.md` that violated the rule

## Test plan

- [ ] `grep -rn -E "docs/|README\.md" plugin/` returns no matches
- [ ] `plugin/skills/monitor/SKILL.md` still reads cleanly and the loop prompt block is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)