### PR TITLE
ci: add Dependabot PR auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-pr-automerge.yml
+++ b/.github/workflows/dependabot-pr-automerge.yml
@@ -53,7 +53,9 @@ jobs:
               });
 
               for (const review of sortedReviews) {
-                latestStateByUser.set(review.user.login, review.state);
+                if (review.user) {
+                  latestStateByUser.set(review.user.login, review.state);
+                }
               }
 
               return [...latestStateByUser.values()].includes('APPROVED');
@@ -102,14 +104,18 @@ jobs:
             }
 
             core.info('Enabling auto-merge');
-            await github.graphql(`
-              mutation($pullRequestId: ID!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $pullRequestId,
-                  mergeMethod: SQUASH
-                }) {
-                  pullRequest { autoMergeRequest { enabledAt } }
+            try {
+              await github.graphql(`
+                mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: SQUASH
+                  }) {
+                    pullRequest { autoMergeRequest { enabledAt } }
+                  }
                 }
-              }
-            `, { pullRequestId: freshPr.node_id });
-            core.info('Done: auto-merge enabled');
+              `, { pullRequestId: freshPr.node_id });
+              core.info('Done: auto-merge enabled');
+            } catch (err) {
+              core.warning(`Could not enable auto-merge: ${err.message}. Ensure branch protection with required status checks is configured on the base branch.`);
+            }

--- a/.github/workflows/dependabot-pr-automerge.yml
+++ b/.github/workflows/dependabot-pr-automerge.yml
@@ -1,0 +1,115 @@
+name: Dependabot PR Auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  automerge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+
+            function isMajorBump(from, to) {
+              const major = v => parseInt(v.replace(/^v/, '').split('.')[0], 10);
+              return major(to) > major(from);
+            }
+
+            function hasMajorBump(pullRequest) {
+              const titleMatch = pullRequest.title.match(/from\s+v?([\d.]+)\s+to\s+v?([\d.]+)/i);
+              if (titleMatch) {
+                return isMajorBump(titleMatch[1], titleMatch[2]);
+              }
+
+              const body = pullRequest.body ?? '';
+              const bodyMatches = [...body.matchAll(/from\s+`?v?([\d.]+)`?\s+to\s+`?v?([\d.]+)`?/gi)];
+              return bodyMatches.some(match => isMajorBump(match[1], match[2]));
+            }
+
+            function hasActiveApproval(reviews) {
+              const latestStateByUser = new Map();
+              const sortedReviews = [...reviews].sort((a, b) => {
+                return new Date(a.submitted_at ?? 0).getTime() - new Date(b.submitted_at ?? 0).getTime();
+              });
+
+              for (const review of sortedReviews) {
+                latestStateByUser.set(review.user.login, review.state);
+              }
+
+              return [...latestStateByUser.values()].includes('APPROVED');
+            }
+
+            core.info(`Evaluating PR #${pr.number} (${pr.title})`);
+
+            if (pr.draft) {
+              core.info('Skipping draft pull request');
+              return;
+            }
+
+            if (hasMajorBump(pr)) {
+              core.info('Skipping semver-major update');
+              return;
+            }
+
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            if (hasActiveApproval(reviews)) {
+              core.info('Approval already present');
+            } else {
+              core.info('Approving PR');
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pr.number,
+                event: 'APPROVE',
+              });
+            }
+
+            const { data: freshPr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            });
+
+            if (freshPr.auto_merge) {
+              core.info('Auto-merge already enabled');
+              return;
+            }
+
+            core.info('Enabling auto-merge');
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH
+                }) {
+                  pullRequest { autoMergeRequest { enabledAt } }
+                }
+              }
+            `, { pullRequestId: freshPr.node_id });
+            core.info('Done: auto-merge enabled');


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-pr-automerge.yml` that approves and enables squash auto-merge on Dependabot PRs using only `GITHUB_TOKEN` (no PAT required)
- Skips draft PRs and semver-major bumps (those stay for human review)
- Idempotent: won't re-approve or re-enable auto-merge if already done

## Prerequisites (one-time manual setup required)

Two settings must be enabled for this to work end-to-end:

1. **Branch protection on `main` with required status checks** — `main` is currently unprotected. Without a required check blocking merge, `enablePullRequestAutoMerge` fails with `Pull request is in clean status`. Recommend requiring the `lint / typecheck / test` CI jobs from `.github/workflows/ci.yml`.
2. **"Allow GitHub Actions to create and approve pull requests"** — enable at `Settings → Actions → General → Workflow permissions`. Without it, the `APPROVE` review call fails.

`allow_auto_merge` and `allow_squash_merge` are already enabled on the repo.

## Test plan

- [ ] Enable the two prerequisites above
- [ ] Trigger a Dependabot run (`Insights → Dependency graph → Dependabot → Check for updates`)
- [ ] Confirm the workflow logs `Approving PR` then `Enabling auto-merge` on the resulting PR
- [ ] Confirm the PR shows approval from `github-actions[bot]` and an auto-merge badge (squash)
- [ ] Confirm CI gates the merge and the PR auto-merges when all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)