### PR TITLE
docs: restructure README to focus on skills; move CLI/config/custom-command detail to docs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,3 +7,6 @@ npm run --silent lint
 
 echo "pre-push: npm run typecheck"
 npm run --silent typecheck
+
+echo "pre-push: npm run format:check"
+npm run --silent format:check

--- a/README.md
+++ b/README.md
@@ -25,126 +25,6 @@ Concrete improvements to an agentic PR-review workflow:
 - **Skills over subagents** — subagents reload all CLAUDE.md context on every turn; skills inject into the main conversation instead, keeping cost low
 - **JSON/text parity** — `--format=json` and `--format=text` carry equivalent information; every field in one has a representation in the other
 
-## Features
-
-pr-shepherd is split into a CLI (deterministic, pure GitHub I/O) and three Claude Code skills that wrap the CLI with model-driven flow and mutation.
-
-### What the CLI does
-
-Deterministic commands that fetch, classify, and mutate PR state without invoking the model:
-
-- **`check`** — one-shot PR snapshot (merge state, CI results, unresolved comments) via a single batched GraphQL query
-- **`resolve`** — fetch/triage mode auto-resolves outdated threads and returns actionable items (each annotated with any parseable ` ```suggestion ` block); mutate mode batch-resolves threads, minimizes comments, and dismisses reviews by ID, polling `--require-sha` so reviewers see the push before threads close
-- **`commit-suggestion`** — applies a single reviewer ` ```suggestion ` block as a local git commit (one suggestion = one commit): builds a unified diff, validates it with `git apply --check`, commits with a caller-supplied message + `Co-authored-by: <reviewer>` trailer, and resolves the thread on GitHub
-- **`iterate`** — classifies current PR state and emits exactly one of eight actions: `cooldown`, `wait`, `rerun_ci`, `mark_ready`, `rebase`, `fix_code`, `cancel`, `escalate` (see [docs/actions.md](docs/actions.md))
-- **`status`** — multi-PR summary table, one lightweight GraphQL query per PR in parallel
-
-Cross-cutting machinery: file cache with atomic writes ([docs/cache.md](docs/cache.md)), merge-status derivation ([docs/merge-status.md](docs/merge-status.md)), CI failure classification into `actionable` / `infrastructure` / `timeout` / `flaky` ([docs/checks.md](docs/checks.md)), outdated-thread detection ([docs/comments.md](docs/comments.md)), deprecation-warning-aware RC loader.
-
-### What the skills do
-
-Claude Code skills that wrap the CLI with model-driven triage, code edits, and flow control:
-
-- **`/pr-shepherd:check`** — calls `check --format=json` and prints a human summary; never declares "ready to merge" unless every gate passes (merge status CLEAN, status READY, Copilot review not in progress)
-- **`/pr-shepherd:monitor`** — creates a `/loop` cron job (4-minute default, 8-hour expiry, 50-turn cap), deduplicates via a `# pr-shepherd-loop:pr=<N>` tag in `CronList`, follows the `## Instructions` section emitted by `iterate` each tick (the `[ACTION]` H1 tag identifies the action for logging), runs rebase scripts and fix instructions in the main conversation
-- **`/pr-shepherd:resolve`** — runs `resolve --fetch` and follows the `## Instructions` section embedded in the Markdown output; the CLI output describes the full triage/fix/push/resolve/report flow, including commit-suggestion preference and per-bucket dispatch rules
-
-See [docs/skills.md](docs/skills.md) for full skill reference.
-
-## Install
-
-> **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. If you're using `pr-shepherd` as development tooling for your repo, install it as a dev dependency so `npx` resolves it without prompting:
->
-> ```bash
-> npm install --save-dev pr-shepherd
-> ```
->
-> A plain `npm install pr-shepherd` adds it to regular dependencies instead; use that only if you specifically want it under `dependencies`. Or install globally: `npm install -g pr-shepherd`.
-
-### As individual skills via `npx skills`
-
-```bash
-npx skills add jonathanong/pr-shepherd
-```
-
-Installs the three skills (`check`, `monitor`, `resolve`) into your agent's skill directory (`.claude/skills/` for project scope, `~/.claude/skills/` with `-g` for global scope). Powered by [skills.sh](https://skills.sh).
-
-### As a Claude Code plugin (recommended)
-
-```bash
-claude /plugin marketplace add jonathanong/pr-shepherd
-claude /plugin install pr-shepherd
-```
-
-This repo ships two `marketplace.json` files that serve different install flows: the root `marketplace.json` resolves the plugin from the npm registry (used by the `claude /plugin marketplace add` command above); `.claude-plugin/marketplace.json` is the owner-level registry manifest that resolves the plugin from the local plugin directory (used when Claude Code installs from a local or git-based source). Both files are needed to support these two install paths.
-
-See [Usage](#usage) below.
-
-### Without the plugin — custom slash command
-
-If you don't want the full plugin, create a project-local (or user-scope)
-slash command that wraps the CLI directly. This still requires `pr-shepherd`
-to be installed in the repository first (`npm install pr-shepherd`), so that
-`npx pr-shepherd ...` runs without prompting to install the package.
-
-1. **Create the command file:**
-   - Project-scope: `.claude/commands/pr-check.md`
-   - User-scope: `~/.claude/commands/pr-check.md`
-
-2. **Paste this as the file contents:**
-
-   ````markdown
-   ---
-   description: "Check GitHub CI status and review comments for the current PR"
-   argument-hint: "[PR number or URL ...]"
-   allowed-tools: ["Bash", "Read", "Grep"]
-   ---
-
-   # PR Status Check
-
-   ## Arguments: $ARGUMENTS
-
-   ## Resolve PR number(s)
-
-   1. If `$ARGUMENTS` contains PR numbers or GitHub PR URLs, extract the number(s).
-   2. Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
-   3. If no PR found, report an error and stop.
-
-   ## Run the check
-
-   ```bash
-   npx pr-shepherd check <PR_NUMBER> --format=json
-   ```
-
-   Parse the JSON and report:
-
-   - **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN
-   - **CI check results** (`checks.passing`, `checks.failing`, `checks.inProgress`): passing count, failing names, in-progress names
-   - **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details
-   ````
-
-3. **Use it in Claude Code:**
-
-   ```
-   /pr-check
-   /pr-check 42
-   ```
-
-For `monitor` and `resolve` custom commands, do **not** copy the
-[`plugin/skills/`](plugin/skills/) files directly — those contain skill/plugin-specific
-frontmatter that is not valid for `.claude/commands/` files. Instead, create
-`.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
-using the same command-file structure as the `pr-check` example above, with
-the CLI invocation changed to `npx pr-shepherd iterate ...` or
-`npx pr-shepherd resolve ...`. To drive the CLI without Claude at all, see
-[docs/usage.md](docs/usage.md).
-
-### As a global CLI
-
-```bash
-npm install -g pr-shepherd
-```
-
 ## Usage
 
 ### Monitor a PR
@@ -188,9 +68,42 @@ See [docs/skills.md](docs/skills.md) for full argument reference.
 
 On each tick (4-minute default, tunable via `watch.interval`): fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (fix code, rebase, rerun CI, mark ready, or wait). See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
 
-## CLI
+## Install
 
-End-users normally interact with pr-shepherd through the `/pr-shepherd:*` skills shown above. The full per-command CLI reference — signatures, flags, exit codes, JSON/Markdown output examples — lives in [docs/usage.md](docs/usage.md).
+> **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. If you're using `pr-shepherd` as development tooling for your repo, install it as a dev dependency so `npx` resolves it without prompting:
+>
+> ```bash
+> npm install --save-dev pr-shepherd
+> ```
+>
+> A plain `npm install pr-shepherd` adds it to regular dependencies instead; use that only if you specifically want it under `dependencies`. Or install globally: `npm install -g pr-shepherd`.
+
+### As individual skills via `npx skills`
+
+```bash
+npx skills add jonathanong/pr-shepherd
+```
+
+Installs the three skills (`check`, `monitor`, `resolve`) into your agent's skill directory (`.claude/skills/` for project scope, `~/.claude/skills/` with `-g` for global scope). Powered by [skills.sh](https://skills.sh).
+
+### As a Claude Code plugin (recommended)
+
+```bash
+claude /plugin marketplace add jonathanong/pr-shepherd
+claude /plugin install pr-shepherd
+```
+
+This repo ships two `marketplace.json` files that serve different install flows: the root `marketplace.json` resolves the plugin from the npm registry (used by the `claude /plugin marketplace add` command above); `.claude-plugin/marketplace.json` is the owner-level registry manifest that resolves the plugin from the local plugin directory (used when Claude Code installs from a local or git-based source). Both files are needed to support these two install paths.
+
+### Without the plugin
+
+See [docs/custom-commands.md](docs/custom-commands.md) for a project-local slash command that wraps the CLI without the plugin.
+
+### As a global CLI
+
+```bash
+npm install -g pr-shepherd
+```
 
 ## Configuration
 
@@ -207,37 +120,6 @@ checks:
 actions:
   autoRebase: false # disable for repos that enforce merge commits
 ```
-
-All supported keys:
-
-| Key                                         | Default                                   | Purpose                                                                                                           |
-| ------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                                |
-| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                               |
-| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                          |
-| `iterate.stallTimeoutMinutes`               | `30`                                      | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
-| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
-| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
-| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
-| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
-| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                                         |
-| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                                |
-| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                                     |
-| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                                    |
-| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
-| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                                        |
-| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
-| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
-| `checks.timeoutPatterns`                    | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `timeout`                                                                 |
-| `checks.infraPatterns`                      | see [`src/config.json`](src/config.json)  | Log patterns that classify a failure as `infrastructure`                                                          |
-| `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                              |
-| `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                                         |
-| `checks.errorLines`                         | `1`                                       | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                                |
-| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
-| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                                  |
-| `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                                   |
-| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
-| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
 
 Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_CACHE_DIR` (override cache base dir), `PR_SHEPHERD_CACHE_TTL_SECONDS` (override cache TTL; `--cache-ttl` takes precedence over this env var, which in turn takes precedence over the RC/config value).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Quick entry point. For a command overview see [`../README.md`](../README.md).
 | [usage.md](usage.md)                 | CLI command reference and flags                                 |
 | [skills.md](skills.md)               | Claude Code skill usage (`/pr-shepherd:*`)                      |
 | [configuration.md](configuration.md) | `.pr-shepherdrc.yml` reference                                  |
+| [custom-commands.md](custom-commands.md) | Project-local slash command that wraps the CLI without the plugin |
 | [forking.md](forking.md)             | How to fork and customize pr-shepherd                           |
 | [flow.md](flow.md)                   | End-to-end mermaid flow diagram                                 |
 | [architecture.md](architecture.md)   | Module map, dependency rules, where to put new code             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,23 +2,23 @@
 
 Quick entry point. For a command overview see [`../README.md`](../README.md).
 
-| Document                             | What it covers                                                  |
-| ------------------------------------ | --------------------------------------------------------------- |
-| [usage.md](usage.md)                 | CLI command reference and flags                                 |
-| [skills.md](skills.md)               | Claude Code skill usage (`/pr-shepherd:*`)                      |
-| [configuration.md](configuration.md) | `.pr-shepherdrc.yml` reference                                  |
+| Document                                 | What it covers                                                    |
+| ---------------------------------------- | ----------------------------------------------------------------- |
+| [usage.md](usage.md)                     | CLI command reference and flags                                   |
+| [skills.md](skills.md)                   | Claude Code skill usage (`/pr-shepherd:*`)                        |
+| [configuration.md](configuration.md)     | `.pr-shepherdrc.yml` reference                                    |
 | [custom-commands.md](custom-commands.md) | Project-local slash command that wraps the CLI without the plugin |
-| [forking.md](forking.md)             | How to fork and customize pr-shepherd                           |
-| [flow.md](flow.md)                   | End-to-end mermaid flow diagram                                 |
-| [architecture.md](architecture.md)   | Module map, dependency rules, where to put new code             |
-| [iterate-flow.md](iterate-flow.md)   | Full 8-step dispatch walkthrough inside `iterate`               |
-| [actions.md](actions.md)             | Every action: trigger, side-effects, prescriptive output fields |
-| [watch-loop.md](watch-loop.md)       | How the monitor skill + `/loop` + `iterate` interact            |
-| [ready-delay.md](ready-delay.md)     | The `ready-since.txt` state machine                             |
-| [cache.md](cache.md)                 | File layout, atomic writes, TTL, bypass paths                   |
-| [graphql.md](graphql.md)             | Batch query, pagination strategy, REST fallbacks                |
-| [checks.md](checks.md)               | Classify → triage → `failureKind`, event filtering              |
-| [comments.md](comments.md)           | Threads vs comments, outdated detection, push-before-resolve    |
-| [merge-status.md](merge-status.md)   | `deriveMergeStatus` rules, edge cases                           |
-| [extending.md](extending.md)         | Recipes: add an action, classifier, mutation                    |
-| [debugging.md](debugging.md)         | Failure modes, how to replay an iteration                       |
+| [forking.md](forking.md)                 | How to fork and customize pr-shepherd                             |
+| [flow.md](flow.md)                       | End-to-end mermaid flow diagram                                   |
+| [architecture.md](architecture.md)       | Module map, dependency rules, where to put new code               |
+| [iterate-flow.md](iterate-flow.md)       | Full 8-step dispatch walkthrough inside `iterate`                 |
+| [actions.md](actions.md)                 | Every action: trigger, side-effects, prescriptive output fields   |
+| [watch-loop.md](watch-loop.md)           | How the monitor skill + `/loop` + `iterate` interact              |
+| [ready-delay.md](ready-delay.md)         | The `ready-since.txt` state machine                               |
+| [cache.md](cache.md)                     | File layout, atomic writes, TTL, bypass paths                     |
+| [graphql.md](graphql.md)                 | Batch query, pagination strategy, REST fallbacks                  |
+| [checks.md](checks.md)                   | Classify → triage → `failureKind`, event filtering                |
+| [comments.md](comments.md)               | Threads vs comments, outdated detection, push-before-resolve      |
+| [merge-status.md](merge-status.md)       | `deriveMergeStatus` rules, edge cases                             |
+| [extending.md](extending.md)             | Recipes: add an action, classifier, mutation                      |
+| [debugging.md](debugging.md)             | Failure modes, how to replay an iteration                         |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,39 @@ iterate:
 
 ---
 
+## All supported keys
+
+| Key                                         | Default                                   | Purpose                                                                                                           |
+| ------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                                |
+| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                               |
+| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                          |
+| `iterate.stallTimeoutMinutes`               | `30`                                      | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
+| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
+| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
+| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
+| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
+| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                                         |
+| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                                |
+| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                                     |
+| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                                    |
+| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
+| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                                        |
+| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
+| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
+| `checks.timeoutPatterns`                    | see [`src/config.json`](../src/config.json)  | Log patterns that classify a failure as `timeout`                                                              |
+| `checks.infraPatterns`                      | see [`src/config.json`](../src/config.json)  | Log patterns that classify a failure as `infrastructure`                                                       |
+| `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                              |
+| `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                                         |
+| `checks.errorLines`                         | `1`                                       | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                                |
+| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
+| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                                  |
+| `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                                   |
+| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
+| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
+
+---
+
 ## `cache`
 
 ### `cache.ttlSeconds` — default `300`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,34 +59,34 @@ iterate:
 
 ## All supported keys
 
-| Key                                         | Default                                   | Purpose                                                                                                           |
-| ------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                                |
-| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                               |
-| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                          |
-| `iterate.stallTimeoutMinutes`               | `30`                                      | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
-| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
-| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
-| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
-| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
-| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                                         |
-| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                                |
-| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                                     |
-| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                                    |
-| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
-| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                                        |
-| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
-| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
-| `checks.timeoutPatterns`                    | see [`src/config.json`](../src/config.json)  | Log patterns that classify a failure as `timeout`                                                              |
-| `checks.infraPatterns`                      | see [`src/config.json`](../src/config.json)  | Log patterns that classify a failure as `infrastructure`                                                       |
-| `checks.logMaxLines`                        | `50`                                      | Max log lines kept per failing check                                                                              |
-| `checks.logMaxChars`                        | `3000`                                    | Max log characters kept per failing check                                                                         |
-| `checks.errorLines`                         | `1`                                       | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                                |
-| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
-| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                                  |
-| `actions.autoRebase`                        | `true`                                    | Emit `rebase` for flaky failures when the branch is behind base                                                   |
-| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
-| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
+| Key                                         | Default                                     | Purpose                                                                                                           |
+| ------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `cache.ttlSeconds`                          | `300`                                       | File-cache TTL for read operations                                                                                |
+| `iterate.cooldownSeconds`                   | `30`                                        | Wait after a push before reading CI                                                                               |
+| `iterate.fixAttemptsPerThread`              | `3`                                         | Max fix attempts per unresolved thread before `escalate`                                                          |
+| `iterate.stallTimeoutMinutes`               | `30`                                        | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
+| `iterate.minimizeReviewSummaries.bots`      | `true`                                      | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
+| `iterate.minimizeReviewSummaries.humans`    | `true`                                      | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
+| `iterate.minimizeReviewSummaries.approvals` | `false`                                     | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
+| `watch.interval`                            | `"4m"`                                      | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
+| `watch.readyDelayMinutes`                   | `10`                                        | Settle window after READY before the monitor loop cancels                                                         |
+| `watch.expiresHours`                        | `8`                                         | Max lifetime of a monitor cron job                                                                                |
+| `watch.maxTurns`                            | `50`                                        | Max monitor ticks per session                                                                                     |
+| `resolve.concurrency`                       | `4`                                         | Parallel fanout for per-thread GraphQL fetches                                                                    |
+| `resolve.shaPoll.intervalMs`                | `2000`                                      | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
+| `resolve.shaPoll.maxAttempts`               | `10`                                        | Max `--require-sha` polls before giving up                                                                        |
+| `resolve.fetchReviewSummaries`              | `true`                                      | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
+| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]`   | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
+| `checks.timeoutPatterns`                    | see [`src/config.json`](../src/config.json) | Log patterns that classify a failure as `timeout`                                                                 |
+| `checks.infraPatterns`                      | see [`src/config.json`](../src/config.json) | Log patterns that classify a failure as `infrastructure`                                                          |
+| `checks.logMaxLines`                        | `50`                                        | Max log lines kept per failing check                                                                              |
+| `checks.logMaxChars`                        | `3000`                                      | Max log characters kept per failing check                                                                         |
+| `checks.errorLines`                         | `1`                                         | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                                |
+| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                               | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
+| `actions.autoResolveOutdated`               | `true`                                      | Auto-resolve threads that point to code no longer in the PR diff                                                  |
+| `actions.autoRebase`                        | `true`                                      | Emit `rebase` for flaky failures when the branch is behind base                                                   |
+| `actions.autoMarkReady`                     | `true`                                      | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
+| `actions.commitSuggestions`                 | `true`                                      | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
 
 ---
 

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -4,8 +4,9 @@
 
 If you don't want the full plugin, create a project-local (or user-scope)
 slash command that wraps the CLI directly. This still requires `pr-shepherd`
-to be installed in the repository first (`npm install pr-shepherd`), so that
-`npx pr-shepherd ...` runs without prompting to install the package.
+to be installed in the repository first (preferably as a dev dependency:
+`npm install --save-dev pr-shepherd`), so that `npx pr-shepherd ...` runs
+without prompting to install the package.
 
 1. **Create the command file:**
    - Project-scope: `.claude/commands/pr-check.md`

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -1,0 +1,60 @@
+# Custom slash commands without the plugin
+
+[← README](../README.md)
+
+If you don't want the full plugin, create a project-local (or user-scope)
+slash command that wraps the CLI directly. This still requires `pr-shepherd`
+to be installed in the repository first (`npm install pr-shepherd`), so that
+`npx pr-shepherd ...` runs without prompting to install the package.
+
+1. **Create the command file:**
+   - Project-scope: `.claude/commands/pr-check.md`
+   - User-scope: `~/.claude/commands/pr-check.md`
+
+2. **Paste this as the file contents:**
+
+   ````markdown
+   ---
+   description: "Check GitHub CI status and review comments for the current PR"
+   argument-hint: "[PR number or URL ...]"
+   allowed-tools: ["Bash", "Read", "Grep"]
+   ---
+
+   # PR Status Check
+
+   ## Arguments: $ARGUMENTS
+
+   ## Resolve PR number(s)
+
+   1. If `$ARGUMENTS` contains PR numbers or GitHub PR URLs, extract the number(s).
+   2. Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
+   3. If no PR found, report an error and stop.
+
+   ## Run the check
+
+   ```bash
+   npx pr-shepherd check <PR_NUMBER> --format=json
+   ```
+
+   Parse the JSON and report:
+
+   - **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN
+   - **CI check results** (`checks.passing`, `checks.failing`, `checks.inProgress`): passing count, failing names, in-progress names
+   - **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details
+   ````
+
+3. **Use it in Claude Code:**
+
+   ```
+   /pr-check
+   /pr-check 42
+   ```
+
+For `monitor` and `resolve` custom commands, do **not** copy the
+[`plugin/skills/`](../plugin/skills/) files directly — those contain skill/plugin-specific
+frontmatter that is not valid for `.claude/commands/` files. Instead, create
+`.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
+using the same command-file structure as the `pr-check` example above, with
+the CLI invocation changed to `npx pr-shepherd iterate ...` or
+`npx pr-shepherd resolve ...`. To drive the CLI without Claude at all, see
+[usage.md](usage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,7 @@ Read-only PR status snapshot. Fetches CI results, merge state, and review commen
 ```sh
 pr-shepherd check           # infer PR from current branch
 pr-shepherd check 42
-pr-shepherd check 42 --format=json
+pr-shepherd check 42
 pr-shepherd check 42 --no-cache
 ```
 
@@ -64,7 +64,7 @@ Two modes: **fetch** (default) auto-resolves outdated threads and returns action
 
 ```sh
 pr-shepherd resolve           # fetch + auto-resolve outdated threads
-pr-shepherd resolve 42 --fetch --format=json
+pr-shepherd resolve 42 --fetch
 ```
 
 ```
@@ -164,7 +164,7 @@ Exit codes: `0` suggestion applied and committed · `1` any error.
 One monitor tick: classifies current PR state and emits a single action. Used by the cron loop; the monitor skill calls this every 4 minutes and acts on the result. See [iterate-flow.md](iterate-flow.md) for the full decision tree.
 
 ```sh
-pr-shepherd iterate 42 --no-cache --format=json \
+pr-shepherd iterate 42 --no-cache \
   --ready-delay 10m \
   --last-push-time "$(git log -1 --format=%ct HEAD)"
 ```
@@ -220,7 +220,7 @@ Multi-PR summary table. One lightweight GraphQL query per PR, run in parallel.
 
 ```sh
 pr-shepherd status 41 42 43
-pr-shepherd status 100 --format=json
+pr-shepherd status 100
 ```
 
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,6 @@ Read-only PR status snapshot. Fetches CI results, merge state, and review commen
 ```sh
 pr-shepherd check           # infer PR from current branch
 pr-shepherd check 42
-pr-shepherd check 42
 pr-shepherd check 42 --no-cache
 ```
 


### PR DESCRIPTION
## Summary

- Removes `## Features` (CLI command catalog) and standalone `## CLI` section from README; replaces with a merged Usage section that puts skills front-and-center right after Design principles
- Extracts the custom-slash-command walkthrough into `docs/custom-commands.md`; README now has a one-line pointer under Install
- Moves the 30-row config key quick-reference table from README into `docs/configuration.md` (sits above the existing per-key long-form reference as a new `## All supported keys` section)
- Adds `docs/custom-commands.md` to the `docs/README.md` index
- Drops non-demonstrative `--format=json` flags from `docs/usage.md` examples (JSON output is the exception, not the default; kept only where the example explicitly shows JSON output)

## Test plan

- [ ] Render `README.md` preview and confirm section order: Title → Why → Design principles → Usage → Workflow → Install → Configuration → Requirements → Docs → Architecture → Forking → License
- [ ] Confirm no `## Features`, `## CLI`, 30-row config table, or inline custom-command walkthrough remain on the README
- [ ] All links in README resolve: `docs/skills.md`, `docs/custom-commands.md`, `docs/configuration.md`, `docs/usage.md`, `docs/iterate-flow.md`, `docs/flow.md`, `docs/architecture.md`, `docs/forking.md`, `docs/README.md`
- [ ] `grep -n "format=json" docs/usage.md` returns only the Common-flags table row, commit-suggestion JSON demo, JSON-output heading, and parity prose sentence
- [ ] `docs/custom-commands.md` opens with title + `[← README](../README.md)` backlink
- [ ] `docs/configuration.md` has `## All supported keys` table between `## Example` and `## cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)