### PR TITLE
docs: fix audit findings — correct JSON paths, missing config keys, stale links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cross-cutting machinery: file cache with atomic writes ([docs/cache.md](docs/cac
 Claude Code skills that wrap the CLI with model-driven triage, code edits, and flow control:
 
 - **`/pr-shepherd:check`** — calls `check --format=json` and prints a human summary; never declares "ready to merge" unless every gate passes (merge status CLEAN, status READY, Copilot review not in progress)
-- **`/pr-shepherd:monitor`** — creates a `/loop` cron job (4-minute default, 8-hour expiry, 50-turn cap), deduplicates via a `# pr-shepherd-loop:pr=<N>` tag in `CronList`, dispatches on the `[ACTION]` H1 tag each tick, runs rebase scripts and fix instructions in the main conversation
+- **`/pr-shepherd:monitor`** — creates a `/loop` cron job (4-minute default, 8-hour expiry, 50-turn cap), deduplicates via a `# pr-shepherd-loop:pr=<N>` tag in `CronList`, follows the `## Instructions` section emitted by `iterate` each tick (the `[ACTION]` H1 tag identifies the action for logging), runs rebase scripts and fix instructions in the main conversation
 - **`/pr-shepherd:resolve`** — runs `resolve --fetch` and follows the `## Instructions` section embedded in the Markdown output; the CLI output describes the full triage/fix/push/resolve/report flow, including commit-suggestion preference and per-bucket dispatch rules
 
 See [docs/skills.md](docs/skills.md) for full skill reference.
@@ -118,9 +118,9 @@ to be installed in the repository first (`npm install pr-shepherd`), so that
 
    Parse the JSON and report:
 
-   - **Merge status** (`report.mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN
-   - **CI check results** (`report.checks`): passing count, failing names, in-progress names
-   - **Unresolved review comments** (`report.threads.actionable` + `report.comments.actionable`): count + details
+   - **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN
+   - **CI check results** (`checks`): passing count, failing names, in-progress names
+   - **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details
    ````
 
 3. **Use it in Claude Code:**
@@ -186,7 +186,7 @@ See [docs/skills.md](docs/skills.md) for full argument reference.
 
 ## Workflow
 
-On each tick (4-minute default, tunable via `watch.interval`): fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (fix code, rebase, rerun CI, mark ready, or wait). See [docs/flow.md](docs/flow.md) for the full decision tree.
+On each tick (4-minute default, tunable via `watch.interval`): fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (fix code, rebase, rerun CI, mark ready, or wait). See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
 
 ## CLI
 
@@ -215,6 +215,7 @@ All supported keys:
 | `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                             |
 | `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                            |
 | `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                       |
+| `iterate.stallTimeoutMinutes`               | `30`                                      | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
 | `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                 |
 | `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                             |
 | `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                               |
@@ -231,7 +232,8 @@ All supported keys:
 | `checks.infraPatterns`                      | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `infrastructure`                                                       |
 | `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                           |
 | `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                                      |
-| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review blocks `mark_ready`                                                       |
+| `checks.errorLines`                         | `1`                                       | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                             |
+| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                         |
 | `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                               |
 | `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                                |
 | `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                              |

--- a/README.md
+++ b/README.md
@@ -210,34 +210,34 @@ actions:
 
 All supported keys:
 
-| Key                                         | Default                                   | Purpose                                                                                                        |
-| ------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                             |
-| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                            |
-| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                       |
+| Key                                         | Default                                   | Purpose                                                                                                           |
+| ------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                                |
+| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                               |
+| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                          |
 | `iterate.stallTimeoutMinutes`               | `30`                                      | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
-| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                 |
-| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                             |
-| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                               |
-| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                               |
-| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                                      |
-| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                             |
-| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                                  |
-| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                                 |
-| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                               |
-| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                                     |
-| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                               |
-| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                               |
-| `checks.timeoutPatterns`                    | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `timeout`                                                              |
-| `checks.infraPatterns`                      | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `infrastructure`                                                       |
-| `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                           |
-| `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                                      |
-| `checks.errorLines`                         | `1`                                       | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                             |
-| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                         |
-| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                               |
-| `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                                |
-| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                              |
-| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block |
+| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
+| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
+| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
+| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
+| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                                         |
+| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                                |
+| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                                     |
+| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                                    |
+| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
+| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                                        |
+| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
+| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
+| `checks.timeoutPatterns`                    | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `timeout`                                                                 |
+| `checks.infraPatterns`                      | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `infrastructure`                                                          |
+| `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                              |
+| `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                                         |
+| `checks.errorLines`                         | `1`                                       | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                                |
+| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
+| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                                  |
+| `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                                   |
+| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
+| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
 
 Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_CACHE_DIR` (override cache base dir), `PR_SHEPHERD_CACHE_TTL_SECONDS` (override cache TTL; `--cache-ttl` takes precedence over this env var, which in turn takes precedence over the RC/config value).
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ to be installed in the repository first (`npm install pr-shepherd`), so that
    Parse the JSON and report:
 
    - **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN
-   - **CI check results** (`checks`): passing count, failing names, in-progress names
+   - **CI check results** (`checks.passing`, `checks.failing`, `checks.inProgress`): passing count, failing names, in-progress names
    - **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details
    ````
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,6 +1,6 @@
 # shepherd actions
 
-[← README.md](README.md)
+[← README](../README.md)
 
 Each iteration of `shepherd iterate` returns exactly one action. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # shepherd — architecture
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## Module tree
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,6 +1,6 @@
 # shepherd cache
 
-[← README.md](README.md) | [ready-delay.md](ready-delay.md)
+[← README](../README.md) | [ready-delay.md](ready-delay.md)
 
 ## File layout
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1,6 +1,6 @@
 # shepherd CI checks
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## Classification pipeline
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,6 +1,6 @@
 # shepherd comments and threads
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## Review threads vs PR comments
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,6 @@
 # shepherd — debugging
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## Common failure modes
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,6 +1,6 @@
 # shepherd — extending
 
-[← README.md](README.md) | [architecture.md](architecture.md)
+[← README](../README.md) | [architecture.md](architecture.md)
 
 Four recipes for common extension patterns.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,6 +1,6 @@
 # shepherd GraphQL
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## The batch query
 

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -1,6 +1,6 @@
 # shepherd iterate — step-by-step flow
 
-[← README.md](README.md) | [actions.md](actions.md)
+[← README](../README.md) | [actions.md](actions.md)
 
 `commands/iterate.mts` is the heart of the watch loop. Each cron tick calls it once and interprets the JSON result.
 

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -1,10 +1,10 @@
 # shepherd merge-status derivation
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## `deriveMergeStatus` — first-match-wins table
 
-Located in `shepherd/merge-status/derive.mts`. Given a `BatchPrData`, returns a `MergeStatusResult`.
+Located in `src/merge-status/derive.mts`. Given a `BatchPrData`, returns a `MergeStatusResult`.
 
 | Priority | Condition                                         | Status         | Notes                                                                      |
 | -------- | ------------------------------------------------- | -------------- | -------------------------------------------------------------------------- |

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -1,6 +1,6 @@
 # shepherd ready-delay
 
-[← README.md](README.md)
+[← README](../README.md)
 
 ## What it does
 

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -1,6 +1,6 @@
 # shepherd watch loop
 
-[← README.md](README.md) | [actions.md](actions.md) | [iterate-flow.md](iterate-flow.md)
+[← README](../README.md) | [actions.md](actions.md) | [iterate-flow.md](iterate-flow.md)
 
 ## Overview
 

--- a/plugin/skills/check/SKILL.md
+++ b/plugin/skills/check/SKILL.md
@@ -35,7 +35,7 @@ npx pr-shepherd check <N> --format=json
 Parse the JSON output and report all three:
 
 - **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN — never omit; include `copilotReviewInProgress` when true
-- **CI check results** (`checks`): passing count, failing names + kinds, in-progress names
+- **CI check results** (`checks.passing`, `checks.failing`, `checks.inProgress`): passing count, failing names + kinds, in-progress names
 - **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details with file paths and line numbers
 
 ## Rebase policy
@@ -50,7 +50,7 @@ Do not re-derive these conditions from raw branch state. For automated monitorin
 
 ## CI budget policy
 
-Each entry in `checks` carries a `failureKind` field. Read it directly rather than re-classifying failures:
+Each entry in `checks.failing` carries a `failureKind` field. Read it directly rather than re-classifying failures:
 
 - `actionable` — the failure is code-level and needs a fix.
 - `infrastructure` — transient infra problem; re-run with `gh run rerun <runId> --failed`.

--- a/plugin/skills/check/SKILL.md
+++ b/plugin/skills/check/SKILL.md
@@ -34,13 +34,13 @@ npx pr-shepherd check <N> --format=json
 
 Parse the JSON output and report all three:
 
-- **Merge status** (`report.mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN — never omit; include `copilotReviewInProgress` when true
-- **CI check results** (`report.checks`): passing count, failing names + kinds, in-progress names
-- **Unresolved review comments** (`report.threads.actionable` + `report.comments.actionable`): count + details with file paths and line numbers
+- **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN — never omit; include `copilotReviewInProgress` when true
+- **CI check results** (`checks`): passing count, failing names + kinds, in-progress names
+- **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details with file paths and line numbers
 
 ## Rebase policy
 
-The CLI already determines whether a rebase is warranted. Read `report.mergeStatus.status` directly:
+The CLI already determines whether a rebase is warranted. Read `mergeStatus.status` directly:
 
 - `CONFLICTS` — a rebase is required to resolve the merge conflict before the PR can land.
 - `BEHIND` — a rebase may be appropriate; a `flaky` failure while `BEHIND` is the canonical rebase signal. If all checks pass but the PR is `BEHIND`, a rebase is optional.
@@ -50,7 +50,7 @@ Do not re-derive these conditions from raw branch state. For automated monitorin
 
 ## CI budget policy
 
-Each entry in `report.checks` carries a `failureKind` field. Read it directly rather than re-classifying failures:
+Each entry in `checks` carries a `failureKind` field. Read it directly rather than re-classifying failures:
 
 - `actionable` — the failure is code-level and needs a fix.
 - `infrastructure` — transient infra problem; re-run with `gh run rerun <runId> --failed`.
@@ -61,8 +61,8 @@ Each entry in `report.checks` carries a `failureKind` field. Read it directly ra
 
 Unless ALL of:
 
-1. `report.mergeStatus.mergeStateStatus == 'CLEAN'`
-2. `report.status == 'READY'`
-3. `report.mergeStatus.copilotReviewInProgress == false`
+1. `mergeStatus.mergeStateStatus == 'CLEAN'`
+2. `status == 'READY'`
+3. `mergeStatus.copilotReviewInProgress == false`
 
 This is a one-shot check. For continuous monitoring, use `/pr-shepherd:monitor`.


### PR DESCRIPTION
## Summary

- **Wrong JSON field paths**: `report.mergeStatus.status` etc. in README custom-slash-command example and `plugin/skills/check/SKILL.md` — the JSON output is a flat object with no `report` wrapper. Any user following the example literally would get `null` from `jq`.
- **Missing config table rows**: `iterate.stallTimeoutMinutes` (default 30) and `checks.errorLines` (default 1) existed in `src/config.json` and `docs/configuration.md` but were absent from the README table.
- **Monitor description misstated dispatch**: README said the skill "dispatches on the `[ACTION]` H1 tag", but per `docs/actions.md` and CLAUDE.md, behavior is driven by the `## Instructions` section — the tag is for identification only.
- **Workflow link**: "full decision tree" link pointed only at `docs/flow.md` (diagram); now also links `docs/iterate-flow.md` which has the actual decision table.
- **`blockingReviewerLogins` description**: said "pending review" only; code also fires on outstanding review requests.
- **Stale path in `docs/merge-status.md`**: referenced `shepherd/merge-status/derive.mts`; actual path is `src/merge-status/derive.mts`.
- **`[← README]` nav links**: 12 docs files used `[← README.md](README.md)` (→ `docs/README.md`) while 4 others used `[← README](../README.md)` (→ top-level README); standardized to the latter.

## Test plan

- [ ] `rg 'report\.(mergeStatus|checks|threads|comments|status)' README.md plugin/skills/check/SKILL.md` returns nothing
- [ ] README config table keys match `src/config.json` keys
- [ ] `rg 'shepherd/merge-status' docs/` returns nothing
- [ ] All `[← README]` links in docs/ point to `../README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)