### PR TITLE
feat: add pre-push hook for lint and typecheck

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Runs before `git push`. Bypass with `git push --no-verify`.
+set -e
+
+echo "pre-push: npm run lint"
+npm run --silent lint
+
+echo "pre-push: npm run typecheck"
+npm run --silent typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ npm install && npm run build
 
 The `bin/` directory is gitignored and must be built before `npx pr-shepherd` works.
 
-`npm install` also registers `.githooks/pre-push` (lint + typecheck) via `git config core.hooksPath .githooks`. Bypass with `git push --no-verify`.
+If no `core.hooksPath` is already configured in the local repo config, `npm install` registers `.githooks/pre-push` (lint + typecheck) via `git config core.hooksPath .githooks`. If `core.hooksPath` is already set locally, the install step is skipped and your existing hooks path takes precedence. Bypass with `git push --no-verify`.
 
 ## Output format invariant
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ npm install && npm run build
 
 The `bin/` directory is gitignored and must be built before `npx pr-shepherd` works.
 
+`npm install` also registers `.githooks/pre-push` (lint + typecheck) via `git config core.hooksPath .githooks`. Bypass with `git push --no-verify`.
+
 ## Output format invariant
 
 `--format=json` and `--format=text` (default) must surface equivalent information. Every field exposed in JSON output should have a corresponding representation in text output, and vice versa. Do not add data to one format without updating the other.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
-    "prepare": "npm run build && node scripts/install-hooks.mjs",
+    "prepare": "node scripts/install-hooks.mjs && npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/ plugin/skills/",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
-    "prepare": "npm run build",
+    "prepare": "npm run build && node scripts/install-hooks.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src/ plugin/skills/",

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -5,4 +5,7 @@ if (process.env.CI) process.exit(0)
 if (!existsSync('.git')) process.exit(0)
 
 const res = spawnSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'inherit' })
-process.exit(res.status ?? 0)
+if (res.status !== 0) {
+  console.warn('Warning: Failed to set git core.hooksPath. Git hooks may not be installed.')
+}
+process.exit(0)

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -4,6 +4,16 @@ import { existsSync } from 'node:fs'
 if (process.env.CI) process.exit(0)
 if (!existsSync('.git')) process.exit(0)
 
+const currentHooksPathRes = spawnSync('git', ['config', '--get', 'core.hooksPath'], { encoding: 'utf8' })
+const currentHooksPath = currentHooksPathRes.status === 0 ? currentHooksPathRes.stdout.trim() : ''
+
+if (currentHooksPath && currentHooksPath !== '.githooks') {
+  console.warn(`Skipping git hooks installation: core.hooksPath is already set to "${currentHooksPath}".`)
+  process.exit(0)
+}
+
+if (currentHooksPath === '.githooks') process.exit(0)
+
 const res = spawnSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'inherit' })
 if (res.status !== 0) {
   console.warn('Warning: Failed to set git core.hooksPath. Git hooks may not be installed.')

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,8 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+if (process.env.CI) process.exit(0)
+if (!existsSync('.git')) process.exit(0)
+
+const res = spawnSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'inherit' })
+process.exit(res.status ?? 0)

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs'
 if (process.env.CI) process.exit(0)
 if (!existsSync('.git')) process.exit(0)
 
-const currentHooksPathRes = spawnSync('git', ['config', '--get', 'core.hooksPath'], { encoding: 'utf8' })
+const currentHooksPathRes = spawnSync('git', ['config', '--local', '--get', 'core.hooksPath'], { encoding: 'utf8' })
 const currentHooksPath = currentHooksPathRes.status === 0 ? currentHooksPathRes.stdout.trim() : ''
 
 if (currentHooksPath && currentHooksPath !== '.githooks') {


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-push` — a POSIX `#!/bin/sh` script that runs `npm run lint` and `npm run typecheck` before every push (blocks on failure; bypass with `git push --no-verify`)
- Adds `scripts/install-hooks.mjs` — registers `core.hooksPath=.githooks` via `git config`; skips in CI (`CI` env var) and outside a git repo (npm consumers)
- Extends `prepare` to chain `node scripts/install-hooks.mjs` so `npm install` auto-registers the hook path
- Updates `CLAUDE.md` setup section to document the hook

Cross-OS: `#!/bin/sh` runs natively on macOS/Linux and via Git Bash on Windows — same approach used by husky and simple-git-hooks.

## Test plan

- [x] `npm install` → `git config --get core.hooksPath` returns `.githooks`
- [x] `git push` fires the hook and prints both lint/typecheck steps (verified during this PR push)
- [ ] `git push --no-verify` skips the hook
- [ ] Introduce a lint error, push → hook blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)