### PR TITLE
feat(iterate): surface all CI checks; agent-side rerun; ##[error] excerpts

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -14,6 +14,12 @@ The default output format is Markdown — what you see when running `npx pr-shep
 **status** `<…>` · **merge** `<…>` · **state** `<…>` · **repo** `<…>`
 **summary** <N> passing, <N> skipped, <N> filtered, <N> inProgress · **remainingSeconds** <N> · **copilotReviewInProgress** <bool> · **isDraft** <bool> · **shouldCancel** <bool>
 
+## Checks
+
+- ✓ `<name>` — SUCCESS
+- ✗ `<name>` (<failureKind>) — <conclusion> · `<runId>`
+  > <errorExcerpt line>
+
 <action-specific body>
 
 ## Instructions
@@ -28,6 +34,7 @@ Load-bearing conventions (the monitor SKILL depends on these):
 3. Every action ends with a `## Instructions` section — numbered `1.`, `2.`, … — that tells the monitor exactly what to do. The monitor follows those steps; it does not need its own dispatch table.
 4. Under `[REBASE]`, the shell script is inside a ```bash fenced block — instruction 1 tells the monitor to extract and run it.
 5. Under `[FIX_CODE]`, the `## Post-fix push` section has a `` resolve: `<command>` `` bullet — the instructions reference this bullet so the monitor strips backticks and runs the command.
+6. `## Checks` appears immediately after the base fields in every action where checks were fetched (all actions except `cooldown`). It lists every completed, non-skipped PR CI check — passing entries with ✓, failing entries with ✗ plus `failureKind` and a short `errorExcerpt`. The section is omitted when there are no checks (e.g. during `cooldown` or when the PR has no CI configured). JSON surfaces the same data as `checks: RelevantCheck[]` on the base object.
 
 ---
 
@@ -95,11 +102,11 @@ The body line (`WAIT: …`) varies with the merge state — `branch is behind ba
 
 ## `rerun_ci`
 
-Re-triggers CI runs that failed due to transient infrastructure or timeout issues.
+Surfaces CI runs that failed due to transient infrastructure or timeout issues, and instructs the agent to re-trigger them.
 
 **Trigger:** One or more failing checks have `failureKind === "timeout"` or `"infrastructure"`, and no actionable work was found (evaluated after step 4).
 
-**CLI side-effects:** Calls `gh run rerun <runId> --failed` for each unique run ID. Deduplicates — multiple failed steps sharing a run ID produce one rerun call.
+**CLI side-effects:** None. The CLI emits the list of run IDs that need a rerun; the agent runs `gh run rerun <runId> --failed` for each one. Deduplicates — multiple failed steps sharing a run ID produce one rerun entry.
 
 **Exit code:** 0
 
@@ -111,16 +118,23 @@ Re-triggers CI runs that failed due to transient infrastructure or timeout issue
 **status** `FAILING` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 0 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
 
-RERAN 2 CI runs: 24697658766 (lint / typecheck / test (22.x) — timeout), 24697658767 (build — infrastructure)
+## Checks
+
+- ✗ `lint / typecheck / test (22.x)` (timeout) — TIMED_OUT · `24697658766`
+- ✗ `build` (infrastructure) — CANCELLED · `24697658767`
+
+RERUN NEEDED — 2 CI runs: 24697658766 (lint / typecheck / test (22.x) — timeout), 24697658767 (build — infrastructure)
 
 ## Instructions
 
-1. The CLI already triggered the re-run above — end this iteration and wait for CI to report results.
+1. Run: `gh run rerun 24697658766 --failed`
+2. Run: `gh run rerun 24697658767 --failed`
+3. End this iteration — wait for CI to report results after the re-run.
 ```
 
 Each comma-separated entry on the body line has shape `<runId> (<check names joined by ", "> — <failureKind>)`. JSON surfaces the same information as `reran: ReranRun[]`.
 
-**What the monitor does:** Follow `## Instructions` — end the iteration and wait for CI to re-queue.
+**What the monitor does:** Follow `## Instructions` — run `gh run rerun <runId> --failed` for each listed run ID, then end the iteration and wait for CI to re-queue.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,7 @@ Character cap applied after the line limit. The excerpt is trimmed to the last N
 
 Number of trailing `##[error]`-marked lines to surface per failing check as `errorExcerpt`. These are the red "Error:" lines GitHub Actions renders in its log viewer. The excerpt is shown under each failing check in the `## Checks` section of every iterate action.
 
-- Falls back to the last N raw log lines when no `##[error]` markers are found (e.g. external status checks that don't use workflow commands).
+- Falls back to the last N raw log lines for fetched GitHub Actions logs when no `##[error]` markers are found (for example, jobs that do not emit workflow commands). Checks without a `runId` do not have fetched logs, so they will not have an `errorExcerpt`.
 - Set higher (e.g. `3`) for checks that emit multi-line error summaries across several `##[error]` lines.
 - The window is taken from within the `logMaxLines`/`logMaxChars` slice, so raising `errorLines` beyond that window has no effect.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ checks:
     - ECONNRESET
   logMaxLines: 50
   logMaxChars: 3000
+  errorLines: 1
 
 mergeStatus:
   blockingReviewerLogins:
@@ -210,6 +211,14 @@ The last N lines of each failing check's log are kept for triage. Larger values 
 ### `checks.logMaxChars` — default `3000`
 
 Character cap applied after the line limit. The excerpt is trimmed to the last N characters. Combined with `logMaxLines`, this bounds the payload size.
+
+### `checks.errorLines` — default `1`
+
+Number of trailing `##[error]`-marked lines to surface per failing check as `errorExcerpt`. These are the red "Error:" lines GitHub Actions renders in its log viewer. The excerpt is shown under each failing check in the `## Checks` section of every iterate action.
+
+- Falls back to the last N raw log lines when no `##[error]` markers are found (e.g. external status checks that don't use workflow commands).
+- Set higher (e.g. `3`) for checks that emit multi-line error summaries across several `##[error]` lines.
+- The window is taken from within the `logMaxLines`/`logMaxChars` slice, so raising `errorLines` beyond that window has no effect.
 
 ---
 

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -99,7 +99,7 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 
 **Check:** any failing check has `failureKind === 'timeout'` or `failureKind === 'infrastructure'`, and no actionable work, no conflicts.
 
-**Side-effects:** `gh run rerun <runId> --failed` for each unique run ID.
+**Side-effects:** None — the CLI reports the run IDs that need a rerun; the agent executes `gh run rerun <runId> --failed` for each unique run ID as instructed by `## Instructions`.
 
 **Emits:** `action: 'rerun_ci'`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -163,7 +163,6 @@ Flags:
 | `--ready-delay Nm`            | `10m`   | Settle window before the loop cancels after READY |
 | `--cooldown-seconds N`        | `30`    | Wait after a push before reading CI               |
 | `--last-push-time N`          | —       | Unix timestamp hint embedded in the result        |
-| `--no-auto-rerun`             | false   | Return `wait` instead of rerunning transient CI   |
 | `--no-auto-mark-ready`        | false   | Skip converting draft → ready-for-review          |
 | `--no-auto-cancel-actionable` | false   | Skip cancelling actionable failing runs           |
 

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -294,4 +294,13 @@ describe("extractErrorLines", () => {
   it("returns empty string when logs are all whitespace", () => {
     expect(extractErrorLines("   \n  \n  ", 1)).toBe("");
   });
+
+  it("falls back to last real line when logs end with a trailing newline", () => {
+    // split("\n") on "last line\n" yields ["last line", ""] — filter(Boolean) removes the empty tail
+    expect(extractErrorLines("first line\nlast line\n", 1)).toBe("last line");
+  });
+
+  it("returns empty string when maxLines is 0", () => {
+    expect(extractErrorLines("some output\n##[error]Error: boom", 0)).toBe("");
+  });
 });

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -270,11 +270,9 @@ describe("extractErrorLines", () => {
   });
 
   it("returns up to maxLines ##[error] lines when multiple exist", () => {
-    const logs = [
-      "##[error]Error: first",
-      "##[error]Error: second",
-      "##[error]Error: third",
-    ].join("\n");
+    const logs = ["##[error]Error: first", "##[error]Error: second", "##[error]Error: third"].join(
+      "\n",
+    );
     expect(extractErrorLines(logs, 2)).toBe("Error: second\nError: third");
     expect(extractErrorLines(logs, 3)).toBe("Error: first\nError: second\nError: third");
   });

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { triageFailingChecks } from "./triage.mts";
+import { triageFailingChecks, extractErrorLines } from "./triage.mts";
 import type { ClassifiedCheck } from "../types.mts";
 
 const REPO = { owner: "owner", name: "repo" };
@@ -221,5 +221,79 @@ describe("triageFailingChecks — batch", () => {
     expect(results).toHaveLength(2);
     expect(results[0]!.failureKind).toBe("actionable");
     expect(results[1]!.failureKind).toBe("infrastructure");
+  });
+});
+
+describe("triageFailingChecks — errorExcerpt", () => {
+  it("extracts ##[error]-marked line and strips prefix", async () => {
+    setupFetch("some output\n##[error]Error: test failed\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
+    expect(result!.errorExcerpt).toBe("Error: test failed");
+  });
+
+  it("strips timestamp + ##[error] prefix from error lines", async () => {
+    setupFetch("2026-04-23T09:53:06.123Z ##[error]AssertionError: expected 42 to equal 43\n");
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
+    expect(result!.errorExcerpt).toBe("AssertionError: expected 42 to equal 43");
+  });
+
+  it("falls back to last raw log line when no ##[error] markers exist", async () => {
+    setupFetch("first line\nsecond line\nlast line"); // no trailing newline so "last line" is last element
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
+    // default errorLines=1 → last non-empty line
+    expect(result!.errorExcerpt).toBe("last line");
+  });
+
+  it("returns undefined errorExcerpt when runId is null (no logs fetched)", async () => {
+    const check = makeCheck({ runId: null });
+    const [result] = await triageFailingChecks([check], REPO);
+    expect(result!.errorExcerpt).toBeUndefined();
+  });
+
+  it("returns undefined errorExcerpt when log fetch returns empty string", async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(500));
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
+    expect(result!.errorExcerpt).toBeUndefined();
+  });
+});
+
+describe("extractErrorLines", () => {
+  it("returns last ##[error]-marked line with prefix stripped (maxLines=1)", () => {
+    const logs = [
+      "build output line",
+      "##[error]Error: first error",
+      "more output",
+      "##[error]Error: second error",
+      "##[error]Error: third error",
+    ].join("\n");
+    expect(extractErrorLines(logs, 1)).toBe("Error: third error");
+  });
+
+  it("returns up to maxLines ##[error] lines when multiple exist", () => {
+    const logs = [
+      "##[error]Error: first",
+      "##[error]Error: second",
+      "##[error]Error: third",
+    ].join("\n");
+    expect(extractErrorLines(logs, 2)).toBe("Error: second\nError: third");
+    expect(extractErrorLines(logs, 3)).toBe("Error: first\nError: second\nError: third");
+  });
+
+  it("strips ISO timestamp prefix before ##[error]", () => {
+    const logs = "2026-04-23T09:53:06.123Z ##[error]Error: timed out waiting";
+    expect(extractErrorLines(logs, 1)).toBe("Error: timed out waiting");
+  });
+
+  it("falls back to last N raw lines when no ##[error] markers exist", () => {
+    const logs = "line one\nline two\nline three\nline four";
+    expect(extractErrorLines(logs, 2)).toBe("line three\nline four");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(extractErrorLines("", 1)).toBe("");
+  });
+
+  it("returns empty string when logs are all whitespace", () => {
+    expect(extractErrorLines("   \n  \n  ", 1)).toBe("");
   });
 });

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -50,8 +50,7 @@ async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<Tria
   const logExcerpt = await fetchFailedLogs(check.runId, repo);
   const failureKind = classifyLogs(check, logExcerpt);
   const boundedLogExcerpt = logExcerpt.slice(-config.checks.logMaxChars);
-  const errorExcerpt =
-    extractErrorLines(boundedLogExcerpt, config.checks.errorLines) || undefined;
+  const errorExcerpt = extractErrorLines(boundedLogExcerpt, config.checks.errorLines) || undefined;
 
   return {
     ...check,

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -49,12 +49,14 @@ async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<Tria
 
   const logExcerpt = await fetchFailedLogs(check.runId, repo);
   const failureKind = classifyLogs(check, logExcerpt);
-  const errorExcerpt = extractErrorLines(logExcerpt, config.checks.errorLines) || undefined;
+  const boundedLogExcerpt = logExcerpt.slice(-config.checks.logMaxChars);
+  const errorExcerpt =
+    extractErrorLines(boundedLogExcerpt, config.checks.errorLines) || undefined;
 
   return {
     ...check,
     failureKind,
-    logExcerpt: logExcerpt.slice(-config.checks.logMaxChars) || undefined,
+    logExcerpt: boundedLogExcerpt || undefined,
     errorExcerpt,
   };
 }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -118,12 +118,14 @@ async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
  * stripping the workflow-command prefix and any leading timestamp.
  *
  * Falls back to the last `maxLines` raw lines when no `##[error]` markers are found
- * (some checks don't emit workflow commands — e.g. external status checks).
+ * (for example, jobs that do not emit workflow commands). Checks without a `runId`
+ * do not have fetched logs, so they will not have an `errorExcerpt`.
  */
 export function extractErrorLines(logs: string, maxLines: number): string {
+  if (maxLines <= 0) return "";
   const lines = logs.split("\n");
   const errorLines = lines.filter((l) => ERROR_MARKER_RE.test(l));
-  const source = errorLines.length > 0 ? errorLines : lines;
+  const source = errorLines.length > 0 ? errorLines : lines.filter(Boolean);
   const tail = source.slice(-maxLines);
   return tail
     .map((l) => {

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -18,6 +18,10 @@ const config = loadConfig();
 const TIMEOUT_PATTERNS = config.checks.timeoutPatterns.map((p) => new RegExp(p, "i"));
 const INFRA_PATTERNS = config.checks.infraPatterns.map((p) => new RegExp(p, "i"));
 
+// Matches GitHub Actions workflow-command error markers: `##[error]...`
+// May be preceded by a timestamp: `2026-04-23T09:53:06.123Z ##[error]Error: foo`
+const ERROR_MARKER_RE = /##\[error\]/;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -45,11 +49,13 @@ async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<Tria
 
   const logExcerpt = await fetchFailedLogs(check.runId, repo);
   const failureKind = classifyLogs(check, logExcerpt);
+  const errorExcerpt = extractErrorLines(logExcerpt, config.checks.errorLines) || undefined;
 
   return {
     ...check,
     failureKind,
     logExcerpt: logExcerpt.slice(-config.checks.logMaxChars) || undefined,
+    errorExcerpt,
   };
 }
 
@@ -105,6 +111,28 @@ async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
   } catch {
     return "";
   }
+}
+
+/**
+ * Extract the last `maxLines` `##[error]`-marked lines from GitHub Actions logs,
+ * stripping the workflow-command prefix and any leading timestamp.
+ *
+ * Falls back to the last `maxLines` raw lines when no `##[error]` markers are found
+ * (some checks don't emit workflow commands — e.g. external status checks).
+ */
+export function extractErrorLines(logs: string, maxLines: number): string {
+  const lines = logs.split("\n");
+  const errorLines = lines.filter((l) => ERROR_MARKER_RE.test(l));
+  const source = errorLines.length > 0 ? errorLines : lines;
+  const tail = source.slice(-maxLines);
+  return tail
+    .map((l) => {
+      // Strip optional timestamp + `##[error]` prefix:
+      // "2026-04-23T09:53:06.123Z ##[error]Error: foo" → "Error: foo"
+      return l.replace(/^[^\s]*\s*##\[error\]/, "").trim();
+    })
+    .filter(Boolean)
+    .join("\n");
 }
 
 function classifyLogs(check: ClassifiedCheck, logs: string): FailureKind {

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -129,7 +129,7 @@ export function extractErrorLines(logs: string, maxLines: number): string {
     .map((l) => {
       // Strip optional timestamp + `##[error]` prefix:
       // "2026-04-23T09:53:06.123Z ##[error]Error: foo" → "Error: foo"
-      return l.replace(/^[^\s]*\s*##\[error\]/, "").trim();
+      return l.replace(/^.*##\[error\]/, "").trim();
     })
     .filter(Boolean)
     .join("\n");

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -92,6 +92,7 @@ function makeIterateResult(action: IterateResult["action"] = "wait"): IterateRes
     remainingSeconds: 60,
     summary: { passing: 0, skipped: 0, filtered: 0, inProgress: 1 },
     baseBranch: "main",
+    checks: [] as import("./types.mts").RelevantCheck[],
   };
   if (action === "cooldown") return { ...base, action: "cooldown", log: "SKIP: CI still starting" };
   if (action === "wait") return { ...base, action: "wait", log: "WAIT: 0 passing, 1 in-progress" };
@@ -438,14 +439,18 @@ describe("main — iterate text format", () => {
     expect(out).toContain("1. End this iteration");
   });
 
-  it("rerun_ci: heading includes [RERUN_CI] tag, log, and ## Instructions with re-run note", async () => {
-    mockRunIterate.mockResolvedValue(makeIterateResult("rerun_ci"));
+  it("rerun_ci: heading includes [RERUN_CI] tag, log, and ## Instructions with gh run rerun", async () => {
+    mockRunIterate.mockResolvedValue({
+      ...makeIterateResult("rerun_ci"),
+      log: "RERUN NEEDED — 1 CI run: run-99 (typecheck — timeout)",
+      reran: [{ runId: "run-99", checkNames: ["typecheck"], failureKind: "timeout" }],
+    } as IterateResult);
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain("# PR #42 [RERUN_CI]");
-    expect(out).toContain("RERAN: run-99 (typecheck — transient)");
+    expect(out).toContain("RERUN NEEDED");
     expect(out).toContain("## Instructions");
-    expect(out).toContain("1. The CLI already triggered the re-run above");
+    expect(out).toContain("gh run rerun run-99 --failed");
   });
 
   it("mark_ready: heading includes [MARK_READY] tag and ## Instructions with end-iteration step", async () => {

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -836,6 +836,57 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42"]);
     expect(getStdout()).not.toContain("## Checks");
   });
+
+  it("## Checks section renders in rerun_ci, mark_ready, cancel, rebase, escalate, fix_code when checks is non-empty", async () => {
+    const passingCheck: import("./types.mts").RelevantCheck = {
+      name: "lint",
+      conclusion: "SUCCESS",
+      runId: "run-1",
+      detailsUrl: null,
+    };
+    // Test each action that had an uncovered checksSection TRUE branch.
+    for (const action of [
+      "rerun_ci",
+      "mark_ready",
+      "cancel",
+      "rebase",
+      "escalate",
+      "fix_code",
+    ] as const) {
+      const result = makeIterateResult(action);
+      result.checks = [passingCheck];
+      mockRunIterate.mockResolvedValue(result as IterateResult);
+      await main(["node", "shepherd", "iterate", "42"]);
+      const out = getStdout();
+      expect(out).toContain("## Checks");
+      expect(out).toContain("- ✓ `lint` — SUCCESS");
+    }
+  });
+
+  it("## Checks — failing check with no failureKind omits kind suffix", async () => {
+    const result = makeIterateResult("wait");
+    result.checks = [
+      {
+        name: "external-check",
+        conclusion: "FAILURE",
+        runId: null,
+        detailsUrl: "https://example.com",
+        // no failureKind — exercises the `c.failureKind ? ...` false branch
+      } as import("./types.mts").RelevantCheck,
+    ];
+    mockRunIterate.mockResolvedValue(result);
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    // No kind suffix in parens when failureKind is absent
+    expect(out).toContain("- ✗ `external-check` — FAILURE · external `https://example.com`");
+    expect(out).not.toContain("(undefined)");
+  });
+
+  it("iterate --cooldown-seconds passes parsed value to runIterate", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+    await main(["node", "shepherd", "iterate", "42", "--cooldown-seconds", "120"]);
+    expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ cooldownSeconds: 120 }));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -764,6 +764,78 @@ describe("main — iterate text format", () => {
     expect(text).toContain(`${result.summary.inProgress} inProgress`);
     expect(text).toContain(`**remainingSeconds** ${result.remainingSeconds}`);
   });
+
+  it("## Checks section renders in wait/cancel/rerun_ci actions when checks is non-empty", async () => {
+    const result = makeIterateResult("wait");
+    result.checks = [
+      {
+        name: "lint",
+        conclusion: "SUCCESS",
+        runId: "run-1",
+        detailsUrl: "https://github.com/owner/repo/actions/runs/1",
+      },
+      {
+        name: "test",
+        conclusion: "FAILURE",
+        runId: "run-2",
+        detailsUrl: "https://github.com/owner/repo/actions/runs/2",
+        failureKind: "actionable",
+        errorExcerpt: "AssertionError: expected 1 to equal 2",
+      },
+    ] as import("./types.mts").RelevantCheck[];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+
+    // ## Checks section present before ## Instructions
+    const checksIdx = out.indexOf("## Checks");
+    const instrIdx = out.indexOf("## Instructions");
+    expect(checksIdx).toBeGreaterThan(-1);
+    expect(instrIdx).toBeGreaterThan(checksIdx);
+
+    // Passing check: ✓ bullet
+    expect(out).toContain("- ✓ `lint` — SUCCESS");
+    // Failing check: ✗ bullet with failureKind, conclusion, runId
+    expect(out).toContain("- ✗ `test` (actionable) — FAILURE · `run-2`");
+    // errorExcerpt rendered as blockquote
+    expect(out).toContain("  > AssertionError: expected 1 to equal 2");
+  });
+
+  it("## Checks — external detailsUrl renders `external` prefix; no-ID renders `(no runId)`", async () => {
+    const result = makeIterateResult("wait");
+    result.checks = [
+      {
+        name: "codecov/patch",
+        conclusion: "FAILURE",
+        runId: null,
+        detailsUrl: "https://app.codecov.io/gh/owner/repo/pull/42",
+        failureKind: "actionable",
+      },
+      {
+        name: "mystery",
+        conclusion: "FAILURE",
+        runId: null,
+        detailsUrl: null,
+        failureKind: "infrastructure",
+      },
+    ] as import("./types.mts").RelevantCheck[];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+
+    expect(out).toContain(
+      "- ✗ `codecov/patch` (actionable) — FAILURE · external `https://app.codecov.io/gh/owner/repo/pull/42`",
+    );
+    expect(out).toContain("- ✗ `mystery` (infrastructure) — FAILURE · (no runId)");
+  });
+
+  it("## Checks section is absent when checks is empty (cooldown keeps no-checks invariant)", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cooldown")); // checks: []
+    await main(["node", "shepherd", "iterate", "42"]);
+    expect(getStdout()).not.toContain("## Checks");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -10,7 +10,7 @@
  *   pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [--description DESC]
  *                                      [--format text|json]
  *   pr-shepherd iterate [PR] [--format text|json] [--cooldown-seconds N] [--ready-delay Nm] [--last-push-time N]
- *                              [--stall-timeout <duration>] [--no-auto-rerun] [--no-auto-mark-ready]
+ *                              [--stall-timeout <duration>] [--no-auto-mark-ready]
  *                              [--no-auto-cancel-actionable]
  *   pr-shepherd status PR1 [PR2 …]
  */
@@ -193,7 +193,6 @@ async function handleIterate(args: string[]): Promise<void> {
   const cooldownSeconds = cooldownSecondsStr
     ? parseIntStrict(cooldownSecondsStr, "--cooldown-seconds")
     : cfg.iterate.cooldownSeconds;
-  const noAutoRerun = hasFlag(extra, "--no-auto-rerun");
   const noAutoMarkReady = hasFlag(extra, "--no-auto-mark-ready");
   const noAutoCancelActionable = hasFlag(extra, "--no-auto-cancel-actionable");
   const stallTimeoutStr = getFlag(extra, "--stall-timeout");
@@ -208,7 +207,6 @@ async function handleIterate(args: string[]): Promise<void> {
     readyDelaySeconds,
     cooldownSeconds,
     stallTimeoutSeconds,
-    noAutoRerun,
     noAutoMarkReady,
     noAutoCancelActionable,
   });
@@ -380,6 +378,7 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
   const baseLine = `**status** \`${result.status}\` · **merge** \`${result.mergeStateStatus}\` · **state** \`${result.state}\` · **repo** \`${result.repo}\``;
   const summaryLine = `**summary** ${result.summary.passing} passing, ${result.summary.skipped} skipped, ${result.summary.filtered} filtered, ${result.summary.inProgress} inProgress · **remainingSeconds** ${result.remainingSeconds} · **copilotReviewInProgress** ${result.copilotReviewInProgress} · **isDraft** ${result.isDraft} · **shouldCancel** ${result.shouldCancel}`;
   const header = [heading, "", baseLine, summaryLine].join("\n");
+  const checksSection = formatChecksSection(result.checks);
 
   switch (result.action) {
     case "cooldown":
@@ -393,27 +392,21 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
         "1. End this iteration — the next cron fire will recheck once CI starts reporting.",
       ].join("\n");
 
-    case "wait":
-      return [
-        header,
-        "",
-        result.log,
-        "",
-        "## Instructions",
-        "",
-        "1. End this iteration — the next cron fire will recheck.",
-      ].join("\n");
+    case "wait": {
+      const parts = [header];
+      if (checksSection) parts.push(checksSection);
+      parts.push(result.log, "", "## Instructions", "", "1. End this iteration — the next cron fire will recheck.");
+      return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
+    }
 
-    case "rerun_ci":
-      return [
-        header,
-        "",
-        result.log,
-        "",
-        "## Instructions",
-        "",
-        "1. The CLI already triggered the re-run above — end this iteration and wait for CI to report results.",
-      ].join("\n");
+    case "rerun_ci": {
+      const rerunInstructions = result.reran.map((r, i) => `${i + 1}. Run: \`gh run rerun ${r.runId} --failed\``);
+      rerunInstructions.push(`${rerunInstructions.length + 1}. End this iteration — wait for CI to report results after the re-run.`);
+      const parts = [header];
+      if (checksSection) parts.push(checksSection);
+      parts.push(result.log, "", "## Instructions", "", rerunInstructions.join("\n"));
+      return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
+    }
 
     case "mark_ready":
       return [
@@ -426,33 +419,24 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
         "1. The CLI already marked the PR ready for review — end this iteration.",
       ].join("\n");
 
-    case "cancel":
-      return [
-        header,
-        "",
-        result.log,
-        "",
-        "## Instructions",
-        "",
-        "1. Invoke `/loop cancel` via the Skill tool.",
-        "2. Stop.",
-      ].join("\n");
+    case "cancel": {
+      const parts = [header];
+      if (checksSection) parts.push(checksSection);
+      parts.push(result.log, "", "## Instructions", "", "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.");
+      return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
+    }
 
-    case "rebase":
-      return [
-        header,
-        "",
+    case "rebase": {
+      const parts = [header];
+      if (checksSection) parts.push(checksSection);
+      parts.push(
         result.rebase.reason,
-        "",
-        "```bash",
-        result.rebase.shellScript,
-        "```",
-        "",
+        "```bash\n" + result.rebase.shellScript + "\n```",
         "## Instructions",
-        "",
-        "1. Copy the shell script from the ` ```bash ` block above and run it in Bash.",
-        "2. End this iteration — the next cron fire will check CI after the rebase.",
-      ].join("\n");
+        "1. Copy the shell script from the ` ```bash ` block above and run it in Bash.\n2. End this iteration — the next cron fire will check CI after the rebase.",
+      );
+      return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
+    }
 
     case "escalate":
       return [
@@ -467,15 +451,41 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       ].join("\n");
 
     case "fix_code":
-      return formatFixCodeResult(header, result);
+      return formatFixCodeResult(header, checksSection, result);
   }
+}
+
+function formatChecksSection(checks: import("./types.mts").RelevantCheck[]): string | null {
+  if (checks.length === 0) return null;
+  const lines: string[] = ["## Checks", ""];
+  for (const c of checks) {
+    if (c.conclusion === "SUCCESS") {
+      lines.push(`- ✓ \`${c.name}\` — SUCCESS`);
+    } else {
+      const kind = c.failureKind ? ` (${c.failureKind})` : "";
+      const locator = c.runId
+        ? `\`${c.runId}\``
+        : c.detailsUrl
+          ? `\`${c.detailsUrl}\``
+          : "(no ID)";
+      lines.push(`- ✗ \`${c.name}\`${kind} — ${c.conclusion} · ${locator}`);
+      if (c.errorExcerpt) {
+        for (const eLine of c.errorExcerpt.split("\n")) {
+          lines.push(`  > ${eLine}`);
+        }
+      }
+    }
+  }
+  return lines.join("\n");
 }
 
 function formatFixCodeResult(
   header: string,
+  checksSection: string | null,
   result: import("./types.mts").IterateResultFixCode,
 ): string {
   const sections: string[] = [header];
+  if (checksSection) sections.push(checksSection);
 
   if (result.fix.threads.length > 0) {
     sections.push("## Review threads");

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -397,9 +397,7 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       if (checksSection) parts.push(checksSection);
       parts.push(
         result.log,
-        "",
         "## Instructions",
-        "",
         "1. End this iteration — the next cron fire will recheck.",
       );
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
@@ -414,7 +412,7 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       );
       const parts = [header];
       if (checksSection) parts.push(checksSection);
-      parts.push(result.log, "", "## Instructions", "", rerunInstructions.join("\n"));
+      parts.push(result.log, "## Instructions", rerunInstructions.join("\n"));
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
     }
 
@@ -423,9 +421,7 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       if (checksSection) parts.push(checksSection);
       parts.push(
         result.log,
-        "",
         "## Instructions",
-        "",
         "1. The CLI already marked the PR ready for review — end this iteration.",
       );
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
@@ -436,9 +432,7 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       if (checksSection) parts.push(checksSection);
       parts.push(
         result.log,
-        "",
         "## Instructions",
-        "",
         "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.",
       );
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
@@ -461,9 +455,7 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       if (checksSection) parts.push(checksSection);
       parts.push(
         result.escalate.humanMessage,
-        "",
         "## Instructions",
-        "",
         "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop — the PR needs human direction before monitoring can resume.",
       );
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
@@ -482,7 +474,11 @@ function formatChecksSection(checks: import("./types.mts").RelevantCheck[]): str
       lines.push(`- ✓ \`${c.name}\` — SUCCESS`);
     } else {
       const kind = c.failureKind ? ` (${c.failureKind})` : "";
-      const locator = c.runId ? `\`${c.runId}\`` : c.detailsUrl ? `\`${c.detailsUrl}\`` : "(no ID)";
+      const locator = c.runId
+        ? `\`${c.runId}\``
+        : c.detailsUrl
+          ? `external \`${c.detailsUrl}\``
+          : "(no runId)";
       lines.push(`- ✗ \`${c.name}\`${kind} — ${c.conclusion} · ${locator}`);
       if (c.errorExcerpt) {
         for (const eLine of c.errorExcerpt.split("\n")) {

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -395,13 +395,23 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
     case "wait": {
       const parts = [header];
       if (checksSection) parts.push(checksSection);
-      parts.push(result.log, "", "## Instructions", "", "1. End this iteration — the next cron fire will recheck.");
+      parts.push(
+        result.log,
+        "",
+        "## Instructions",
+        "",
+        "1. End this iteration — the next cron fire will recheck.",
+      );
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
     }
 
     case "rerun_ci": {
-      const rerunInstructions = result.reran.map((r, i) => `${i + 1}. Run: \`gh run rerun ${r.runId} --failed\``);
-      rerunInstructions.push(`${rerunInstructions.length + 1}. End this iteration — wait for CI to report results after the re-run.`);
+      const rerunInstructions = result.reran.map(
+        (r, i) => `${i + 1}. Run: \`gh run rerun ${r.runId} --failed\``,
+      );
+      rerunInstructions.push(
+        `${rerunInstructions.length + 1}. End this iteration — wait for CI to report results after the re-run.`,
+      );
       const parts = [header];
       if (checksSection) parts.push(checksSection);
       parts.push(result.log, "", "## Instructions", "", rerunInstructions.join("\n"));
@@ -422,7 +432,13 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
     case "cancel": {
       const parts = [header];
       if (checksSection) parts.push(checksSection);
-      parts.push(result.log, "", "## Instructions", "", "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.");
+      parts.push(
+        result.log,
+        "",
+        "## Instructions",
+        "",
+        "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.",
+      );
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
     }
 
@@ -463,11 +479,7 @@ function formatChecksSection(checks: import("./types.mts").RelevantCheck[]): str
       lines.push(`- ✓ \`${c.name}\` — SUCCESS`);
     } else {
       const kind = c.failureKind ? ` (${c.failureKind})` : "";
-      const locator = c.runId
-        ? `\`${c.runId}\``
-        : c.detailsUrl
-          ? `\`${c.detailsUrl}\``
-          : "(no ID)";
+      const locator = c.runId ? `\`${c.runId}\`` : c.detailsUrl ? `\`${c.detailsUrl}\`` : "(no ID)";
       lines.push(`- ✗ \`${c.name}\`${kind} — ${c.conclusion} · ${locator}`);
       if (c.errorExcerpt) {
         for (const eLine of c.errorExcerpt.split("\n")) {

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -418,16 +418,18 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
     }
 
-    case "mark_ready":
-      return [
-        header,
-        "",
+    case "mark_ready": {
+      const parts = [header];
+      if (checksSection) parts.push(checksSection);
+      parts.push(
         result.log,
         "",
         "## Instructions",
         "",
         "1. The CLI already marked the PR ready for review — end this iteration.",
-      ].join("\n");
+      );
+      return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
+    }
 
     case "cancel": {
       const parts = [header];
@@ -454,17 +456,18 @@ function formatIterateResult(result: import("./types.mts").IterateResult): strin
       return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
     }
 
-    case "escalate":
-      return [
-        header,
-        "",
+    case "escalate": {
+      const parts = [header];
+      if (checksSection) parts.push(checksSection);
+      parts.push(
         result.escalate.humanMessage,
         "",
         "## Instructions",
         "",
-        "1. Invoke `/loop cancel` via the Skill tool.",
-        "2. Stop — the PR needs human direction before monitoring can resume.",
-      ].join("\n");
+        "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop — the PR needs human direction before monitoring can resume.",
+      );
+      return parts.join("\n\n").replace(/\n\n\n+/g, "\n\n");
+    }
 
     case "fix_code":
       return formatFixCodeResult(header, checksSection, result);

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -39,7 +39,6 @@ vi.mock("../github/client.mts", () => ({
   getCurrentPrNumber: vi.fn().mockResolvedValue(42),
 }));
 
-
 vi.mock("../cache/fix-attempts.mts", () => ({
   readFixAttempts: vi.fn().mockResolvedValue(null),
   writeFixAttempts: vi.fn().mockResolvedValue(undefined),

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -3003,4 +3003,43 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
     expect(result.action).toBe("wait");
     expect(result.checks).toEqual([]);
   });
+
+  it("passing check with null detailsUrl maps to detailsUrl: null in base.checks", async () => {
+    // Exercises the `c.detailsUrl || null` false branch in buildRelevantChecks when
+    // detailsUrl is null (StatusContext checks have no detailsUrl).
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        checks: {
+          passing: [
+            {
+              name: "status-check",
+              status: "COMPLETED" as const,
+              conclusion: "SUCCESS" as const,
+              detailsUrl: null as unknown as string,
+              event: null,
+              runId: null,
+              category: "passed" as const,
+            },
+          ],
+          failing: [],
+          inProgress: [],
+          skipped: [],
+          filtered: [],
+          filteredNames: [],
+          blockedByFilteredCheck: false,
+        },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: false,
+      remainingSeconds: 300,
+    });
+
+    const result = await runIterate(makeOpts({ noAutoMarkReady: true }));
+
+    expect(result.action).toBe("wait");
+    expect(result.checks).toHaveLength(1);
+    expect(result.checks[0]!.detailsUrl).toBeNull();
+  });
 });

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -39,10 +39,6 @@ vi.mock("../github/client.mts", () => ({
   getCurrentPrNumber: vi.fn().mockResolvedValue(42),
 }));
 
-vi.mock("../checks/triage.mts", () => ({
-  // Pass checks through unchanged — failureKind is pre-set by test fixtures.
-  triageFailingChecks: vi.fn((checks: unknown[]) => Promise.resolve(checks)),
-}));
 
 vi.mock("../cache/fix-attempts.mts", () => ({
   readFixAttempts: vi.fn().mockResolvedValue(null),
@@ -60,7 +56,6 @@ vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 import { runIterate, renderResolveCommand } from "./iterate.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
-import { triageFailingChecks } from "../checks/triage.mts";
 import { readFixAttempts, writeFixAttempts } from "../cache/fix-attempts.mts";
 import { readStallState, writeStallState, type StallState } from "../cache/iterate-stall.mts";
 import type { ShepherdReport, IterateCommandOptions } from "../types.mts";
@@ -71,7 +66,6 @@ import type { ShepherdReport, IterateCommandOptions } from "../types.mts";
 
 const mockRunCheck = vi.mocked(runCheck);
 const mockUpdateReadyDelay = vi.mocked(updateReadyDelay);
-const mockTriageFailingChecks = vi.mocked(triageFailingChecks);
 const mockReadFixAttempts = vi.mocked(readFixAttempts);
 const mockWriteFixAttempts = vi.mocked(writeFixAttempts);
 const mockReadStallState = vi.mocked(readStallState);
@@ -166,6 +160,7 @@ function defaultConfig() {
       infraPatterns: [],
       logMaxLines: 50,
       logMaxChars: 3000,
+      errorLines: 1,
     },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
@@ -206,8 +201,6 @@ beforeEach(() => {
   mockWriteFixAttempts.mockResolvedValue(undefined);
   mockReadStallState.mockResolvedValue(null);
   mockWriteStallState.mockResolvedValue(undefined);
-  // Pass checks through unchanged — failureKind is pre-set by test fixtures.
-  mockTriageFailingChecks.mockImplementation((checks) => Promise.resolve(checks));
 });
 
 afterEach(() => {
@@ -678,9 +671,6 @@ describe("runIterate — fix_code agent projection", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockTriageFailingChecks.mockResolvedValue([
-      { ...check, failureKind: "actionable", logExcerpt: "some log" },
-    ]);
 
     const result = await runIterate(makeOpts());
 
@@ -706,6 +696,7 @@ describe("runIterate — fix_code agent projection", () => {
       event: "pull_request",
       runId: null,
       category: "failing" as const,
+      failureKind: "actionable" as const,
     };
     const ghActionsCheck = makeActionableCheck("run-77", "lint");
     mockRunCheck.mockResolvedValue(
@@ -727,10 +718,6 @@ describe("runIterate — fix_code agent projection", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockTriageFailingChecks.mockResolvedValue([
-      { ...externalCheck, failureKind: "actionable", category: "failing" as const },
-      { ...ghActionsCheck, failureKind: "actionable" },
-    ]);
 
     const result = await runIterate(makeOpts());
 
@@ -755,6 +742,7 @@ describe("runIterate — fix_code agent projection", () => {
       event: "pull_request",
       runId: null,
       category: "failing" as const,
+      failureKind: "actionable" as const,
     };
     mockRunCheck.mockResolvedValue(
       makeReport({
@@ -775,9 +763,6 @@ describe("runIterate — fix_code agent projection", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockTriageFailingChecks.mockResolvedValue([
-      { ...bareCheck, failureKind: "actionable", category: "failing" as const },
-    ]);
 
     const result = await runIterate(makeOpts());
 
@@ -805,6 +790,7 @@ describe("runIterate — fix_code agent projection", () => {
       event: "pull_request",
       runId: null,
       category: "failing" as const,
+      failureKind: "actionable" as const,
     };
     const bareCheck = {
       name: "mystery",
@@ -814,6 +800,7 @@ describe("runIterate — fix_code agent projection", () => {
       event: "pull_request",
       runId: null,
       category: "failing" as const,
+      failureKind: "actionable" as const,
     };
     mockRunCheck.mockResolvedValue(
       makeReport({
@@ -834,11 +821,6 @@ describe("runIterate — fix_code agent projection", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    mockTriageFailingChecks.mockResolvedValue([
-      { ...ghActionsCheck, failureKind: "actionable" },
-      { ...externalCheck, failureKind: "actionable", category: "failing" as const },
-      { ...bareCheck, failureKind: "actionable", category: "failing" as const },
-    ]);
 
     const result = await runIterate(makeOpts());
 
@@ -911,10 +893,9 @@ describe("runIterate — rerun_ci", () => {
       expect(result.reran.find((r) => r.runId === "run-10")?.failureKind).toBe("timeout");
     }
 
-    // Verify rerun-failed-jobs was called for both via fetch
+    // CLI no longer calls rerun-failed-jobs — the agent does it via `gh run rerun`.
     const fetchUrls = (mockFetch.mock.calls as Array<[string, RequestInit]>).map(([url]) => url);
-    expect(fetchUrls.some((u) => u.includes("run-10/rerun-failed-jobs"))).toBe(true);
-    expect(fetchUrls.some((u) => u.includes("run-11/rerun-failed-jobs"))).toBe(true);
+    expect(fetchUrls.some((u) => u.includes("rerun-failed-jobs"))).toBe(false);
   });
 
   it("deduplicates runIds when multiple failing steps share the same run", async () => {
@@ -1224,8 +1205,8 @@ describe("runIterate — cancel on merged/closed PR", () => {
   });
 });
 
-describe("runIterate — deferred triage", () => {
-  it("skips triage when PR is MERGED and checks are failing", async () => {
+describe("runIterate — triage via runCheck", () => {
+  it("returns action: cancel when PR is MERGED even with failing checks", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
         mergeStatus: {
@@ -1248,6 +1229,7 @@ describe("runIterate — deferred triage", () => {
               event: "pull_request",
               runId: "run-1",
               category: "failing",
+              failureKind: "actionable",
             },
           ],
           inProgress: [],
@@ -1262,10 +1244,9 @@ describe("runIterate — deferred triage", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("cancel");
-    expect(mockTriageFailingChecks).not.toHaveBeenCalled();
   });
 
-  it("runs triage for CONFLICTS + failing checks, returns fix_code", async () => {
+  it("returns fix_code for CONFLICTS even with a failing check (CONFLICTS is always actionable)", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
         status: "FAILING",
@@ -1289,6 +1270,7 @@ describe("runIterate — deferred triage", () => {
               event: "pull_request",
               runId: "run-2",
               category: "failing",
+              failureKind: "actionable",
             },
           ],
           inProgress: [],
@@ -1307,13 +1289,10 @@ describe("runIterate — deferred triage", () => {
 
     const result = await runIterate(makeOpts());
 
-    // Triage runs before the CONFLICTS/actionable check now.
-    expect(mockTriageFailingChecks).toHaveBeenCalledOnce();
-    // CONFLICTS is actionable — fix_code handler does the rebase.
     expect(result.action).toBe("fix_code");
   });
 
-  it("calls triage for OPEN PR with failing checks and surfaces actionable failureKind in fix payload", async () => {
+  it("surfaces actionable failureKind in fix payload when check has failureKind set", async () => {
     const failingCheck = {
       name: "typecheck",
       status: "COMPLETED" as const,
@@ -1322,6 +1301,8 @@ describe("runIterate — deferred triage", () => {
       event: "pull_request",
       runId: "run-3",
       category: "failing" as const,
+      failureKind: "actionable" as const,
+      logExcerpt: "error TS2345: type mismatch",
     };
     mockRunCheck.mockResolvedValue(
       makeReport({
@@ -1342,14 +1323,9 @@ describe("runIterate — deferred triage", () => {
       shouldCancel: false,
       remainingSeconds: 600,
     });
-    // Mock triage to return check with failureKind: 'actionable'
-    mockTriageFailingChecks.mockResolvedValue([
-      { ...failingCheck, failureKind: "actionable", logExcerpt: "error TS2345: type mismatch" },
-    ]);
 
     const result = await runIterate(makeOpts());
 
-    expect(mockTriageFailingChecks).toHaveBeenCalledOnce();
     expect(result.action).toBe("fix_code");
     if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
       expect(result.fix.checks).toHaveLength(1);
@@ -1710,7 +1686,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("rerun_ci");
     if (result.action === "rerun_ci") {
-      expect(result.log).toMatch(/RERAN/);
+      expect(result.log).toMatch(/RERUN NEEDED/);
       expect(result.log).toMatch(/run-99/);
       expect(result.log).toMatch(/test/);
       expect(result.log).toMatch(/timeout/);
@@ -2839,5 +2815,193 @@ describe("runIterate — stall-timeout guard", () => {
     const written = mockWriteStallState.mock.calls[0]![1] as StallState;
     expect(written.firstSeenAt).toBe(NOW);
     expect(written.fingerprint).toBe(realFp);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// base.checks — always carries all relevant checks regardless of action
+// ---------------------------------------------------------------------------
+
+describe("runIterate — base.checks carries passing + failing (regression: missing CI bug)", () => {
+  it("regression: 5 passing + 1 infra failure → rerun_ci with failing check in base.checks", async () => {
+    const infraCheck = {
+      name: "build",
+      status: "COMPLETED" as const,
+      conclusion: "CANCELLED" as const,
+      detailsUrl: "https://github.com/owner/repo/actions/runs/50",
+      event: "pull_request",
+      runId: "run-50",
+      category: "failing" as const,
+      failureKind: "infrastructure" as const,
+      errorExcerpt: "Runner error: the runner crashed",
+    };
+    const passingChecks = ["lint", "typecheck", "test", "e2e", "security"].map((name) => ({
+      name,
+      status: "COMPLETED" as const,
+      conclusion: "SUCCESS" as const,
+      detailsUrl: `https://github.com/owner/repo/actions/runs/${name}`,
+      event: "pull_request",
+      runId: `run-${name}`,
+      category: "passed" as const,
+    }));
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        status: "FAILING",
+        checks: {
+          passing: passingChecks,
+          failing: [infraCheck],
+          inProgress: [],
+          skipped: [],
+          filtered: [],
+          filteredNames: [],
+          blockedByFilteredCheck: false,
+        },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(result.action).toBe("rerun_ci");
+    // All 6 checks visible — the bug was that the failing infra check disappeared from output.
+    expect(result.checks).toHaveLength(6);
+    const failing = result.checks.find((c) => c.name === "build");
+    expect(failing).toBeDefined();
+    expect(failing!.failureKind).toBe("infrastructure");
+    expect(failing!.errorExcerpt).toBe("Runner error: the runner crashed");
+    const passNames = result.checks
+      .filter((c) => c.conclusion === "SUCCESS")
+      .map((c) => c.name)
+      .sort();
+    expect(passNames).toEqual(["e2e", "lint", "security", "test", "typecheck"]);
+  });
+
+  it("flaky+BEHIND → rebase action with failing check still in base.checks", async () => {
+    const flakyCheck = {
+      name: "flaky-test",
+      status: "COMPLETED" as const,
+      conclusion: "FAILURE" as const,
+      detailsUrl: "https://github.com/owner/repo/actions/runs/60",
+      event: "pull_request",
+      runId: "run-60",
+      category: "failing" as const,
+      failureKind: "flaky" as const,
+      errorExcerpt: "Test is flaky: failed 1/3 runs",
+    };
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        status: "FAILING",
+        mergeStatus: {
+          status: "BEHIND",
+          state: "OPEN" as const,
+          isDraft: false,
+          mergeable: "MERGEABLE",
+          reviewDecision: null,
+          copilotReviewInProgress: false,
+          mergeStateStatus: "BEHIND",
+        },
+        checks: {
+          passing: [],
+          failing: [flakyCheck],
+          inProgress: [],
+          skipped: [],
+          filtered: [],
+          filteredNames: [],
+          blockedByFilteredCheck: false,
+        },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(result.action).toBe("rebase");
+    expect(result.checks).toHaveLength(1);
+    expect(result.checks[0]!.name).toBe("flaky-test");
+    expect(result.checks[0]!.failureKind).toBe("flaky");
+    expect(result.checks[0]!.errorExcerpt).toBe("Test is flaky: failed 1/3 runs");
+  });
+
+  it("cooldown path returns checks: []", async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "log") {
+        return Promise.resolve({ stdout: String(NOW - 5), stderr: "" });
+      }
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+
+    const result = await runIterate(makeOpts({ cooldownSeconds: 30 }));
+
+    expect(result.action).toBe("cooldown");
+    expect(result.checks).toEqual([]);
+  });
+
+  it("wait path includes passing checks in base.checks", async () => {
+    mockRunCheck.mockResolvedValue(makeReport()); // 1 passing check: "ci"
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: false,
+      remainingSeconds: 300,
+    });
+
+    const result = await runIterate(makeOpts({ noAutoMarkReady: true }));
+
+    expect(result.action).toBe("wait");
+    expect(result.checks).toHaveLength(1);
+    expect(result.checks[0]!.name).toBe("ci");
+    expect(result.checks[0]!.conclusion).toBe("SUCCESS");
+    expect(result.checks[0]!.failureKind).toBeUndefined();
+  });
+
+  it("skipped and filtered checks are excluded from base.checks", async () => {
+    const skippedCheck = {
+      name: "skipped-job",
+      status: "COMPLETED" as const,
+      conclusion: "SKIPPED" as const,
+      detailsUrl: "https://github.com/owner/repo/actions/runs/70",
+      event: "pull_request",
+      runId: "run-70",
+      category: "skipped" as const,
+    };
+    const filteredCheck = {
+      name: "windows-only",
+      status: "COMPLETED" as const,
+      conclusion: "SUCCESS" as const,
+      detailsUrl: "https://github.com/owner/repo/actions/runs/71",
+      event: "pull_request",
+      runId: "run-71",
+      category: "filtered" as const,
+    };
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        checks: {
+          passing: [],
+          failing: [],
+          inProgress: [],
+          skipped: [skippedCheck],
+          filtered: [filteredCheck],
+          filteredNames: ["windows-only"],
+          blockedByFilteredCheck: false,
+        },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: false,
+      remainingSeconds: 300,
+    });
+
+    const result = await runIterate(makeOpts({ noAutoMarkReady: true }));
+
+    expect(result.action).toBe("wait");
+    expect(result.checks).toEqual([]);
   });
 });

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -464,20 +464,26 @@ function buildSummary(report: Awaited<ReturnType<typeof runCheck>>): IterateResu
  * Includes both passing and failing. Failing entries carry failureKind + errorExcerpt.
  */
 function buildRelevantChecks(report: Awaited<ReturnType<typeof runCheck>>): RelevantCheck[] {
-  const passing: RelevantCheck[] = report.checks.passing.map((c) => ({
-    name: c.name,
-    conclusion: c.conclusion as RelevantCheck["conclusion"],
-    runId: c.runId,
-    detailsUrl: c.detailsUrl || null,
-  }));
-  const failing: RelevantCheck[] = report.checks.failing.map((c) => ({
-    name: c.name,
-    conclusion: c.conclusion as RelevantCheck["conclusion"],
-    runId: c.runId,
-    detailsUrl: c.detailsUrl || null,
-    failureKind: c.failureKind,
-    errorExcerpt: c.errorExcerpt,
-  }));
+  const excluded = new Set([null, "SKIPPED", "NEUTRAL"]);
+  const passing: RelevantCheck[] = report.checks.passing.flatMap((c) => {
+    if (excluded.has(c.conclusion)) return [];
+    const conclusion = c.conclusion as RelevantCheck["conclusion"];
+    return [{ name: c.name, conclusion, runId: c.runId, detailsUrl: c.detailsUrl || null }];
+  });
+  const failing: RelevantCheck[] = report.checks.failing.flatMap((c) => {
+    if (excluded.has(c.conclusion)) return [];
+    const conclusion = c.conclusion as RelevantCheck["conclusion"];
+    return [
+      {
+        name: c.name,
+        conclusion,
+        runId: c.runId,
+        detailsUrl: c.detailsUrl || null,
+        failureKind: c.failureKind,
+        errorExcerpt: c.errorExcerpt,
+      },
+    ];
+  });
   return [...passing, ...failing];
 }
 

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -25,7 +25,6 @@
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { runCheck } from "./check.mts";
-import { triageFailingChecks } from "../checks/triage.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { getCurrentPrNumber } from "../github/client.mts";
 import { rest, graphql } from "../github/http.mts";
@@ -42,6 +41,7 @@ import type {
   IterateResultBase,
   IterateResultSummary,
   PrComment,
+  RelevantCheck,
   ResolveCommand,
   Review,
   ReviewThread,
@@ -86,16 +86,17 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       remainingSeconds: readyDelaySeconds,
       summary: { passing: 0, skipped: 0, filtered: 0, inProgress: 0 },
       baseBranch: "",
+      checks: [],
       log: "SKIP: CI still starting — waiting for first check to appear",
     };
   }
 
   // Step 2: Sweep — fetch CI + comments + merge status, auto-resolve outdated.
-  // skipTriage defers log fetching until we know we'll need failureKind (steps 4–6).
+  // Always triage failing checks (fetch logs) so failureKind and errorExcerpt are
+  // available on every subsequent step regardless of which action fires.
   let report = await runCheck({
     ...optsWithPr,
     autoResolve: config.actions.autoResolveOutdated,
-    skipTriage: true,
   });
 
   // Step 2.5: Cancel if PR is merged or closed — no longer actionable.
@@ -113,6 +114,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       state: report.mergeStatus.state,
       summary: buildSummary(report),
       baseBranch: report.baseBranch,
+      checks: buildRelevantChecks(report),
       action: "cancel",
       log: `CANCEL: PR #${report.pr} is ${state} — stopping monitor`,
     };
@@ -144,6 +146,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     remainingSeconds: readyState.remainingSeconds,
     summary: buildSummary(report),
     baseBranch: report.baseBranch,
+    checks: buildRelevantChecks(report),
   };
 
   // Step 3 cont.: cancel if ready-delay elapsed.
@@ -152,22 +155,13 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       ...base,
       action: "cancel",
       log: `CANCEL: PR #${base.pr} has been ready for review — ready-delay elapsed, stopping monitor`,
-    };
+    }; // base.checks already set
   }
 
   // Fetch HEAD SHA once — used by both fix-attempts tracking and stall-detection fingerprint.
   // Done after the shouldCancel early-return to avoid a subprocess call on cancel paths.
   const headSha = await getCurrentHeadSha();
   const stallKey = { owner: repoOwner, repo: repoName, pr: prNumber };
-
-  // Triage failing checks now that we know we need failureKind for steps 4–6.
-  if (report.checks.failing.length > 0) {
-    const triaged = await triageFailingChecks(report.checks.failing, {
-      owner: repoOwner,
-      name: repoName,
-    });
-    report = { ...report, checks: { ...report.checks, failing: triaged } };
-  }
 
   // Step 4: Actionable work — fix comments, review requests, CI failures, and merge
   // conflicts all in one push. CONFLICTS is included here because the fix_code handler
@@ -331,10 +325,12 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   }
 
   // Step 5: Transient failures (timeout / infrastructure) — no actionable work, no conflicts.
+  // The CLI identifies which runs need a rerun and emits them; the agent runs
+  // `gh run rerun <runId> --failed` for each entry.
   const transientChecks = report.checks.failing.filter(
     (f) => f.failureKind === "timeout" || f.failureKind === "infrastructure",
   );
-  if (transientChecks.length > 0 && !opts.noAutoRerun) {
+  if (transientChecks.length > 0) {
     // Group checks by runId — multiple failed steps can share one run.
     const runMap = new Map<string, import("../types.mts").ReranRun>();
     for (const c of transientChecks) {
@@ -351,11 +347,6 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       }
     }
     const reran = [...runMap.values()];
-    await Promise.all(
-      reran.map(({ runId }) =>
-        rest("POST", `/repos/${repoOwner}/${repoName}/actions/runs/${runId}/rerun-failed-jobs`),
-      ),
-    );
     const runSummaries = reran.map(
       ({ runId, checkNames, failureKind }) =>
         `${runId} (${checkNames.join(", ")} — ${failureKind})`,
@@ -370,7 +361,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
         ...base,
         action: "rerun_ci" as const,
         reran,
-        log: `RERAN ${reran.length} CI run${reran.length === 1 ? "" : "s"}: ${runSummaries.join(", ")}`,
+        log: `RERUN NEEDED — ${reran.length} CI run${reran.length === 1 ? "" : "s"}: ${runSummaries.join(", ")}`,
       } as IterateResult,
       report,
       reviewSummaryIds,
@@ -465,6 +456,29 @@ function buildSummary(report: Awaited<ReturnType<typeof runCheck>>): IterateResu
     filtered: report.checks.filtered.length,
     inProgress: report.checks.inProgress.length,
   };
+}
+
+/**
+ * Build the full list of CI checks relevant to PR readiness: triggered by a PR
+ * event (or StatusContext with null event), completed, and not skipped/neutral.
+ * Includes both passing and failing. Failing entries carry failureKind + errorExcerpt.
+ */
+function buildRelevantChecks(report: Awaited<ReturnType<typeof runCheck>>): RelevantCheck[] {
+  const passing: RelevantCheck[] = report.checks.passing.map((c) => ({
+    name: c.name,
+    conclusion: c.conclusion as RelevantCheck["conclusion"],
+    runId: c.runId,
+    detailsUrl: c.detailsUrl || null,
+  }));
+  const failing: RelevantCheck[] = report.checks.failing.map((c) => ({
+    name: c.name,
+    conclusion: c.conclusion as RelevantCheck["conclusion"],
+    runId: c.runId,
+    detailsUrl: c.detailsUrl || null,
+    failureKind: c.failureKind,
+    errorExcerpt: c.errorExcerpt,
+  }));
+  return [...passing, ...failing];
 }
 
 async function getLastCommitTime(): Promise<number> {

--- a/src/config.json
+++ b/src/config.json
@@ -42,7 +42,8 @@
       "the hosted runner lost connection"
     ],
     "logMaxLines": 50,
-    "logMaxChars": 3000
+    "logMaxChars": 3000,
+    "errorLines": 1
   },
   "mergeStatus": {
     "blockingReviewerLogins": ["copilot"]

--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -46,6 +46,8 @@ export interface PrShepherdConfig {
     infraPatterns: string[];
     logMaxLines: number;
     logMaxChars: number;
+    /** Number of trailing `##[error]`-marked lines to surface per failing check. Default 1. */
+    errorLines: number;
   };
   mergeStatus: {
     blockingReviewerLogins: string[];

--- a/src/types.mts
+++ b/src/types.mts
@@ -63,7 +63,7 @@ export type FailureKind = "timeout" | "infrastructure" | "actionable" | "flaky";
 
 export interface TriagedCheck extends ClassifiedCheck {
   failureKind?: FailureKind;
-  /** Full log excerpt used for failure classification. */
+  /** Truncated tail of the log excerpt retained for classification/debugging, bounded by configured line/char limits. */
   logExcerpt?: string;
   /** Last N `##[error]`-marked lines (or last N raw lines as fallback). Compact error summary. */
   errorExcerpt?: string;

--- a/src/types.mts
+++ b/src/types.mts
@@ -63,8 +63,10 @@ export type FailureKind = "timeout" | "infrastructure" | "actionable" | "flaky";
 
 export interface TriagedCheck extends ClassifiedCheck {
   failureKind?: FailureKind;
-  /** Log excerpt for actionable failures. */
+  /** Full log excerpt used for failure classification. */
   logExcerpt?: string;
+  /** Last N `##[error]`-marked lines (or last N raw lines as fallback). Compact error summary. */
+  errorExcerpt?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,6 +267,31 @@ export interface AgentCheck {
 }
 
 // ---------------------------------------------------------------------------
+// Relevant check (iterate output — completed, non-skipped, PR-triggered)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single CI check that is relevant to PR readiness — triggered by a PR event
+ * (or by a StatusContext with null event), completed, and not skipped/neutral.
+ *
+ * Included in every iterate result so the agent always sees the full CI picture
+ * regardless of which action fired.
+ */
+export interface RelevantCheck {
+  name: string;
+  conclusion: Exclude<CheckConclusion, "SKIPPED" | "NEUTRAL" | null>;
+  runId: string | null;
+  detailsUrl: string | null;
+  /** Present for non-SUCCESS conclusions. */
+  failureKind?: FailureKind;
+  /**
+   * Last `checks.errorLines` `##[error]`-marked log lines (fallback: last N raw lines).
+   * Present for non-SUCCESS conclusions when logs were fetched.
+   */
+  errorExcerpt?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Iterate command types
 // ---------------------------------------------------------------------------
 
@@ -312,6 +339,15 @@ export interface IterateResultBase {
   summary: IterateResultSummary;
   /** Validated base branch (e.g. "main") for this PR. Echoed from `ShepherdReport.baseBranch` after `validateBaseBranch` whenever a sweep/report has run; `""` only for early-return cases where no sweep has run yet (for example, cooldown). */
   baseBranch: string;
+  /**
+   * All CI checks that are relevant to PR readiness: triggered by a PR event
+   * (pull_request / pull_request_target, or StatusContext with null event),
+   * completed (status === COMPLETED), and not skipped/neutral.
+   *
+   * Includes both passing and failing checks. Failing entries carry `failureKind`
+   * and `errorExcerpt`. Empty (`[]`) during the `cooldown` early-return (no sweep ran).
+   */
+  checks: RelevantCheck[];
 }
 
 export interface IterateResultCooldown extends IterateResultBase {
@@ -417,7 +453,6 @@ export interface IterateCommandOptions extends GlobalOptions {
   cooldownSeconds?: number;
   readyDelaySeconds?: number;
   lastPushTime?: number;
-  noAutoRerun?: boolean;
   noAutoMarkReady?: boolean;
   noAutoCancelActionable?: boolean;
   /** Override the stall-timeout threshold (seconds). Defaults to config.iterate.stallTimeoutMinutes * 60. */


### PR DESCRIPTION
## Summary

- **Agent-side CI rerun**: Remove the `POST rerun-failed-jobs` API call from the CLI. The `rerun_ci` action now emits explicit `gh run rerun <runId> --failed` steps in `## Instructions` for the agent to execute. The CLI is now report-only — no GitHub mutations for transient failures.

- **All checks visible in every action**: Add `checks: RelevantCheck[]` to `IterateResultBase` so every action (`wait`, `rerun_ci`, `rebase`, `cancel`, `fix_code`) carries the complete list of completed, non-skipped PR CI checks. This fixes a bug where a failing infra/timeout/flaky check disappeared from iterate output when no other actionable work was found (only `fix_code` previously listed checks, and only `actionable` ones at that). Renders as a `## Checks` section with ✓/✗ bullets immediately after the base fields.

- **`##[error]` excerpts**: Add `extractErrorLines()` in `triage.mts` that extracts the last N lines containing `##[error]` workflow-command markers from GitHub Actions logs, stripping timestamps and the prefix. Configurable via `checks.errorLines` (default 1). Falls back to last N raw lines for external status checks. Renders as a `> blockquote` under each failing check in `## Checks`.

## Test plan

- [x] 591 tests pass (`npx vitest run`)
- [x] New tests: `extractErrorLines` unit tests (prefix stripping, fallback, configurable count)
- [x] New tests: `errorExcerpt` field on `TriagedCheck` via `triageFailingChecks`
- [x] New regression test: 5 passing + 1 infra failure → `rerun_ci` with failing check in `base.checks`
- [x] New tests: flaky+BEHIND → `rebase` with failing check in `base.checks`
- [x] New tests: cooldown returns `checks: []`, wait includes passing checks, skipped/filtered excluded
- [x] Existing test updated: `rerun_ci` asserts no `rerun-failed-jobs` POST is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)