### PR TITLE
refactor: shift check skill policy into CLI output; shrink SKILL.md to thin dispatcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,22 @@ CLI output that targets a human or an AI agent must be easy to read and act on:
 
 ## Keep skills and loop prompts minimal
 
-Skills (`plugin/skills/*/SKILL.md`) and `/loop` prompts should be thin dispatchers: parse inputs, invoke the CLI, print the output, then follow the output's own `## Instructions` section.
+Skills (`plugin/skills/*/SKILL.md`) and `/loop` prompts should be thin dispatchers with this shape:
 
-Per-action dispatch logic — which command to extract, which tool to call, what variant to run, substitution rules — belongs in the CLI's Markdown output as a `## Instructions` section, not in the skill or the loop prompt.
+1. Parse arguments.
+2. Short-circuit trivial cases (e.g. merged PR).
+3. Invoke the CLI.
+4. Print the full output.
+5. Follow the output's own `## Instructions` section exactly.
 
-Rule of thumb: if a skill or loop prompt contains a dispatch table keyed on CLI output shape, that table should live in the CLI's output instead.
+The canonical example is `plugin/skills/resolve/SKILL.md` — 37 lines, pure dispatcher, no policy.
+
+Everything else belongs in the CLI's Markdown `## Instructions` output, not in the skill:
+
+- Per-action dispatch (which command to extract, which tool to call, what variant to run).
+- **Interpretation and policy tables keyed on CLI output shape** — enum meanings (e.g. what `CONFLICTS` means for rebase), CI budget rules (`failureKind` handling, rerun commands), ready-to-merge predicates, field-by-field reporting templates.
+- Any instruction the reader is expected to act on.
+
+Rule of thumb: if a skill contains a table, policy, or interpretation block whose inputs come from CLI output fields, that content belongs in the CLI's `## Instructions` section instead.
 
 Skills must not link to files outside the `plugin/` directory (such as `docs/**` or `README.md`). Those files are not included in the published plugin and will be dead links for consumers. All information a skill consumer needs must come from the CLI output itself or be written inline in the skill.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -39,20 +39,35 @@ Exit codes: `0` READY · `2` IN_PROGRESS · `3` UNRESOLVED_COMMENTS · `1` all o
 PR #42 — owner/repo
 Status: UNRESOLVED_COMMENTS
 
-Merge Status: CLEAN
-  mergeStateStatus:       CLEAN
-  mergeable:              MERGEABLE
-  reviewDecision:         APPROVED
-  isDraft:                false
-  copilotReviewInProgress:false
+## Merge Status
 
-CI Checks: 3/3 passed
+CLEAN
+  mergeStateStatus:        CLEAN
+  mergeable:               MERGEABLE
+  reviewDecision:          APPROVED
+  isDraft:                 false
+  copilotReviewInProgress: false
 
-Actionable Review Threads (1):
-  - threadId=RT_kwDOBxyz123 src/api.ts:47 (@reviewer)
-    Please add error handling here
+## CI Checks
 
-Summary: 1 actionable item(s) remaining
+3/3 passed
+
+## Review Threads
+
+### Actionable (1)
+
+- threadId=RT_kwDOBxyz123 src/api.ts:47 (@reviewer)
+  Please add error handling here
+
+## Summary
+
+1 actionable item(s) remaining
+
+## Instructions
+
+1. Report: merge status is CLEAN, CI 3/3 passed, 1 actionable review item(s).
+2. Do not declare this PR ready to merge: status is UNRESOLVED_COMMENTS (not READY).
+3. This is a one-shot check. For continuous monitoring…, use `/pr-shepherd:monitor`.
 ```
 
 ### pr-shepherd resolve [PR]

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -67,7 +67,7 @@ CLEAN
 
 1. Report: merge status is CLEAN, CI 3/3 passed, 1 actionable review item(s).
 2. Do not declare this PR ready to merge: status is UNRESOLVED_COMMENTS (not READY).
-3. This is a one-shot check. For continuous monitoring…, use `/pr-shepherd:monitor`.
+3. This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.
 ```
 
 ### pr-shepherd resolve [PR]

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,7 +21,7 @@ The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-m
 
 ## `/pr-shepherd:check`
 
-One-shot PR status snapshot. Reports merge status, CI results, and unresolved comments.
+One-shot PR status snapshot. Reports merge status, CI results, and unresolved comments. The skill is a thin dispatcher: it runs `pr-shepherd check <N>`, prints the Markdown output, then follows the `## Instructions` section embedded in that output. All rebase policy, CI budget rules, and ready-to-merge gating are described in the CLI output itself — not in the skill.
 
 ```
 /pr-shepherd:check        # infer from branch

--- a/plugin/skills/check/SKILL.md
+++ b/plugin/skills/check/SKILL.md
@@ -10,59 +10,26 @@ allowed-tools: ["Bash"]
 
 ## Arguments: $ARGUMENTS
 
-## Resolve PR number(s)
+## Steps
 
-1. If `$ARGUMENTS` contains PR numbers or GitHub PR URLs, extract the number(s).
-2. Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
-3. If no PR found, report an error and stop.
+1. **Parse `$ARGUMENTS`:** extract PR numbers or GitHub PR URLs. If none, infer:
+   `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
+   If no PR found, report an error and stop.
 
-For each resolved PR number, check if it is already merged:
+2. **Short-circuit if merged:**
 
-```bash
-gh pr view <N> --json state --jq '.state'
-```
+   ```bash
+   gh pr view <N> --json state --jq '.state'
+   ```
 
-If `MERGED`, output: `PR #N is already merged. Nothing to check.` and skip.
+   If `MERGED`, output: `PR #N is already merged. Nothing to check.` and skip.
 
-## Run the check
+3. **Run the check and follow instructions:**
 
-```bash
-npx pr-shepherd check <N> --format=json
-```
+   ```bash
+   npx pr-shepherd check <N>
+   ```
 
-## Reporting
+   Print the full output. Follow the `## Instructions` section exactly.
 
-Parse the JSON output and report all three:
-
-- **Merge status** (`mergeStatus.status`): CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN — never omit; include `copilotReviewInProgress` when true
-- **CI check results** (`checks.passing`, `checks.failing`, `checks.inProgress`): passing count, failing names + kinds, in-progress names
-- **Unresolved review comments** (`threads.actionable` + `comments.actionable`): count + details with file paths and line numbers
-
-## Rebase policy
-
-The CLI already determines whether a rebase is warranted. Read `mergeStatus.status` directly:
-
-- `CONFLICTS` — a rebase is required to resolve the merge conflict before the PR can land.
-- `BEHIND` — a rebase may be appropriate; a `flaky` failure while `BEHIND` is the canonical rebase signal. If all checks pass but the PR is `BEHIND`, a rebase is optional.
-- Any other status — no rebase needed.
-
-Do not re-derive these conditions from raw branch state. For automated monitoring that acts on these signals, use `/pr-shepherd:monitor` — it handles rebase decisions end-to-end.
-
-## CI budget policy
-
-Each entry in `checks.failing` carries a `failureKind` field. Read it directly rather than re-classifying failures:
-
-- `actionable` — the failure is code-level and needs a fix.
-- `infrastructure` — transient infra problem; re-run with `gh run rerun <runId> --failed`.
-- `timeout` — job exceeded the time limit; re-run with `gh run rerun <runId> --failed`.
-- `flaky` — known-flaky test; do NOT cancel. Rebase first if `mergeStatus.status` is `BEHIND`.
-
-## Never declare ready to merge
-
-Unless ALL of:
-
-1. `mergeStatus.mergeStateStatus == 'CLEAN'`
-2. `status == 'READY'`
-3. `mergeStatus.copilotReviewInProgress == false`
-
-This is a one-shot check. For continuous monitoring, use `/pr-shepherd:monitor`.
+4. For multiple PRs, repeat steps 2–3 for each.

--- a/src/reporters/check-instructions.mts
+++ b/src/reporters/check-instructions.mts
@@ -1,0 +1,88 @@
+import type { ShepherdReport } from "../types.mts";
+
+/**
+ * Build the numbered instruction steps for the agent to follow after a `check` run.
+ * All rebase policy, CI budget policy, and ready-to-merge gating live here so the
+ * skill stays a thin dispatcher and these rules co-evolve with the CLI data model.
+ */
+export function buildCheckInstructions(report: ShepherdReport): string[] {
+  const { mergeStatus, checks, threads, comments, changesRequestedReviews, status } = report;
+
+  const instructions: string[] = [];
+
+  // 1. Summary
+  const totalActionable =
+    threads.actionable.length + comments.actionable.length + changesRequestedReviews.length;
+  const total =
+    checks.passing.length +
+    checks.failing.length +
+    checks.inProgress.length +
+    checks.skipped.length;
+  const copilotNote = mergeStatus.copilotReviewInProgress ? " (Copilot review in progress)" : "";
+  instructions.push(
+    `Report: merge status is ${mergeStatus.status}${copilotNote}, CI ${checks.passing.length}/${total} passed` +
+      (checks.failing.length > 0 ? ` (${checks.failing.length} failing)` : "") +
+      (checks.inProgress.length > 0 ? ` (${checks.inProgress.length} in progress)` : "") +
+      `, ${totalActionable} actionable review item(s).`,
+  );
+
+  // 2. Rebase policy (only emit when relevant)
+  const anyFlaky = checks.failing.some((c) => c.failureKind === "flaky");
+  if (mergeStatus.status === "CONFLICTS") {
+    instructions.push(
+      "Rebase required: the branch has merge conflicts that must be resolved before this PR can land.",
+    );
+  } else if (mergeStatus.status === "BEHIND" && anyFlaky) {
+    instructions.push(
+      "Rebase recommended: the PR is behind the base branch and has a flaky failure — this is the canonical rebase signal. Run `git fetch origin && git rebase origin/<baseBranch>` then `git push --force-with-lease`."
+        .replace("<baseBranch>", report.baseBranch),
+    );
+  } else if (mergeStatus.status === "BEHIND") {
+    instructions.push(
+      "The PR is behind the base branch. A rebase is optional if all CI checks pass; rebase if a flaky failure appears after rechecking.",
+    );
+  }
+
+  // 3. CI budget policy — one instruction per failing check
+  for (const c of checks.failing) {
+    if (c.failureKind === "actionable") {
+      instructions.push(
+        `Fix code failure: \`${c.name}\` (actionable) — investigate the log excerpt in the output above and apply a fix.`,
+      );
+    } else if (c.failureKind === "infrastructure" || c.failureKind === "timeout") {
+      const rerunCmd = c.runId
+        ? `gh run rerun ${c.runId} --failed`
+        : `gh run rerun <runId> --failed`;
+      instructions.push(
+        `Re-run transient failure: \`${c.name}\` [${c.failureKind}] — run \`${rerunCmd}\`.`,
+      );
+    } else if (c.failureKind === "flaky") {
+      const rebasing = mergeStatus.status === "BEHIND" ? " Rebase first — see rebase instruction above." : "";
+      instructions.push(
+        `Do not cancel flaky failure: \`${c.name}\` [flaky]. Do NOT cancel the run.${rebasing}`,
+      );
+    }
+  }
+
+  // 4. Ready-to-merge gate
+  const isClean = mergeStatus.mergeStateStatus === "CLEAN";
+  const isReady = isClean && status === "READY" && !mergeStatus.copilotReviewInProgress;
+  if (isReady) {
+    instructions.push(
+      "This PR is ready to merge: mergeStateStatus is CLEAN, status is READY, and no Copilot review is in progress.",
+    );
+  } else {
+    const blockers: string[] = [];
+    if (!isClean) blockers.push(`mergeStateStatus is ${mergeStatus.mergeStateStatus} (not CLEAN)`);
+    if (status !== "READY") blockers.push(`status is ${status} (not READY)`);
+    if (mergeStatus.copilotReviewInProgress) blockers.push("Copilot review is still in progress");
+    instructions.push(`Do not declare this PR ready to merge: ${blockers.join("; ")}.`);
+  }
+
+  // 5. Continuous monitoring pointer
+  instructions.push(
+    "This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.",
+  );
+
+  return instructions;
+}

--- a/src/reporters/check-instructions.mts
+++ b/src/reporters/check-instructions.mts
@@ -34,8 +34,10 @@ export function buildCheckInstructions(report: ShepherdReport): string[] {
     );
   } else if (mergeStatus.status === "BEHIND" && anyFlaky) {
     instructions.push(
-      "Rebase recommended: the PR is behind the base branch and has a flaky failure — this is the canonical rebase signal. Run `git fetch origin && git rebase origin/<baseBranch>` then `git push --force-with-lease`."
-        .replace("<baseBranch>", report.baseBranch),
+      "Rebase recommended: the PR is behind the base branch and has a flaky failure — this is the canonical rebase signal. Run `git fetch origin && git rebase origin/<baseBranch>` then `git push --force-with-lease`.".replace(
+        "<baseBranch>",
+        report.baseBranch,
+      ),
     );
   } else if (mergeStatus.status === "BEHIND") {
     instructions.push(
@@ -57,7 +59,8 @@ export function buildCheckInstructions(report: ShepherdReport): string[] {
         `Re-run transient failure: \`${c.name}\` [${c.failureKind}] — run \`${rerunCmd}\`.`,
       );
     } else if (c.failureKind === "flaky") {
-      const rebasing = mergeStatus.status === "BEHIND" ? " Rebase first — see rebase instruction above." : "";
+      const rebasing =
+        mergeStatus.status === "BEHIND" ? " Rebase first — see rebase instruction above." : "";
       instructions.push(
         `Do not cancel flaky failure: \`${c.name}\` [flaky]. Do NOT cancel the run.${rebasing}`,
       );

--- a/src/reporters/check-instructions.mts
+++ b/src/reporters/check-instructions.mts
@@ -48,8 +48,11 @@ export function buildCheckInstructions(report: ShepherdReport): string[] {
   // 3. CI budget policy — one instruction per failing check
   for (const c of checks.failing) {
     if (c.failureKind === "actionable") {
+      const diagnosisSource = c.logExcerpt
+        ? "investigate the log excerpt in the output above"
+        : `open the check details (${c.detailsUrl}) to diagnose the failure`;
       instructions.push(
-        `Fix code failure: \`${c.name}\` (actionable) — investigate the log excerpt in the output above and apply a fix.`,
+        `Fix code failure: \`${c.name}\` (actionable) — ${diagnosisSource} and apply a fix.`,
       );
     } else if (c.failureKind === "infrastructure" || c.failureKind === "timeout") {
       const rerunCmd = c.runId

--- a/src/reporters/check-instructions.test.mts
+++ b/src/reporters/check-instructions.test.mts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import { buildCheckInstructions } from "./check-instructions.mts";
+import type { ShepherdReport, ClassifiedCheck, TriagedCheck } from "../types.mts";
+
+function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
+  return {
+    name: "ci / tests",
+    status: "COMPLETED",
+    conclusion: "SUCCESS",
+    detailsUrl: "",
+    event: "pull_request",
+    runId: null,
+    category: "passed",
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
+  return {
+    pr: 42,
+    nodeId: "PR_kgDOAAA",
+    repo: "owner/repo",
+    status: "READY",
+    baseBranch: "main",
+    mergeStatus: {
+      status: "CLEAN",
+      state: "OPEN",
+      isDraft: false,
+      mergeable: "MERGEABLE",
+      reviewDecision: "APPROVED",
+      copilotReviewInProgress: false,
+      mergeStateStatus: "CLEAN",
+    },
+    checks: {
+      passing: [makeCheck()],
+      failing: [],
+      inProgress: [],
+      skipped: [],
+      filtered: [],
+      filteredNames: [],
+      blockedByFilteredCheck: false,
+    },
+    threads: { actionable: [], autoResolved: [], autoResolveErrors: [] },
+    comments: { actionable: [] },
+    changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
+    ...overrides,
+  };
+}
+
+describe("buildCheckInstructions — summary", () => {
+  it("includes merge status in summary", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps[0]).toContain("CLEAN");
+  });
+
+  it("includes CI pass count in summary", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps[0]).toContain("1/1 passed");
+  });
+
+  it("includes failing count in summary when non-zero", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ category: "failing", conclusion: "FAILURE" }),
+      failureKind: "actionable",
+    };
+    const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
+    const steps = buildCheckInstructions(report);
+    expect(steps[0]).toContain("1 failing");
+  });
+
+  it("mentions copilot review in progress when true", () => {
+    const report = makeReport({
+      mergeStatus: { ...makeReport().mergeStatus, copilotReviewInProgress: true },
+    });
+    const steps = buildCheckInstructions(report);
+    expect(steps[0]).toContain("Copilot review in progress");
+  });
+
+  it("includes actionable item count", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps[0]).toContain("0 actionable review item(s)");
+  });
+});
+
+describe("buildCheckInstructions — rebase policy", () => {
+  it("emits rebase-required for CONFLICTS", () => {
+    const report = makeReport({
+      mergeStatus: {
+        ...makeReport().mergeStatus,
+        status: "CONFLICTS",
+        mergeStateStatus: "DIRTY",
+      },
+    });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Rebase required"))).toBe(true);
+  });
+
+  it("emits rebase-recommended for BEHIND + flaky failure", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "tests", category: "failing", conclusion: "FAILURE" }),
+      failureKind: "flaky",
+    };
+    const report = makeReport({
+      mergeStatus: { ...makeReport().mergeStatus, status: "BEHIND" },
+      checks: { ...makeReport().checks, failing: [failing] },
+    });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Rebase recommended"))).toBe(true);
+  });
+
+  it("emits rebase-optional for BEHIND + no flaky failures", () => {
+    const report = makeReport({
+      mergeStatus: { ...makeReport().mergeStatus, status: "BEHIND" },
+    });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("A rebase is optional"))).toBe(true);
+  });
+
+  it("emits no rebase step for CLEAN", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps.some((s) => s.toLowerCase().includes("rebase"))).toBe(false);
+  });
+});
+
+describe("buildCheckInstructions — CI budget policy", () => {
+  it("emits fix-code for actionable failure", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "lint", category: "failing", conclusion: "FAILURE" }),
+      failureKind: "actionable",
+    };
+    const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Fix code failure") && s.includes("lint"))).toBe(true);
+  });
+
+  it("emits rerun with runId for infrastructure failure", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "build", category: "failing", conclusion: "CANCELLED", runId: "99999" }),
+      failureKind: "infrastructure",
+    };
+    const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("gh run rerun 99999 --failed"))).toBe(true);
+  });
+
+  it("emits rerun with placeholder when runId is null", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "build", category: "failing", conclusion: "TIMED_OUT", runId: null }),
+      failureKind: "timeout",
+    };
+    const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("gh run rerun <runId> --failed"))).toBe(true);
+  });
+
+  it("emits do-not-cancel for flaky failure", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "e2e", category: "failing", conclusion: "FAILURE" }),
+      failureKind: "flaky",
+    };
+    const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Do not cancel") && s.includes("e2e"))).toBe(true);
+  });
+
+  it("appends rebase-first note to flaky step when BEHIND", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "e2e", category: "failing", conclusion: "FAILURE" }),
+      failureKind: "flaky",
+    };
+    const report = makeReport({
+      mergeStatus: { ...makeReport().mergeStatus, status: "BEHIND" },
+      checks: { ...makeReport().checks, failing: [failing] },
+    });
+    const steps = buildCheckInstructions(report);
+    const flakStep = steps.find((s) => s.includes("Do not cancel") && s.includes("e2e"));
+    expect(flakStep).toContain("Rebase first");
+  });
+
+  it("emits no CI budget steps when no failing checks", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps.some((s) => s.includes("Fix code") || s.includes("Re-run") || s.includes("Do not cancel"))).toBe(false);
+  });
+});
+
+describe("buildCheckInstructions — ready-to-merge gate", () => {
+  it("declares ready when CLEAN + READY + no copilot", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps.some((s) => s.includes("ready to merge"))).toBe(true);
+  });
+
+  it("blocks when status is not READY", () => {
+    const report = makeReport({ status: "FAILING" });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Do not declare") && s.includes("FAILING"))).toBe(true);
+  });
+
+  it("blocks when mergeStateStatus is not CLEAN", () => {
+    const report = makeReport({
+      mergeStatus: { ...makeReport().mergeStatus, mergeStateStatus: "BLOCKED" },
+    });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Do not declare") && s.includes("BLOCKED"))).toBe(true);
+  });
+
+  it("blocks when copilotReviewInProgress is true", () => {
+    const report = makeReport({
+      mergeStatus: { ...makeReport().mergeStatus, copilotReviewInProgress: true },
+    });
+    const steps = buildCheckInstructions(report);
+    expect(steps.some((s) => s.includes("Do not declare") && s.includes("Copilot"))).toBe(true);
+  });
+});
+
+describe("buildCheckInstructions — monitoring pointer", () => {
+  it("always includes a /pr-shepherd:monitor pointer", () => {
+    const steps = buildCheckInstructions(makeReport());
+    expect(steps[steps.length - 1]).toContain("/pr-shepherd:monitor");
+  });
+});

--- a/src/reporters/check-instructions.test.mts
+++ b/src/reporters/check-instructions.test.mts
@@ -181,7 +181,11 @@ describe("buildCheckInstructions — CI budget policy", () => {
 
   it("emits no CI budget steps when no failing checks", () => {
     const steps = buildCheckInstructions(makeReport());
-    expect(steps.some((s) => s.includes("Fix code") || s.includes("Re-run") || s.includes("Do not cancel"))).toBe(false);
+    expect(
+      steps.some(
+        (s) => s.includes("Fix code") || s.includes("Re-run") || s.includes("Do not cancel"),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/reporters/json.mts
+++ b/src/reporters/json.mts
@@ -1,12 +1,13 @@
 /**
- * Machine-readable JSON reporter.
+ * Machine-readable JSON reporter for shepherd check output.
  *
  * Slash commands parse this output to extract IDs, status, and actionable items
  * without string-scraping the human-readable text reporter.
  */
 
 import type { ShepherdReport } from "../types.mts";
+import { buildCheckInstructions } from "./check-instructions.mts";
 
 export function formatJson(report: ShepherdReport): string {
-  return JSON.stringify(report, null, 2);
+  return JSON.stringify({ ...report, instructions: buildCheckInstructions(report) }, null, 2);
 }

--- a/src/reporters/json.test.mts
+++ b/src/reporters/json.test.mts
@@ -37,10 +37,20 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
 }
 
 describe("formatJson", () => {
-  it("produces valid JSON that round-trips to the original report", () => {
+  it("produces valid JSON containing all report fields", () => {
     const report = makeReport();
     const output = formatJson(report);
-    expect(JSON.parse(output)).toEqual(report);
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    // instructions is added by the formatter; strip it before comparing
+    const { instructions: _instructions, ...rest } = parsed;
+    expect(rest).toEqual(report);
+  });
+
+  it("includes non-empty instructions array", () => {
+    const output = formatJson(makeReport());
+    const parsed = JSON.parse(output) as { instructions: unknown };
+    expect(Array.isArray(parsed.instructions)).toBe(true);
+    expect((parsed.instructions as string[]).length).toBeGreaterThan(0);
   });
 
   it("indents with 2 spaces", () => {
@@ -55,5 +65,11 @@ describe("formatJson", () => {
     const parsed = JSON.parse(formatJson(report)) as ShepherdReport;
     expect(parsed.pr).toBe(99);
     expect(parsed.status).toBe("FAILING");
+  });
+
+  it("instructions include monitoring pointer", () => {
+    const output = formatJson(makeReport());
+    const parsed = JSON.parse(output) as { instructions: string[] };
+    expect(parsed.instructions.some((s) => s.includes("/pr-shepherd:monitor"))).toBe(true);
   });
 });

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -4,7 +4,7 @@ import { buildCheckInstructions } from "./check-instructions.mts";
 export function formatText(report: ShepherdReport): string {
   const parts: string[] = [];
 
-  // Header — status dashboard, scanned at a glance (exempt from heading rule per CLAUDE.md)
+  // Header — scan-friendly status lines for quick at-a-glance review
   parts.push(`\nPR #${report.pr} — ${report.repo}`);
   parts.push(`Status: ${report.status}`);
   parts.push("");
@@ -62,6 +62,7 @@ export function formatText(report: ShepherdReport): string {
     parts.push(
       `### Filtered non-PR-trigger (${report.checks.filtered.length}): ${report.checks.filtered.map((c) => c.name).join(", ")}`,
     );
+    parts.push("");
     if (report.checks.blockedByFilteredCheck) {
       parts.push(
         "  Note: PR is BLOCKED and all filtered checks are non-PR-trigger — one of these filtered checks may be a required status check blocking merge.",

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -1,127 +1,160 @@
-/**
- * Human-readable text reporter for shepherd check output.
- */
-
 import type { ShepherdReport, TriagedCheck } from "../types.mts";
+import { buildCheckInstructions } from "./check-instructions.mts";
 
 export function formatText(report: ShepherdReport): string {
-  const lines: string[] = [];
+  const parts: string[] = [];
 
-  // Header
-  lines.push(`\nPR #${report.pr} — ${report.repo}`);
-  lines.push(`Status: ${report.status}`);
-  lines.push("");
+  // Header — status dashboard, scanned at a glance (exempt from heading rule per CLAUDE.md)
+  parts.push(`\nPR #${report.pr} — ${report.repo}`);
+  parts.push(`Status: ${report.status}`);
+  parts.push("");
 
   // Merge status
   const ms = report.mergeStatus;
-  lines.push(`Merge Status: ${ms.status}`);
-  lines.push(`  mergeStateStatus:       ${ms.mergeStateStatus}`);
-  lines.push(`  mergeable:              ${ms.mergeable}`);
-  lines.push(`  reviewDecision:         ${ms.reviewDecision ?? "(none)"}`);
-  lines.push(`  isDraft:                ${ms.isDraft}`);
-  lines.push(`  copilotReviewInProgress:${ms.copilotReviewInProgress}`);
-  lines.push("");
+  parts.push("## Merge Status");
+  parts.push("");
+  parts.push(`${ms.status}`);
+  parts.push(`  mergeStateStatus:        ${ms.mergeStateStatus}`);
+  parts.push(`  mergeable:               ${ms.mergeable}`);
+  parts.push(`  reviewDecision:          ${ms.reviewDecision ?? "(none)"}`);
+  parts.push(`  isDraft:                 ${ms.isDraft}`);
+  parts.push(`  copilotReviewInProgress: ${ms.copilotReviewInProgress}`);
+  parts.push("");
 
   // CI checks
   const { passing, failing, inProgress, skipped } = report.checks;
   const total = passing.length + failing.length + inProgress.length + skipped.length;
-  lines.push(`CI Checks: ${passing.length}/${total} passed`);
+
+  parts.push("## CI Checks");
+  parts.push("");
+  parts.push(`${passing.length}/${total} passed`);
+  parts.push("");
 
   if (failing.length > 0) {
-    lines.push(`\nFailed Checks (${failing.length}):`);
+    parts.push(`### Failed (${failing.length})`);
+    parts.push("");
     for (const c of failing) {
       const triaged = c as TriagedCheck;
       const kind = triaged.failureKind ? ` [${triaged.failureKind}]` : "";
-      lines.push(`  - ${c.name}${kind}: ${c.conclusion ?? c.status}`);
+      parts.push(`- ${c.name}${kind}: ${c.conclusion ?? c.status}`);
       if (triaged.logExcerpt) {
-        lines.push(indent(triaged.logExcerpt.split("\n").slice(-10).join("\n"), "    "));
+        parts.push(indent(triaged.logExcerpt.split("\n").slice(-10).join("\n"), "    "));
       }
     }
+    parts.push("");
   }
 
   if (inProgress.length > 0) {
-    lines.push(`\nIn Progress (${inProgress.length}):`);
+    parts.push(`### In Progress (${inProgress.length})`);
+    parts.push("");
     for (const c of inProgress) {
-      lines.push(`  - ${c.name}: ${c.status}`);
+      parts.push(`- ${c.name}: ${c.status}`);
     }
+    parts.push("");
   }
 
   if (skipped.length > 0) {
-    lines.push(`\nSkipped (${skipped.length}): ${skipped.map((c) => c.name).join(", ")}`);
+    parts.push(`### Skipped (${skipped.length}): ${skipped.map((c) => c.name).join(", ")}`);
+    parts.push("");
   }
 
   if (report.checks.filtered.length > 0) {
-    lines.push(
-      `\nFiltered (non-PR-trigger) (${report.checks.filtered.length}): ${report.checks.filtered.map((c) => c.name).join(", ")}`,
+    parts.push(
+      `### Filtered non-PR-trigger (${report.checks.filtered.length}): ${report.checks.filtered.map((c) => c.name).join(", ")}`,
     );
     if (report.checks.blockedByFilteredCheck) {
-      lines.push(
+      parts.push(
         "  Note: PR is BLOCKED and all filtered checks are non-PR-trigger — one of these filtered checks may be a required status check blocking merge.",
       );
     } else if (report.mergeStatus.status === "BLOCKED") {
-      lines.push(
+      parts.push(
         "  Note: one or more of these filtered checks may be a required status check blocking merge.",
       );
     }
+    parts.push("");
   }
-
-  lines.push("");
 
   // Review threads
   const { actionable: actionableThreads, autoResolved, autoResolveErrors } = report.threads;
-  if (autoResolved.length > 0) {
-    lines.push(`Auto-resolved outdated threads (${autoResolved.length}):`);
-    for (const t of autoResolved) {
-      lines.push(`  - threadId=${t.id} ${t.path ?? ""}:${t.line ?? "?"} (@${t.author})`);
-    }
-    lines.push("");
-  }
+  const hasThreadSection =
+    autoResolved.length > 0 || autoResolveErrors.length > 0 || actionableThreads.length > 0;
 
-  if (autoResolveErrors.length > 0) {
-    lines.push(`Auto-resolve errors (${autoResolveErrors.length}):`);
-    for (const e of autoResolveErrors) {
-      lines.push(`  - ${e}`);
-    }
-    lines.push("");
-  }
+  if (hasThreadSection) {
+    parts.push("## Review Threads");
+    parts.push("");
 
-  if (actionableThreads.length > 0) {
-    lines.push(`Actionable Review Threads (${actionableThreads.length}):`);
-    for (const t of actionableThreads) {
-      const label = t.path ? `${t.path}:${t.line ?? "?"}` : "(general)";
-      lines.push(`  - threadId=${t.id} ${label} (@${t.author})`);
-      lines.push(`    ${firstLine(t.body)}`);
+    if (autoResolved.length > 0) {
+      parts.push(`Auto-resolved outdated (${autoResolved.length}):`);
+      for (const t of autoResolved) {
+        parts.push(`- threadId=${t.id} ${t.path ?? ""}:${t.line ?? "?"} (@${t.author})`);
+      }
+      parts.push("");
     }
-    lines.push("");
+
+    if (autoResolveErrors.length > 0) {
+      parts.push(`Auto-resolve errors (${autoResolveErrors.length}):`);
+      for (const e of autoResolveErrors) {
+        parts.push(`- ${e}`);
+      }
+      parts.push("");
+    }
+
+    if (actionableThreads.length > 0) {
+      parts.push(`### Actionable (${actionableThreads.length})`);
+      parts.push("");
+      for (const t of actionableThreads) {
+        const label = t.path ? `${t.path}:${t.line ?? "?"}` : "(general)";
+        parts.push(`- threadId=${t.id} ${label} (@${t.author})`);
+        parts.push(`  ${firstLine(t.body)}`);
+      }
+      parts.push("");
+    }
   }
 
   // PR comments
   const { actionable: actionableComments } = report.comments;
   if (actionableComments.length > 0) {
-    lines.push(`Actionable PR Comments (${actionableComments.length}):`);
+    parts.push("## PR Comments");
+    parts.push("");
+    parts.push(`### Actionable (${actionableComments.length})`);
+    parts.push("");
     for (const c of actionableComments) {
-      lines.push(`  - commentId=${c.id} (@${c.author}): ${firstLine(c.body)}`);
+      parts.push(`- commentId=${c.id} (@${c.author}): ${firstLine(c.body)}`);
     }
-    lines.push("");
+    parts.push("");
   }
 
   // CHANGES_REQUESTED reviews
   if (report.changesRequestedReviews.length > 0) {
-    lines.push(`Pending CHANGES_REQUESTED reviews (${report.changesRequestedReviews.length}):`);
+    parts.push("## CHANGES_REQUESTED Reviews");
+    parts.push("");
     for (const r of report.changesRequestedReviews) {
-      lines.push(`  - reviewId=${r.id} (@${r.author}): ${firstLine(r.body)}`);
+      parts.push(`- reviewId=${r.id} (@${r.author}): ${firstLine(r.body)}`);
     }
-    lines.push("");
+    parts.push("");
   }
 
   // Summary
   const totalActionable =
     actionableThreads.length + actionableComments.length + report.changesRequestedReviews.length;
-  lines.push(
-    `Summary: ${totalActionable === 0 ? "0 actionable — all threads resolved/minimized" : `${totalActionable} actionable item(s) remaining`}`,
+  parts.push("## Summary");
+  parts.push("");
+  parts.push(
+    totalActionable === 0
+      ? "0 actionable — all threads resolved/minimized"
+      : `${totalActionable} actionable item(s) remaining`,
   );
+  parts.push("");
 
-  return lines.join("\n");
+  // Instructions
+  parts.push("## Instructions");
+  parts.push("");
+  const instructions = buildCheckInstructions(report);
+  instructions.forEach((step, i) => {
+    parts.push(`${i + 1}. ${step}`);
+  });
+
+  return parts.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -84,16 +84,17 @@ describe("formatText — header", () => {
     expect(out).toContain("Status: FAILING");
   });
 
-  it("includes merge status fields", () => {
+  it("includes merge status heading and fields", () => {
     const out = formatText(makeReport());
-    expect(out).toContain("Merge Status: CLEAN");
+    expect(out).toContain("## Merge Status");
+    expect(out).toContain("CLEAN");
     expect(out).toContain("mergeStateStatus:");
     expect(out).toContain("mergeable:");
   });
 });
 
 describe("formatText — CI check counts", () => {
-  it("shows passed count out of total", () => {
+  it("shows passed count out of total under ## CI Checks", () => {
     const report = makeReport({
       checks: {
         passing: [makeCheck(), makeCheck()],
@@ -106,6 +107,7 @@ describe("formatText — CI check counts", () => {
       },
     });
     const out = formatText(report);
+    expect(out).toContain("## CI Checks");
     expect(out).toContain("2/3 passed");
   });
 });
@@ -175,7 +177,7 @@ describe("formatText — in-progress section", () => {
       },
     });
     const out = formatText(report);
-    expect(out).toContain("In Progress (1):");
+    expect(out).toContain("### In Progress (1)");
   });
 
   it("omits in-progress section when empty", () => {
@@ -196,7 +198,7 @@ describe("formatText — skipped section", () => {
       },
     });
     const out = formatText(report);
-    expect(out).toContain("Skipped (2): deploy, e2e");
+    expect(out).toContain("### Skipped (2): deploy, e2e");
   });
 });
 
@@ -232,7 +234,7 @@ describe("formatText — filtered checks notes", () => {
 });
 
 describe("formatText — threads and comments", () => {
-  it("shows auto-resolved threads", () => {
+  it("shows auto-resolved threads under ## Review Threads", () => {
     const report = makeReport({
       threads: {
         actionable: [],
@@ -241,7 +243,8 @@ describe("formatText — threads and comments", () => {
       },
     });
     const out = formatText(report);
-    expect(out).toContain("Auto-resolved outdated threads (1):");
+    expect(out).toContain("## Review Threads");
+    expect(out).toContain("Auto-resolved outdated (1):");
     expect(out).toContain("threadId=t-1");
   });
 
@@ -297,7 +300,7 @@ describe("formatText — threads and comments", () => {
     expect(out).not.toContain("should not appear");
   });
 
-  it("shows actionable PR comments", () => {
+  it("shows actionable PR comments under ## PR Comments", () => {
     const comment: PrComment = {
       id: "c-1",
       isMinimized: false,
@@ -309,16 +312,16 @@ describe("formatText — threads and comments", () => {
       comments: { actionable: [comment] },
     });
     const out = formatText(report);
-    expect(out).toContain("Actionable PR Comments (1):");
+    expect(out).toContain("## PR Comments");
     expect(out).toContain("commentId=c-1");
     expect(out).toContain("@carol");
   });
 
-  it("shows CHANGES_REQUESTED reviews", () => {
+  it("shows CHANGES_REQUESTED reviews under ## CHANGES_REQUESTED Reviews", () => {
     const review: Review = { id: "r-1", author: "dave", body: "please fix the types" };
     const report = makeReport({ changesRequestedReviews: [review] });
     const out = formatText(report);
-    expect(out).toContain("Pending CHANGES_REQUESTED reviews (1):");
+    expect(out).toContain("## CHANGES_REQUESTED Reviews");
     expect(out).toContain("reviewId=r-1");
   });
 });
@@ -339,5 +342,69 @@ describe("formatText — summary line", () => {
     });
     const out = formatText(report);
     expect(out).toContain("2 actionable item(s) remaining");
+  });
+});
+
+describe("formatText — ## Instructions section", () => {
+  it("includes ## Instructions heading", () => {
+    const out = formatText(makeReport());
+    expect(out).toContain("## Instructions");
+  });
+
+  it("has numbered steps", () => {
+    const out = formatText(makeReport());
+    expect(out).toMatch(/1\. /);
+    expect(out).toMatch(/2\. /);
+  });
+
+  it("includes ready-to-merge declaration when READY+CLEAN", () => {
+    const out = formatText(makeReport());
+    expect(out).toContain("ready to merge");
+  });
+
+  it("includes do-not-merge instruction when not READY", () => {
+    const out = formatText(makeReport({ status: "FAILING" }));
+    expect(out).toContain("Do not declare");
+  });
+
+  it("includes rebase instruction for CONFLICTS", () => {
+    const report = makeReport({
+      mergeStatus: {
+        ...makeReport().mergeStatus,
+        status: "CONFLICTS",
+        mergeStateStatus: "DIRTY",
+      },
+    });
+    const out = formatText(report);
+    expect(out).toContain("Rebase required");
+  });
+
+  it("includes fix-code instruction for actionable failures", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "lint", category: "failing", conclusion: "FAILURE" }),
+      failureKind: "actionable",
+    };
+    const report = makeReport({
+      checks: { ...makeReport().checks, failing: [failing] },
+    });
+    const out = formatText(report);
+    expect(out).toContain("Fix code failure");
+  });
+
+  it("includes rerun instruction for timeout failures with runId", () => {
+    const failing: TriagedCheck = {
+      ...makeCheck({ name: "build", category: "failing", conclusion: "TIMED_OUT", runId: "12345" }),
+      failureKind: "timeout",
+    };
+    const report = makeReport({
+      checks: { ...makeReport().checks, failing: [failing] },
+    });
+    const out = formatText(report);
+    expect(out).toContain("gh run rerun 12345 --failed");
+  });
+
+  it("mentions /pr-shepherd:monitor for continuous monitoring", () => {
+    const out = formatText(makeReport());
+    expect(out).toContain("/pr-shepherd:monitor");
   });
 });


### PR DESCRIPTION
## Summary

- Moves rebase policy, CI budget rules (`failureKind` handling + `gh run rerun` commands), and ready-to-merge gating out of `plugin/skills/check/SKILL.md` into a new `buildCheckInstructions()` function in `src/reporters/check-instructions.mts`
- Appends a `## Instructions` numbered list to the `check` text output; adds matching `instructions: string[]` to JSON output (format parity invariant)
- Skill shrinks from 68 → 35 lines, matching the `resolve` skill shape (pure dispatcher)
- Broadens the "Keep skills and loop prompts minimal" rule in `CLAUDE.md` to explicitly cover interpretation/policy tables, not just dispatch tables

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` — 644 tests pass, 0 errors
- [x] New `src/reporters/check-instructions.test.mts` — 20 tests covering all branches (CLEAN/BEHIND/CONFLICTS × actionable/flaky/infra/timeout × copilot-in-progress × ready/not-ready)
- [x] `wc -l plugin/skills/check/SKILL.md` → 35 (down from 68, matching resolve's 37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)