### PR TITLE
refactor: derive failureKind from GitHub conclusion only; replace log-pattern triage with failedStep

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -201,45 +201,11 @@ Other body-line variants: `CANCEL: PR #42 is closed — stopping monitor`, `CANC
 
 ## `rebase`
 
-Rebases the branch on top of its base to clear merge conflicts.
+> **This action is no longer emitted by `iterate`.** Branch rebasing is now handled inside the `fix_code` instructions (see below). The `rebase` action type and its `## Instructions` format are preserved here for reference, but the CLI will not produce `[REBASE]` output in current releases.
 
-**Trigger:** `fix_code` path when `mergeStatus.status === "CONFLICTS"` and the base branch is resolvable. Also emitted explicitly by the `fix_code` handler for CONFLICTS-only PRs (no threads/comments/reviews) to avoid a separate tick.
+Rebases the branch on top of its base to bring it up to date with the target branch.
 
-> Note: merge conflicts (`CONFLICTS`) route to `fix_code`, not `rebase` — conflicts need manual resolution during the rebase. The `fix_code` runbook always emits a rebase step when the PR is in `CONFLICTS`, even without any threads/comments/checks/reviews; the wording switches from the clean `rebase && push` one-liner to an explicit "Rebase with conflict resolution" step that handles `git rebase --continue` loops before pushing.
-
-**CLI side-effects:** None. The CLI uses the base branch already returned in the GraphQL batch (`baseRefName` → `ShepherdReport.baseBranch`), validates it locally, and pre-builds the shell script.
-
-**Exit code:** 1
-
-**Markdown output:**
-
-````markdown
-# PR #42 [REBASE]
-
-**status** `FAILING` · **merge** `BEHIND` · **state** `OPEN` · **repo** `owner/repo`
-**summary** 2 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
-
-Branch is behind main — rebasing to pick up latest changes
-
-```bash
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "SKIP rebase: dirty worktree (uncommitted changes present)"
-  exit 1
-fi
-git fetch origin && git rebase origin/main && git push --force-with-lease
-```
-
-## Instructions
-
-1. Copy the shell script from the ` ```bash ` block above and run it in Bash.
-2. End this iteration — the next cron fire will check CI after the rebase.
-````
-
-The dirty-worktree guard exits 1 on skip, so the monitor SKILL sees a non-zero exit rather than silently counting the iteration as successful.
-
-**Base branch determination:** The base branch comes from the GraphQL batch (`ShepherdReport.baseBranch`) — no extra network call is needed. `validateBaseBranch` emits `[ESCALATE]` with trigger `base-branch-unknown` if the value is empty or contains characters outside `[A-Za-z0-9._/-]` — force-pushing onto the wrong base would be catastrophic for a PR that actually targets e.g. `release/2026.04`.
-
-**What the monitor does:** Follow `## Instructions` — extract the shell script from the ` ```bash ` block and run it in Bash, then end the iteration.
+**Trigger:** Previously emitted when a branch was `BEHIND` its base and no other actionable items were pending. Removed in favour of embedding the rebase step inside `fix_code` when conflicts are present.
 
 ---
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -18,7 +18,7 @@ The default output format is Markdown — what you see when running `npx pr-shep
 
 - ✓ `<name>` — SUCCESS
 - ✗ `<name>` (<failureKind>) — <conclusion> · `<runId>`
-  > <errorExcerpt line>
+  > <failedStep>
 
 <action-specific body>
 
@@ -34,7 +34,7 @@ Load-bearing conventions (the monitor SKILL depends on these):
 3. Every action ends with a `## Instructions` section — numbered `1.`, `2.`, … — that tells the monitor exactly what to do. The monitor follows those steps; it does not need its own dispatch table.
 4. Under `[REBASE]`, the shell script is inside a ```bash fenced block — instruction 1 tells the monitor to extract and run it.
 5. Under `[FIX_CODE]`, the `## Post-fix push` section has a `` resolve: `<command>` `` bullet — the instructions reference this bullet so the monitor strips backticks and runs the command.
-6. `## Checks` appears immediately after the base fields in every action where checks were fetched (all actions except `cooldown`). It lists every completed, non-skipped PR CI check — passing entries with ✓, failing entries with ✗ plus `failureKind` and a short `errorExcerpt`. The section is omitted when there are no checks (e.g. during `cooldown` or when the PR has no CI configured). JSON surfaces the same data as `checks: RelevantCheck[]` on the base object.
+6. `## Checks` appears immediately after the base fields in every action where checks were fetched (all actions except `cooldown`). It lists every completed, non-skipped PR CI check — passing entries with ✓, failing entries with ✗ plus `failureKind` and the failed step name (`failedStep`) when available. The section is omitted when there are no checks (e.g. during `cooldown` or when the PR has no CI configured). JSON surfaces the same data as `checks: RelevantCheck[]` on the base object.
 
 ---
 
@@ -102,9 +102,9 @@ The body line (`WAIT: …`) varies with the merge state — `branch is behind ba
 
 ## `rerun_ci`
 
-Surfaces CI runs that failed due to transient infrastructure or timeout issues, and instructs the agent to re-trigger them.
+Surfaces CI runs that failed due to transient timeout or external cancellation, and instructs the agent to re-trigger them.
 
-**Trigger:** One or more failing checks have `failureKind === "timeout"` or `"infrastructure"`, and no actionable work was found (evaluated after step 4).
+**Trigger:** One or more failing checks have `failureKind === "timeout"` or `"cancelled"`, and no actionable work was found (evaluated after step 4).
 
 **CLI side-effects:** None. The CLI emits the list of run IDs that need a rerun; the agent runs `gh run rerun <runId> --failed` for each one. Deduplicates — multiple failed steps sharing a run ID produce one rerun entry.
 
@@ -121,9 +121,9 @@ Surfaces CI runs that failed due to transient infrastructure or timeout issues, 
 ## Checks
 
 - ✗ `lint / typecheck / test (22.x)` (timeout) — TIMED_OUT · `24697658766`
-- ✗ `build` (infrastructure) — CANCELLED · `24697658767`
+- ✗ `build` (cancelled) — CANCELLED · `24697658767`
 
-RERUN NEEDED — 2 CI runs: 24697658766 (lint / typecheck / test (22.x) — timeout), 24697658767 (build — infrastructure)
+RERUN NEEDED — 2 CI runs: 24697658766 (lint / typecheck / test (22.x) — timeout), 24697658767 (build — cancelled)
 
 ## Instructions
 
@@ -201,9 +201,9 @@ Other body-line variants: `CANCEL: PR #42 is closed — stopping monitor`, `CANC
 
 ## `rebase`
 
-Rebases the branch on top of its base to clear flaky failures caused by being behind.
+Rebases the branch on top of its base to clear merge conflicts.
 
-**Trigger:** A failing check has `failureKind === "flaky"` AND `mergeStatus.status === "BEHIND"` AND `config.actions.autoRebase` is enabled.
+**Trigger:** `fix_code` path when `mergeStatus.status === "CONFLICTS"` and the base branch is resolvable. Also emitted explicitly by the `fix_code` handler for CONFLICTS-only PRs (no threads/comments/reviews) to avoid a separate tick.
 
 > Note: merge conflicts (`CONFLICTS`) route to `fix_code`, not `rebase` — conflicts need manual resolution during the rebase. The `fix_code` runbook always emits a rebase step when the PR is in `CONFLICTS`, even without any threads/comments/checks/reviews; the wording switches from the clean `rebase && push` one-liner to an explicit "Rebase with conflict resolution" step that handles `git rebase --continue` loops before pushing.
 
@@ -219,12 +219,7 @@ Rebases the branch on top of its base to clear flaky failures caused by being be
 **status** `FAILING` · **merge** `BEHIND` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 2 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
 
-## Checks
-
-- ✓ `build` — SUCCESS
-- ✗ `lint / typecheck / test (22.x)` (flaky) — TIMED_OUT · `24697658766`
-
-Branch is behind main — rebasing to pick up latest changes and clear flaky failures
+Branch is behind main — rebasing to pick up latest changes
 
 ```bash
 if ! git diff --quiet || ! git diff --cached --quiet; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ shepherd/
 │
 ├── checks/
 │   ├── classify.mts       # event filter + CI verdict (CheckCategory, CiVerdict)
-│   └── triage.mts         # failure kind (timeout / infrastructure / flaky / actionable)
+│   └── triage.mts         # failure kind (timeout / cancelled / actionable) + failed step name
 │
 ├── comments/
 │   ├── outdated.mts       # outdated-thread detection (isOutdated flag)

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -41,14 +41,13 @@ Returns:
 
 Failing checks are further classified by `FailureKind`:
 
-| `FailureKind`    | Condition                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------- |
-| `timeout`        | `conclusion === 'TIMED_OUT'`                                                                      |
-| `infrastructure` | `conclusion === 'CANCELLED'` AND log excerpt matches infra patterns (runner not found, OOM, etc.) |
-| `flaky`          | Log excerpt matches known-flaky patterns (test retry noise, network blips)                        |
-| `actionable`     | Everything else — code failures, type errors, lint, test logic errors                             |
+| `FailureKind` | Condition                                                          |
+| ------------- | ------------------------------------------------------------------ |
+| `timeout`     | `conclusion === 'TIMED_OUT'`                                       |
+| `cancelled`   | `conclusion === 'CANCELLED'`, `'STARTUP_FAILURE'`, or `'STALE'`   |
+| `actionable`  | Everything else — code failures, type errors, lint, test failures  |
 
-Triage fetches the first N lines of the failure log for each failing check. The log excerpt is stored in `check.logExcerpt` and surfaced in the `fix_code` payload so the main agent can read it without making additional API calls.
+For `actionable` checks, triage calls the GitHub Actions jobs API (the same `jobs?filter=latest` endpoint) to find the name of the first failed step (e.g. `"Run tests"`, `"Set up job"`). This `failedStep` is returned as part of the check and is visible in both JSON and text output. No log fetching is done for `timeout` or `cancelled` checks.
 
 ## Report output
 
@@ -57,7 +56,7 @@ Triage fetches the first N lines of the failure log for each failing check. The 
 | Field                    | Content                                                      |
 | ------------------------ | ------------------------------------------------------------ |
 | `passing`                | Classified checks with `category === 'passed'`               |
-| `failing`                | Triaged failing checks (with `failureKind` and `logExcerpt`) |
+| `failing`                | Triaged failing checks (with `failureKind` and `failedStep`) |
 | `inProgress`             | Checks with `category === 'in_progress'`                     |
 | `skipped`                | Checks with `category === 'skipped'`                         |
 | `filtered`               | Checks excluded by event filter                              |

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -41,11 +41,11 @@ Returns:
 
 Failing checks are further classified by `FailureKind`:
 
-| `FailureKind` | Condition                                                          |
-| ------------- | ------------------------------------------------------------------ |
-| `timeout`     | `conclusion === 'TIMED_OUT'`                                       |
+| `FailureKind` | Condition                                                         |
+| ------------- | ----------------------------------------------------------------- |
+| `timeout`     | `conclusion === 'TIMED_OUT'`                                      |
 | `cancelled`   | `conclusion === 'CANCELLED'`, `'STARTUP_FAILURE'`, or `'STALE'`   |
-| `actionable`  | Everything else — code failures, type errors, lint, test failures  |
+| `actionable`  | Everything else — code failures, type errors, lint, test failures |
 
 For `actionable` checks, triage calls the GitHub Actions jobs API (the same `jobs?filter=latest` endpoint) to find the name of the first failed step (e.g. `"Run tests"`, `"Set up job"`). This `failedStep` is returned as part of the check and is visible in both JSON and text output. No log fetching is done for `timeout` or `cancelled` checks.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,15 +27,6 @@ checks:
   ciTriggerEvents:
     - pull_request
     - pull_request_target
-  timeoutPatterns:
-    - cancel timeout
-    - exceeded the maximum execution time
-  infraPatterns:
-    - runner error
-    - ECONNRESET
-  logMaxLines: 50
-  logMaxChars: 3000
-  errorLines: 1
 
 mergeStatus:
   blockingReviewerLogins:
@@ -77,14 +68,9 @@ iterate:
 | `resolve.shaPoll.maxAttempts`               | `10`                                        | Max `--require-sha` polls before giving up                                                                        |
 | `resolve.fetchReviewSummaries`              | `true`                                      | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
 | `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]`   | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
-| `checks.timeoutPatterns`                    | see [`src/config.json`](../src/config.json) | Log patterns that classify a failure as `timeout`                                                                 |
-| `checks.infraPatterns`                      | see [`src/config.json`](../src/config.json) | Log patterns that classify a failure as `infrastructure`                                                          |
-| `checks.logMaxLines`                        | `50`                                        | Max log lines kept per failing check                                                                              |
-| `checks.logMaxChars`                        | `3000`                                      | Max log characters kept per failing check                                                                         |
-| `checks.errorLines`                         | `1`                                         | Trailing `##[error]`-marked log lines surfaced as `errorExcerpt` per failing check                                |
 | `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                               | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
 | `actions.autoResolveOutdated`               | `true`                                      | Auto-resolve threads that point to code no longer in the PR diff                                                  |
-| `actions.autoRebase`                        | `true`                                      | Emit `rebase` for flaky failures when the branch is behind base                                                   |
+| `actions.autoRebase`                        | `true`                                      | Emit `rebase` when the branch must be rebased during `fix_code`                                                   |
 | `actions.autoMarkReady`                     | `true`                                      | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
 | `actions.commitSuggestions`                 | `true`                                      | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
 
@@ -225,34 +211,6 @@ Common additions:
 - `merge_group` — for repos using GitHub's merge queue.
 - Remove `pull_request_target` for repos that don't use it (reduces noise).
 
-### `checks.timeoutPatterns` — default: see [`src/config.json`](../src/config.json)
-
-Case-insensitive strings matched against the trimmed failure log. If any pattern matches, the check is classified as `timeout` and shepherd retries the run (`rerun_ci` action) rather than treating it as an actionable failure.
-
-Example: adding `"operation timed out"` classifies any run whose log contains that phrase as a transient timeout.
-
-### `checks.infraPatterns` — default: see [`src/config.json`](../src/config.json)
-
-Same matching logic as `timeoutPatterns`, but classifies the check as `infrastructure` (e.g. a runner crashed). These are also retried via `rerun_ci`.
-
-> `timeoutPatterns` are checked first; `infraPatterns` only apply if the timeout test did not match.
-
-### `checks.logMaxLines` — default `50`
-
-The last N lines of each failing check's log are kept for triage. Larger values give better context but increase memory usage and the size of the `fix_code` payload.
-
-### `checks.logMaxChars` — default `3000`
-
-Character cap applied after the line limit. The excerpt is trimmed to the last N characters. Combined with `logMaxLines`, this bounds the payload size.
-
-### `checks.errorLines` — default `1`
-
-Number of trailing `##[error]`-marked lines to surface per failing check as `errorExcerpt`. These are the red "Error:" lines GitHub Actions renders in its log viewer. The excerpt is shown under each failing check in the `## Checks` section of every iterate action.
-
-- Falls back to the last N raw log lines for fetched GitHub Actions logs when no `##[error]` markers are found (for example, jobs that do not emit workflow commands). Checks without a `runId` do not have fetched logs, so they will not have an `errorExcerpt`.
-- Set higher (e.g. `3`) for checks that emit multi-line error summaries across several `##[error]` lines.
-- The window is taken from within the `logMaxLines`/`logMaxChars` slice, so raising `errorLines` beyond that window has no effect.
-
 ---
 
 ## `mergeStatus`
@@ -275,7 +233,7 @@ When `true`, shepherd automatically resolves threads that GitHub has marked `isO
 
 ### `actions.autoRebase` — default `true`
 
-When `true`, shepherd returns `action: rebase` when it detects a flaky failure and the branch is `BEHIND` the base. The `/pr-shepherd:monitor` skill then runs `git fetch && git rebase && git push --force-with-lease`.
+When `true`, shepherd returns `action: rebase` when the branch must be rebased during `fix_code`. The `/pr-shepherd:monitor` skill then runs `git fetch && git rebase && git push --force-with-lease`.
 
 Disable for repos that enforce merge commits or use a merge queue where rebasing is handled automatically.
 
@@ -314,8 +272,8 @@ The following keys from earlier versions are still accepted but emit a deprecati
 | `resolve.shaPollIntervalMs`      | `resolve.shaPoll.intervalMs`                              |
 | `resolve.shaPollMaxAttempts`     | `resolve.shaPoll.maxAttempts`                             |
 | `checks.relevantEvents`          | `checks.ciTriggerEvents`                                  |
-| `checks.logLinesKept`            | `checks.logMaxLines`                                      |
-| `checks.logExcerptMaxChars`      | `checks.logMaxChars`                                      |
+| `checks.logLinesKept`            | _(removed)_                                               |
+| `checks.logExcerptMaxChars`      | _(removed)_                                               |
 | `baseBranch`                     | _(removed — auto-detected from PR)_                       |
 | `minimizeBots`                   | _(removed)_                                               |
 | `cancelCiOnFailure`              | _(removed)_                                               |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,29 +50,29 @@ iterate:
 
 ## All supported keys
 
-| Key                                         | Default                                     | Purpose                                                                                                           |
-| ------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `cache.ttlSeconds`                          | `300`                                       | File-cache TTL for read operations                                                                                |
-| `iterate.cooldownSeconds`                   | `30`                                        | Wait after a push before reading CI                                                                               |
-| `iterate.fixAttemptsPerThread`              | `3`                                         | Max fix attempts per unresolved thread before `escalate`                                                          |
-| `iterate.stallTimeoutMinutes`               | `30`                                        | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
-| `iterate.minimizeReviewSummaries.bots`      | `true`                                      | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
-| `iterate.minimizeReviewSummaries.humans`    | `true`                                      | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
-| `iterate.minimizeReviewSummaries.approvals` | `false`                                     | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
-| `watch.interval`                            | `"4m"`                                      | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
-| `watch.readyDelayMinutes`                   | `10`                                        | Settle window after READY before the monitor loop cancels                                                         |
-| `watch.expiresHours`                        | `8`                                         | Max lifetime of a monitor cron job                                                                                |
-| `watch.maxTurns`                            | `50`                                        | Max monitor ticks per session                                                                                     |
-| `resolve.concurrency`                       | `4`                                         | Parallel fanout for per-thread GraphQL fetches                                                                    |
-| `resolve.shaPoll.intervalMs`                | `2000`                                      | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
-| `resolve.shaPoll.maxAttempts`               | `10`                                        | Max `--require-sha` polls before giving up                                                                        |
-| `resolve.fetchReviewSummaries`              | `true`                                      | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
-| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]`   | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
-| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                               | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
-| `actions.autoResolveOutdated`               | `true`                                      | Auto-resolve threads that point to code no longer in the PR diff                                                  |
-| `actions.autoRebase`                        | `true`                                      | Emit `rebase` when the branch must be rebased during `fix_code`                                                   |
-| `actions.autoMarkReady`                     | `true`                                      | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
-| `actions.commitSuggestions`                 | `true`                                      | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
+| Key                                         | Default                                   | Purpose                                                                                                           |
+| ------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `cache.ttlSeconds`                          | `300`                                     | File-cache TTL for read operations                                                                                |
+| `iterate.cooldownSeconds`                   | `30`                                      | Wait after a push before reading CI                                                                               |
+| `iterate.fixAttemptsPerThread`              | `3`                                       | Max fix attempts per unresolved thread before `escalate`                                                          |
+| `iterate.stallTimeoutMinutes`               | `30`                                      | Minutes the loop may repeat the same action without progress before `escalate` with `stall-timeout`; `0` disables |
+| `iterate.minimizeReviewSummaries.bots`      | `true`                                    | Auto-minimize COMMENTED review summaries from bot authors; surfaced (not dropped) when `false`                    |
+| `iterate.minimizeReviewSummaries.humans`    | `true`                                    | Auto-minimize COMMENTED review summaries from human authors; surfaced when `false`                                |
+| `iterate.minimizeReviewSummaries.approvals` | `false`                                   | Opt in to minimize APPROVED-state reviews (also enables >50-approval pagination)                                  |
+| `watch.interval`                            | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                  |
+| `watch.readyDelayMinutes`                   | `10`                                      | Settle window after READY before the monitor loop cancels                                                         |
+| `watch.expiresHours`                        | `8`                                       | Max lifetime of a monitor cron job                                                                                |
+| `watch.maxTurns`                            | `50`                                      | Max monitor ticks per session                                                                                     |
+| `resolve.concurrency`                       | `4`                                       | Parallel fanout for per-thread GraphQL fetches                                                                    |
+| `resolve.shaPoll.intervalMs`                | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                                  |
+| `resolve.shaPoll.maxAttempts`               | `10`                                      | Max `--require-sha` polls before giving up                                                                        |
+| `resolve.fetchReviewSummaries`              | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                  |
+| `checks.ciTriggerEvents`                    | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                  |
+| `mergeStatus.blockingReviewerLogins`        | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                            |
+| `actions.autoResolveOutdated`               | `true`                                    | Auto-resolve threads that point to code no longer in the PR diff                                                  |
+| `actions.autoRebase`                        | `true`                                    | Emit `rebase` when the branch must be rebased during `fix_code`                                                   |
+| `actions.autoMarkReady`                     | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                                 |
+| `actions.commitSuggestions`                 | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block    |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,9 +233,7 @@ When `true`, shepherd automatically resolves threads that GitHub has marked `isO
 
 ### `actions.autoRebase` — default `true`
 
-When `true`, shepherd returns `action: rebase` when the branch must be rebased during `fix_code`. The `/pr-shepherd:monitor` skill then runs `git fetch && git rebase && git push --force-with-lease`.
-
-Disable for repos that enforce merge commits or use a merge queue where rebasing is handled automatically.
+This flag is currently unused. Shepherd no longer returns `action: rebase` from `iterate`; branch update and conflict handling are performed inside the `fix_code` instructions instead of via a separate rebase action. It is retained only for backward-compatible configuration parsing and may be removed in a future cleanup. Do not rely on changing this flag to affect runtime behavior.
 
 ### `actions.autoMarkReady` — default `true`
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -84,7 +84,6 @@ All tunable constants live in `src/config.json`. Edit there — do not hardcode 
   "cache": { "ttlSeconds": 300 },
   "iterate": { "cooldownSeconds": 30, "fixAttemptsPerThread": 3 },
   "watch": { "interval": "4m", "readyDelayMinutes": 10 },
-  "checks": { "logMaxLines": 50, "logMaxChars": 3000 },
   "resolve": { "shaPoll": { "maxAttempts": 10, "intervalMs": 2000 } }
 }
 ```

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -25,26 +25,21 @@ flowchart TD
   S4 -->|no| S5{5. transient<br/>timeout/infra?}
   S5 -->|yes| S5X[gh run rerun runId --failed]
   S5X --> A_RR([action: rerun_ci])
-  S5 -->|no| S6{6. flaky + BEHIND?}
-  S6 -->|yes| A_REB([action: rebase])
-  S6 -->|no| S7{7. READY + CLEAN<br/>+ isDraft<br/>+ !copilot?}
-  S7 -->|yes| S7X[gh pr ready PR]
-  S7X --> A_MR([action: mark_ready])
-  S7 -->|no| A_W([action: wait])
+  S5 -->|no| S6{6. READY + CLEAN<br/>+ isDraft<br/>+ !copilot?}
+  S6 -->|yes| S6X[gh pr ready PR]
+  S6X --> A_MR([action: mark_ready])
+  S6 -->|no| A_W([action: wait])
 
   A_COOL --> DEC{Cron prompt<br/>acts on action}
   A_CAN --> DEC
-  A_REB --> DEC
   A_FIX --> DEC
   A_RR --> DEC
   A_MR --> DEC
   A_W --> DEC
 
   DEC -->|cancel| STOP["/loop cancel"]
-  DEC -->|rebase| REB[git fetch && rebase &&<br/>push --force-with-lease]
   DEC -->|fix_code| FIX[Edit files →<br/>git add + commit →<br/>fetch + rebase + push →<br/>pr-shepherd resolve --require-sha HEAD]
   FIX --> NEXT[Wait for next tick]
-  REB --> NEXT
   DEC -->|other| NEXT
   NEXT --> CRON
 ```

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -73,7 +73,7 @@ The fingerprint and a `firstSeenAt` timestamp are persisted to `$TMPDIR/pr-sheph
 
 In-progress check **names** are included so that a long-running CI pipeline where jobs complete one by one (moving from in-progress to passing) resets the timer as progress happens. Timing-only fields (`remainingSeconds`, `inProgress` count by itself) are excluded — only the set of check names changes the fingerprint, not how many are still running.
 
-**Applies to:** `wait`, `fix_code`, `rerun_ci`, `rebase`. Not applied to `cooldown`, `cancel`, `mark_ready`, or `escalate` — these are either pre-sweep, already terminal, or one-shot.
+**Applies to:** `wait`, `fix_code`, `rerun_ci`. Not applied to `cooldown`, `cancel`, `mark_ready`, or `escalate` — these are either pre-sweep, already terminal, or one-shot.
 
 ---
 
@@ -97,7 +97,7 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 
 ### 5. Transient failures
 
-**Check:** any failing check has `failureKind === 'timeout'` or `failureKind === 'infrastructure'`, and no actionable work, no conflicts.
+**Check:** any failing check has `failureKind === 'timeout'` or `failureKind === 'cancelled'`, and no actionable work, no conflicts.
 
 **Side-effects:** None — the CLI reports the run IDs that need a rerun; the agent executes `gh run rerun <runId> --failed` for each unique run ID as instructed by `## Instructions`.
 
@@ -105,17 +105,7 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 
 ---
 
-### 6. Flaky + behind
-
-**Check:** any failing check has `failureKind === 'flaky'` AND `report.mergeStatus.status === 'BEHIND'`.
-
-**Why:** A flaky test is more likely to pass after a rebase onto main.
-
-**Emits:** `action: 'rebase'`
-
----
-
-### 7. Mark ready
+### 6. Mark ready
 
 **Check:** `report.status === 'READY'` AND `mergeStateStatus` is `CLEAN` (or `DRAFT` when `isDraft`) AND `!copilotReviewInProgress` AND `isDraft` AND `!shouldCancel`.
 
@@ -125,7 +115,7 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 
 ---
 
-### 8. Wait
+### 7. Wait
 
 **Fallthrough:** nothing actionable, no terminal state, no ready-delay elapsed.
 
@@ -143,7 +133,6 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 | 3.5     | Same fingerprint for ≥ `stallTimeoutMinutes` (any step) | `escalate`   | 3         |
 | 4       | Actionable threads/comments/CI or CONFLICTS             | `fix_code`   | 1         |
 | 4 esc.  | Same thread hit `fixAttemptsPerThread` times            | `escalate`   | 3         |
-| 5       | Transient CI failures                                   | `rerun_ci`   | 0         |
-| 6       | Flaky + BEHIND                                          | `rebase`     | 1         |
-| 7       | READY + CLEAN + isDraft                                 | `mark_ready` | 0         |
-| 8       | Fallthrough                                             | `wait`       | 0         |
+| 5       | Transient CI failures (timeout or cancelled)            | `rerun_ci`   | 0         |
+| 6       | READY + CLEAN + isDraft                                 | `mark_ready` | 0         |
+| 7       | Fallthrough                                             | `wait`       | 0         |

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { triageFailingChecks, extractErrorLines } from "./triage.mts";
+import { triageFailingChecks } from "./triage.mts";
 import type { ClassifiedCheck } from "../types.mts";
 
 const REPO = { owner: "owner", name: "repo" };
@@ -29,22 +29,15 @@ function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
   };
 }
 
-function makeJobsResponse(jobs: Array<{ id: number; name: string; conclusion: string }>): Response {
+type JobStub = { id: number; name: string; conclusion: string; steps?: Array<{ name: string; number: number; conclusion: string | null }> };
+
+function makeJobsResponse(jobs: JobStub[]): Response {
   return {
     ok: true,
     status: 200,
     headers: new Headers({ "content-type": "application/json" }),
     json: () => Promise.resolve({ jobs }),
     text: () => Promise.resolve(JSON.stringify({ jobs })),
-  } as unknown as Response;
-}
-
-function makeLogsResponse(text: string): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers(),
-    text: () => Promise.resolve(text),
   } as unknown as Response;
 }
 
@@ -57,25 +50,17 @@ function makeErrorResponse(status: number): Response {
   } as unknown as Response;
 }
 
-function setupFetch(logs: string, conclusion = "failure"): void {
-  // First call: list jobs
-  mockFetch.mockResolvedValueOnce(makeJobsResponse([{ id: 42, name: "test-job", conclusion }]));
-  // Second call: fetch logs for that job
-  mockFetch.mockResolvedValueOnce(makeLogsResponse(logs));
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
   mockFetch.mockReset();
-  // Provide a token so auth doesn't shell out to `gh auth token`
   process.env["GH_TOKEN"] = "test-token";
 });
 
 describe("triageFailingChecks — no runId", () => {
-  it("skips log fetch and returns actionable when runId is null", async () => {
+  it("skips fetch and returns actionable when runId is null", async () => {
     const check = makeCheck({ runId: null });
     const [result] = await triageFailingChecks([check], REPO);
     expect(result!.failureKind).toBe("actionable");
@@ -84,134 +69,130 @@ describe("triageFailingChecks — no runId", () => {
 });
 
 describe("triageFailingChecks — TIMED_OUT", () => {
-  it("returns timeout for TIMED_OUT conclusion regardless of logs", async () => {
-    setupFetch("test output: all good\n");
+  it("returns timeout for TIMED_OUT conclusion; skips fetch", async () => {
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "TIMED_OUT" })], REPO);
     expect(result!.failureKind).toBe("timeout");
-  });
-
-  it('returns timeout when logs contain "exceeded the maximum execution time"', async () => {
-    setupFetch("Run exceeded the maximum execution time\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("timeout");
-  });
-
-  it('returns timeout when logs contain "cancel timeout"', async () => {
-    setupFetch("cancel timeout after 6 hours\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("timeout");
-  });
-
-  it('returns timeout when logs contain "job was cancelled"', async () => {
-    setupFetch("Job was cancelled due to timeout\n", "cancelled");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
-    expect(result!.failureKind).toBe("timeout");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });
 
-describe("triageFailingChecks — infrastructure", () => {
-  it("returns infrastructure for CANCELLED + runner error logs", async () => {
-    setupFetch("Runner error: the runner crashed\n", "cancelled");
+describe("triageFailingChecks — cancelled", () => {
+  it("returns cancelled for CANCELLED conclusion; skips fetch", async () => {
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
-    expect(result!.failureKind).toBe("infrastructure");
+    expect(result!.failureKind).toBe("cancelled");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns infrastructure for CANCELLED + ECONNRESET logs", async () => {
-    setupFetch("Error: ECONNRESET connection reset\n", "cancelled");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
-    expect(result!.failureKind).toBe("infrastructure");
+  it("returns cancelled for STARTUP_FAILURE conclusion; skips fetch", async () => {
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "STARTUP_FAILURE" })], REPO);
+    expect(result!.failureKind).toBe("cancelled");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('returns infrastructure for CANCELLED + "lost communication with the server"', async () => {
-    setupFetch("The runner has lost communication with the server\n", "cancelled");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
-    expect(result!.failureKind).toBe("infrastructure");
+  it("returns cancelled for STALE conclusion; skips fetch", async () => {
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "STALE" })], REPO);
+    expect(result!.failureKind).toBe("cancelled");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns infrastructure when jobs fetch fails (empty logs)", async () => {
+  it("does not set failedStep for cancelled checks", async () => {
+    const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
+    expect(result!.failedStep).toBeUndefined();
+  });
+});
+
+describe("triageFailingChecks — actionable: failedStep", () => {
+  it("returns actionable and extracts failedStep from matching job", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{
+        id: 42,
+        name: "tests",
+        conclusion: "failure",
+        steps: [
+          { name: "Set up job", number: 1, conclusion: "success" },
+          { name: "Run tests", number: 2, conclusion: "failure" },
+          { name: "Post", number: 3, conclusion: null },
+        ],
+      }]),
+    );
+    const [result] = await triageFailingChecks([makeCheck()], REPO);
+    expect(result!.failureKind).toBe("actionable");
+    expect(result!.failedStep).toBe("Run tests");
+  });
+
+  it("returns actionable with failedStep=undefined when job has no failed steps", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{ id: 42, name: "tests", conclusion: "failure", steps: [] }]),
+    );
+    const [result] = await triageFailingChecks([makeCheck()], REPO);
+    expect(result!.failureKind).toBe("actionable");
+    expect(result!.failedStep).toBeUndefined();
+  });
+
+  it("returns actionable with failedStep=undefined when no job matches check name", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{
+        id: 42,
+        name: "some-other-job",
+        conclusion: "failure",
+        steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
+      }]),
+    );
+    const [result] = await triageFailingChecks([makeCheck({ name: "tests" })], REPO);
+    expect(result!.failureKind).toBe("actionable");
+    expect(result!.failedStep).toBeUndefined();
+  });
+
+  it("prefers failing job when multiple jobs share the same check name (matrix)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([
+        {
+          id: 1,
+          name: "tests",
+          conclusion: "success",
+          steps: [{ name: "Run tests", number: 1, conclusion: "success" }],
+        },
+        {
+          id: 2,
+          name: "tests",
+          conclusion: "failure",
+          steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
+        },
+      ]),
+    );
+    const [result] = await triageFailingChecks([makeCheck({ name: "tests" })], REPO);
+    expect(result!.failedStep).toBe("Run tests");
+  });
+
+  it("returns actionable with failedStep=undefined when jobs fetch throws", async () => {
     mockFetch.mockResolvedValueOnce(makeErrorResponse(500));
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("infrastructure");
-  });
-
-  it("returns infrastructure for blank logs even with FAILURE conclusion", async () => {
-    setupFetch("   \n  \n  ");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("infrastructure");
-  });
-});
-
-describe("triageFailingChecks — flaky", () => {
-  it('returns flaky when logs contain "flaky"', async () => {
-    setupFetch("Test is flaky: TestFooBar failed 1/3 runs\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("flaky");
-  });
-
-  it('returns flaky when logs contain "race condition"', async () => {
-    setupFetch("Detected race condition in TestBar\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("flaky");
-  });
-
-  it('returns flaky when logs contain "retry"', async () => {
-    setupFetch("Attempt 3/3 failed, no retry left\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("flaky");
-  });
-});
-
-describe("triageFailingChecks — actionable", () => {
-  it("returns actionable for compile errors", async () => {
-    setupFetch("error TS2345: Argument of type 'string' is not assignable\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failureKind).toBe("actionable");
+    expect(result!.failedStep).toBeUndefined();
   });
 
-  it("returns actionable for test assertion failures", async () => {
-    setupFetch("AssertionError: expected 42 to equal 43\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
+  it("returns actionable with failedStep=undefined when runId is null", async () => {
+    const check = makeCheck({ runId: null });
+    const [result] = await triageFailingChecks([check], REPO);
     expect(result!.failureKind).toBe("actionable");
-  });
-
-  it("returns actionable for lint violations", async () => {
-    setupFetch("no-unused-vars: variable `foo` is defined but never used\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.failureKind).toBe("actionable");
-  });
-});
-
-describe("triageFailingChecks — logExcerpt", () => {
-  it("attaches logExcerpt for actionable failures", async () => {
-    setupFetch("Error: test failed\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.logExcerpt).toBeDefined();
-    expect(result!.logExcerpt).toContain("Error: test failed");
-  });
-
-  it("truncates logExcerpt to 3000 chars", async () => {
-    setupFetch("x".repeat(10_000));
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect((result!.logExcerpt?.length ?? 0) <= 3000).toBe(true);
-  });
-
-  it("strips ANSI escape codes from logs", async () => {
-    setupFetch("[31mERROR[0m: something failed\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.logExcerpt).not.toContain("");
-    expect(result!.logExcerpt).toContain("ERROR: something failed");
+    expect(result!.failedStep).toBeUndefined();
   });
 });
 
 describe("triageFailingChecks — batch", () => {
   it("triages multiple checks in parallel", async () => {
-    // check 1: jobs + logs
     mockFetch
-      .mockResolvedValueOnce(makeJobsResponse([{ id: 1, name: "tests", conclusion: "failure" }]))
-      .mockResolvedValueOnce(makeLogsResponse("AssertionError: expected 1 to equal 2\n"))
-      // check 2: jobs + logs
-      .mockResolvedValueOnce(makeJobsResponse([{ id: 2, name: "build", conclusion: "cancelled" }]))
-      .mockResolvedValueOnce(makeLogsResponse("Runner error: crashed\n"));
+      .mockResolvedValueOnce(
+        makeJobsResponse([{
+          id: 1,
+          name: "tests",
+          conclusion: "failure",
+          steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
+        }]),
+      )
+      .mockResolvedValueOnce(
+        makeJobsResponse([{ id: 2, name: "build", conclusion: "cancelled", steps: [] }]),
+      );
 
     const checks: ClassifiedCheck[] = [
       makeCheck({ name: "tests", runId: "run-1", conclusion: "FAILURE" }),
@@ -220,87 +201,9 @@ describe("triageFailingChecks — batch", () => {
     const results = await triageFailingChecks(checks, REPO);
     expect(results).toHaveLength(2);
     expect(results[0]!.failureKind).toBe("actionable");
-    expect(results[1]!.failureKind).toBe("infrastructure");
-  });
-});
-
-describe("triageFailingChecks — errorExcerpt", () => {
-  it("extracts ##[error]-marked line and strips prefix", async () => {
-    setupFetch("some output\n##[error]Error: test failed\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.errorExcerpt).toBe("Error: test failed");
-  });
-
-  it("strips timestamp + ##[error] prefix from error lines", async () => {
-    setupFetch("2026-04-23T09:53:06.123Z ##[error]AssertionError: expected 42 to equal 43\n");
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.errorExcerpt).toBe("AssertionError: expected 42 to equal 43");
-  });
-
-  it("falls back to last raw log line when no ##[error] markers exist", async () => {
-    setupFetch("first line\nsecond line\nlast line"); // no trailing newline so "last line" is last element
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    // default errorLines=1 → last non-empty line
-    expect(result!.errorExcerpt).toBe("last line");
-  });
-
-  it("returns undefined errorExcerpt when runId is null (no logs fetched)", async () => {
-    const check = makeCheck({ runId: null });
-    const [result] = await triageFailingChecks([check], REPO);
-    expect(result!.errorExcerpt).toBeUndefined();
-  });
-
-  it("returns undefined errorExcerpt when log fetch returns empty string", async () => {
-    mockFetch.mockResolvedValueOnce(makeErrorResponse(500));
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
-    expect(result!.errorExcerpt).toBeUndefined();
-  });
-});
-
-describe("extractErrorLines", () => {
-  it("returns last ##[error]-marked line with prefix stripped (maxLines=1)", () => {
-    const logs = [
-      "build output line",
-      "##[error]Error: first error",
-      "more output",
-      "##[error]Error: second error",
-      "##[error]Error: third error",
-    ].join("\n");
-    expect(extractErrorLines(logs, 1)).toBe("Error: third error");
-  });
-
-  it("returns up to maxLines ##[error] lines when multiple exist", () => {
-    const logs = ["##[error]Error: first", "##[error]Error: second", "##[error]Error: third"].join(
-      "\n",
-    );
-    expect(extractErrorLines(logs, 2)).toBe("Error: second\nError: third");
-    expect(extractErrorLines(logs, 3)).toBe("Error: first\nError: second\nError: third");
-  });
-
-  it("strips ISO timestamp prefix before ##[error]", () => {
-    const logs = "2026-04-23T09:53:06.123Z ##[error]Error: timed out waiting";
-    expect(extractErrorLines(logs, 1)).toBe("Error: timed out waiting");
-  });
-
-  it("falls back to last N raw lines when no ##[error] markers exist", () => {
-    const logs = "line one\nline two\nline three\nline four";
-    expect(extractErrorLines(logs, 2)).toBe("line three\nline four");
-  });
-
-  it("returns empty string for empty input", () => {
-    expect(extractErrorLines("", 1)).toBe("");
-  });
-
-  it("returns empty string when logs are all whitespace", () => {
-    expect(extractErrorLines("   \n  \n  ", 1)).toBe("");
-  });
-
-  it("falls back to last real line when logs end with a trailing newline", () => {
-    // split("\n") on "last line\n" yields ["last line", ""] — filter(Boolean) removes the empty tail
-    expect(extractErrorLines("first line\nlast line\n", 1)).toBe("last line");
-  });
-
-  it("returns empty string when maxLines is 0", () => {
-    expect(extractErrorLines("some output\n##[error]Error: boom", 0)).toBe("");
+    expect(results[0]!.failedStep).toBe("Run tests");
+    // CANCELLED → no fetch; mock for run-2 won't be called
+    expect(results[1]!.failureKind).toBe("cancelled");
+    expect(results[1]!.failedStep).toBeUndefined();
   });
 });

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -29,7 +29,12 @@ function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
   };
 }
 
-type JobStub = { id: number; name: string; conclusion: string; steps?: Array<{ name: string; number: number; conclusion: string | null }> };
+type JobStub = {
+  id: number;
+  name: string;
+  conclusion: string;
+  steps?: Array<{ name: string; number: number; conclusion: string | null }>;
+};
 
 function makeJobsResponse(jobs: JobStub[]): Response {
   return {
@@ -84,7 +89,10 @@ describe("triageFailingChecks — cancelled", () => {
   });
 
   it("returns cancelled for STARTUP_FAILURE conclusion; skips fetch", async () => {
-    const [result] = await triageFailingChecks([makeCheck({ conclusion: "STARTUP_FAILURE" })], REPO);
+    const [result] = await triageFailingChecks(
+      [makeCheck({ conclusion: "STARTUP_FAILURE" })],
+      REPO,
+    );
     expect(result!.failureKind).toBe("cancelled");
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -104,16 +112,18 @@ describe("triageFailingChecks — cancelled", () => {
 describe("triageFailingChecks — actionable: failedStep", () => {
   it("returns actionable and extracts failedStep from matching job", async () => {
     mockFetch.mockResolvedValueOnce(
-      makeJobsResponse([{
-        id: 42,
-        name: "tests",
-        conclusion: "failure",
-        steps: [
-          { name: "Set up job", number: 1, conclusion: "success" },
-          { name: "Run tests", number: 2, conclusion: "failure" },
-          { name: "Post", number: 3, conclusion: null },
-        ],
-      }]),
+      makeJobsResponse([
+        {
+          id: 42,
+          name: "tests",
+          conclusion: "failure",
+          steps: [
+            { name: "Set up job", number: 1, conclusion: "success" },
+            { name: "Run tests", number: 2, conclusion: "failure" },
+            { name: "Post", number: 3, conclusion: null },
+          ],
+        },
+      ]),
     );
     const [result] = await triageFailingChecks([makeCheck()], REPO);
     expect(result!.failureKind).toBe("actionable");
@@ -131,12 +141,14 @@ describe("triageFailingChecks — actionable: failedStep", () => {
 
   it("returns actionable with failedStep=undefined when no job matches check name", async () => {
     mockFetch.mockResolvedValueOnce(
-      makeJobsResponse([{
-        id: 42,
-        name: "some-other-job",
-        conclusion: "failure",
-        steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
-      }]),
+      makeJobsResponse([
+        {
+          id: 42,
+          name: "some-other-job",
+          conclusion: "failure",
+          steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
+        },
+      ]),
     );
     const [result] = await triageFailingChecks([makeCheck({ name: "tests" })], REPO);
     expect(result!.failureKind).toBe("actionable");
@@ -183,12 +195,14 @@ describe("triageFailingChecks — batch", () => {
   it("triages multiple checks in parallel", async () => {
     mockFetch
       .mockResolvedValueOnce(
-        makeJobsResponse([{
-          id: 1,
-          name: "tests",
-          conclusion: "failure",
-          steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
-        }]),
+        makeJobsResponse([
+          {
+            id: 1,
+            name: "tests",
+            conclusion: "failure",
+            steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
+          },
+        ]),
       )
       .mockResolvedValueOnce(
         makeJobsResponse([{ id: 2, name: "build", conclusion: "cancelled", steps: [] }]),

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -71,6 +71,13 @@ describe("triageFailingChecks — no runId", () => {
     expect(result!.failureKind).toBe("actionable");
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it("returns actionable (not timeout) for TIMED_OUT when runId is null — no run to rerun", async () => {
+    const check = makeCheck({ runId: null, conclusion: "TIMED_OUT" });
+    const [result] = await triageFailingChecks([check], REPO);
+    expect(result!.failureKind).toBe("actionable");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("triageFailingChecks — TIMED_OUT", () => {

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -253,4 +253,38 @@ describe("triageFailingChecks — batch", () => {
     expect(results[1]!.failureKind).toBe("cancelled");
     expect(results[1]!.failedStep).toBeUndefined();
   });
+
+  it("fetches jobs once per runId when multiple checks share the same run", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([
+        {
+          id: 1,
+          name: "tests",
+          workflow_name: "CI",
+          conclusion: "failure",
+          steps: [{ name: "Run tests", number: 1, conclusion: "failure" }],
+        },
+        {
+          id: 2,
+          name: "lint",
+          workflow_name: "CI",
+          conclusion: "failure",
+          steps: [{ name: "Run lint", number: 1, conclusion: "failure" }],
+        },
+      ]),
+    );
+
+    const checks: ClassifiedCheck[] = [
+      makeCheck({ name: "tests", runId: "run-1", conclusion: "FAILURE" }),
+      makeCheck({ name: "lint", runId: "run-1", conclusion: "FAILURE" }),
+    ];
+    const results = await triageFailingChecks(checks, REPO);
+    expect(results).toHaveLength(2);
+    expect(results[0]!.failedStep).toBe("Run tests");
+    expect(results[0]!.workflowName).toBe("CI");
+    expect(results[1]!.failedStep).toBe("Run lint");
+    expect(results[1]!.workflowName).toBe("CI");
+    // Only one fetch call despite two checks sharing the same runId
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -32,6 +32,7 @@ function makeCheck(overrides: Partial<ClassifiedCheck> = {}): ClassifiedCheck {
 type JobStub = {
   id: number;
   name: string;
+  workflow_name?: string;
   conclusion: string;
   steps?: Array<{ name: string; number: number; conclusion: string | null }>;
 };
@@ -81,48 +82,72 @@ describe("triageFailingChecks — no runId", () => {
 });
 
 describe("triageFailingChecks — TIMED_OUT", () => {
-  it("returns timeout for TIMED_OUT conclusion; skips fetch", async () => {
+  it("returns timeout with workflowName; fetches job info", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{ id: 1, name: "tests", workflow_name: "CI", conclusion: "timed_out" }]),
+    );
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "TIMED_OUT" })], REPO);
     expect(result!.failureKind).toBe("timeout");
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result!.workflowName).toBe("CI");
+    expect(result!.failedStep).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalled();
   });
 });
 
 describe("triageFailingChecks — cancelled", () => {
-  it("returns cancelled for CANCELLED conclusion; skips fetch", async () => {
+  it("returns cancelled with workflowName for CANCELLED; fetches job info", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{ id: 1, name: "tests", workflow_name: "CI", conclusion: "cancelled" }]),
+    );
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
     expect(result!.failureKind).toBe("cancelled");
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result!.workflowName).toBe("CI");
+    expect(result!.failedStep).toBeUndefined();
   });
 
-  it("returns cancelled for STARTUP_FAILURE conclusion; skips fetch", async () => {
+  it("returns cancelled for STARTUP_FAILURE conclusion", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{ id: 1, name: "tests", conclusion: "cancelled" }]),
+    );
     const [result] = await triageFailingChecks(
       [makeCheck({ conclusion: "STARTUP_FAILURE" })],
       REPO,
     );
     expect(result!.failureKind).toBe("cancelled");
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns cancelled for STALE conclusion; skips fetch", async () => {
+  it("returns cancelled for STALE conclusion", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([{ id: 1, name: "tests", conclusion: "cancelled" }]),
+    );
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "STALE" })], REPO);
     expect(result!.failureKind).toBe("cancelled");
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("does not set failedStep for cancelled checks", async () => {
+  it("does not set failedStep for cancelled checks even when fetch succeeds", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJobsResponse([
+        {
+          id: 1,
+          name: "tests",
+          conclusion: "cancelled",
+          steps: [{ name: "Run tests", number: 1, conclusion: "cancelled" }],
+        },
+      ]),
+    );
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "CANCELLED" })], REPO);
     expect(result!.failedStep).toBeUndefined();
   });
 });
 
 describe("triageFailingChecks — actionable: failedStep", () => {
-  it("returns actionable and extracts failedStep from matching job", async () => {
+  it("returns actionable and extracts failedStep + workflowName from matching job", async () => {
     mockFetch.mockResolvedValueOnce(
       makeJobsResponse([
         {
           id: 42,
           name: "tests",
+          workflow_name: "CI",
           conclusion: "failure",
           steps: [
             { name: "Set up job", number: 1, conclusion: "success" },
@@ -134,6 +159,7 @@ describe("triageFailingChecks — actionable: failedStep", () => {
     );
     const [result] = await triageFailingChecks([makeCheck()], REPO);
     expect(result!.failureKind).toBe("actionable");
+    expect(result!.workflowName).toBe("CI");
     expect(result!.failedStep).toBe("Run tests");
   });
 
@@ -223,7 +249,7 @@ describe("triageFailingChecks — batch", () => {
     expect(results).toHaveLength(2);
     expect(results[0]!.failureKind).toBe("actionable");
     expect(results[0]!.failedStep).toBe("Run tests");
-    // CANCELLED → no fetch; mock for run-2 won't be called
+    // CANCELLED → fetch is called for workflowName; mock for run-2 is consumed
     expect(results[1]!.failureKind).toBe("cancelled");
     expect(results[1]!.failedStep).toBeUndefined();
   });

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -5,9 +5,13 @@
  *   - cancelled: conclusion is CANCELLED, STARTUP_FAILURE, or STALE.
  *   - actionable: everything else (FAILURE, ACTION_REQUIRED, …).
  *
- * For actionable checks, the name of the first failed step in the matched job
- * is fetched from the GitHub Actions jobs API and returned as `failedStep`.
- * No log fetching is done for timeout/cancelled checks.
+ * Exception: checks with runId === null are always classified as "actionable"
+ * regardless of conclusion, so they surface in fix_code where the monitor
+ * escalates to the user (no run to rerun/inspect).
+ *
+ * For all checks with a non-null runId, the jobs API is called to fetch the
+ * workflow name. For actionable checks, the first failed step name is also
+ * returned as `failedStep`. No log fetching is done.
  */
 
 import { rest } from "../github/http.mts";

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -9,9 +9,9 @@
  * regardless of conclusion, so they surface in fix_code where the monitor
  * escalates to the user (no run to rerun/inspect).
  *
- * For all checks with a non-null runId, the jobs API is called to fetch the
- * workflow name. For actionable checks, the first failed step name is also
- * returned as `failedStep`. No log fetching is done.
+ * For all checks with a non-null runId, the jobs API is called once per runId
+ * (results are cached across checks that share a run) to fetch workflow name
+ * and, for actionable checks, the first failed step name. No log fetching is done.
  */
 
 import { rest } from "../github/http.mts";
@@ -23,26 +23,36 @@ import type { RepoInfo } from "../github/client.mts";
 // ---------------------------------------------------------------------------
 
 /**
- * Triage each failing check: classify by GitHub conclusion and, for actionable
- * failures, fetch the name of the first failed step from the jobs API.
+ * Triage each failing check: classify by GitHub conclusion and call the jobs
+ * API for each check with a non-null runId to fetch workflow name and (for
+ * actionable failures) the name of the first failed step.
+ *
+ * Jobs responses are cached by runId so checks that share a run (e.g. matrix
+ * builds or multiple required steps in one workflow) make only one API call.
  */
 export function triageFailingChecks(
   failingChecks: ClassifiedCheck[],
   repo: RepoInfo,
 ): Promise<TriagedCheck[]> {
-  return Promise.all(failingChecks.map((c) => triageCheck(c, repo)));
+  const jobsCache = new Map<string, Promise<JobsResponse["jobs"] | undefined>>();
+  return Promise.all(failingChecks.map((c) => triageCheck(c, repo, jobsCache)));
 }
 
 // ---------------------------------------------------------------------------
 // Internal
 // ---------------------------------------------------------------------------
 
-async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<TriagedCheck> {
+async function triageCheck(
+  check: ClassifiedCheck,
+  repo: RepoInfo,
+  jobsCache: Map<string, Promise<JobsResponse["jobs"] | undefined>>,
+): Promise<TriagedCheck> {
   const failureKind = check.runId === null ? "actionable" : classifyConclusion(check.conclusion);
   if (check.runId === null) {
     return { ...check, failureKind };
   }
-  const jobInfo = await fetchJobInfo(check.runId, check.name, repo);
+  const jobs = await fetchJobs(check.runId, repo, jobsCache);
+  const jobInfo = jobs ? pickJobInfo(jobs, check.name, failureKind) : undefined;
   return {
     ...check,
     failureKind,
@@ -72,11 +82,22 @@ interface JobInfo {
   failedStep?: string;
 }
 
-async function fetchJobInfo(
+function fetchJobs(
   runId: string,
-  checkName: string,
   repo: RepoInfo,
-): Promise<JobInfo | undefined> {
+  cache: Map<string, Promise<JobsResponse["jobs"] | undefined>>,
+): Promise<JobsResponse["jobs"] | undefined> {
+  const cached = cache.get(runId);
+  if (cached) return cached;
+  const promise = fetchJobsUncached(runId, repo);
+  cache.set(runId, promise);
+  return promise;
+}
+
+async function fetchJobsUncached(
+  runId: string,
+  repo: RepoInfo,
+): Promise<JobsResponse["jobs"] | undefined> {
   const { owner, name } = repo;
   const perPage = 100;
   const allJobs: JobsResponse["jobs"] = [];
@@ -92,12 +113,21 @@ async function fetchJobInfo(
   } catch {
     return undefined;
   }
+  return allJobs;
+}
+
+function pickJobInfo(
+  jobs: JobsResponse["jobs"],
+  checkName: string,
+  failureKind: FailureKind,
+): JobInfo | undefined {
   // Match by name. For matrix jobs sharing a check name, prefer a failing one.
-  const matches = allJobs.filter((j) => j.name === checkName);
+  const matches = jobs.filter((j) => j.name === checkName);
   const job = matches.find((j) => j.conclusion === "failure") ?? matches[0];
-  const failedStep = job?.steps?.find((s) => s.conclusion === "failure");
-  return {
-    workflowName: job?.workflow_name,
-    failedStep: failedStep?.name,
-  };
+  if (!job) return undefined;
+  const failedStep =
+    failureKind === "actionable"
+      ? job.steps?.find((s) => s.conclusion === "failure")?.name
+      : undefined;
+  return { workflowName: job.workflow_name, failedStep };
 }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -34,7 +34,7 @@ export function triageFailingChecks(
 // ---------------------------------------------------------------------------
 
 async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<TriagedCheck> {
-  const failureKind = classifyConclusion(check.conclusion);
+  const failureKind = check.runId === null ? "actionable" : classifyConclusion(check.conclusion);
   if (failureKind !== "actionable" || check.runId === null) {
     return { ...check, failureKind };
   }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -1,35 +1,26 @@
 /**
- * Triage failing check runs into four categories:
- *   - timeout: conclusion is TIMED_OUT or logs contain timeout markers.
- *   - infrastructure: conclusion is CANCELLED + infra-error log patterns.
- *   - actionable: compile error, test failure, lint violation from the PR's changes.
- *   - flaky: pre-existing or timing-dependent failures in untouched files.
+ * Triage failing check runs into three categories based solely on GitHub's
+ * own conclusion field — no log-content classification:
+ *   - timeout: conclusion is TIMED_OUT.
+ *   - cancelled: conclusion is CANCELLED, STARTUP_FAILURE, or STALE.
+ *   - actionable: everything else (FAILURE, ACTION_REQUIRED, …).
  *
- * Shepherd computes and returns triage results, including `failureKind`, for
- * downstream callers or slash-command logic to consume.
+ * For actionable checks, the name of the first failed step in the matched job
+ * is fetched from the GitHub Actions jobs API and returned as `failedStep`.
+ * No log fetching is done for timeout/cancelled checks.
  */
 
-import { rest, restText } from "../github/http.mts";
-import type { ClassifiedCheck, TriagedCheck, FailureKind } from "../types.mts";
+import { rest } from "../github/http.mts";
+import type { ClassifiedCheck, TriagedCheck, FailureKind, CheckConclusion } from "../types.mts";
 import type { RepoInfo } from "../github/client.mts";
-import { loadConfig } from "../config/load.mts";
-
-const config = loadConfig();
-const TIMEOUT_PATTERNS = config.checks.timeoutPatterns.map((p) => new RegExp(p, "i"));
-const INFRA_PATTERNS = config.checks.infraPatterns.map((p) => new RegExp(p, "i"));
-
-// Matches GitHub Actions workflow-command error markers: `##[error]...`
-// May be preceded by a timestamp: `2026-04-23T09:53:06.123Z ##[error]Error: foo`
-const ERROR_MARKER_RE = /##\[error\]/;
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch logs and triage each failing check.
- *
- * Fetching logs is skipped for checks that have no `runId` (e.g. StatusContext nodes).
+ * Triage each failing check: classify by GitHub conclusion and, for actionable
+ * failures, fetch the name of the first failed step from the jobs API.
  */
 export function triageFailingChecks(
   failingChecks: ClassifiedCheck[],
@@ -43,21 +34,18 @@ export function triageFailingChecks(
 // ---------------------------------------------------------------------------
 
 async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<TriagedCheck> {
-  if (check.runId === null) {
-    return { ...check, failureKind: "actionable" };
+  const failureKind = classifyConclusion(check.conclusion);
+  if (failureKind !== "actionable" || check.runId === null) {
+    return { ...check, failureKind };
   }
+  const failedStep = await fetchFailedStep(check.runId, check.name, repo);
+  return { ...check, failureKind, failedStep };
+}
 
-  const logExcerpt = await fetchFailedLogs(check.runId, repo);
-  const failureKind = classifyLogs(check, logExcerpt);
-  const boundedLogExcerpt = logExcerpt.slice(-config.checks.logMaxChars);
-  const errorExcerpt = extractErrorLines(boundedLogExcerpt, config.checks.errorLines) || undefined;
-
-  return {
-    ...check,
-    failureKind,
-    logExcerpt: boundedLogExcerpt || undefined,
-    errorExcerpt,
-  };
+function classifyConclusion(c: CheckConclusion): FailureKind {
+  if (c === "TIMED_OUT") return "timeout";
+  if (c === "CANCELLED" || c === "STARTUP_FAILURE" || c === "STALE") return "cancelled";
+  return "actionable";
 }
 
 interface JobsResponse {
@@ -65,90 +53,33 @@ interface JobsResponse {
     id: number;
     name: string;
     conclusion: string | null;
+    steps?: Array<{ name: string; number: number; conclusion: string | null }>;
   }>;
 }
 
-async function fetchFailedLogs(runId: string, repo: RepoInfo): Promise<string> {
+async function fetchFailedStep(
+  runId: string,
+  checkName: string,
+  repo: RepoInfo,
+): Promise<string | undefined> {
+  const { owner, name } = repo;
+  const perPage = 100;
+  const allJobs: JobsResponse["jobs"] = [];
   try {
-    const { owner, name } = repo;
-    const perPage = 100;
-    const allJobs: JobsResponse["jobs"] = [];
-
     for (let page = 1; ; page++) {
-      const jobsData = await rest<JobsResponse>(
+      const data = await rest<JobsResponse>(
         "GET",
         `/repos/${owner}/${name}/actions/runs/${runId}/jobs?filter=latest&per_page=${perPage}&page=${page}`,
       );
-      allJobs.push(...jobsData.jobs);
-      if (jobsData.jobs.length < perPage) break;
+      allJobs.push(...data.jobs);
+      if (data.jobs.length < perPage) break;
     }
-
-    const failedJobs = allJobs.filter((j) =>
-      ["failure", "timed_out", "cancelled"].includes(j.conclusion ?? ""),
-    );
-
-    if (failedJobs.length === 0) return "";
-
-    const logParts = await Promise.all(
-      failedJobs.map(async (job) => {
-        try {
-          // Job-level endpoint (jobs/{id}/logs) redirects to plain text, unlike
-          // run-level (runs/{id}/logs) which returns a ZIP archive.
-          const logs = await restText(`/repos/${owner}/${name}/actions/jobs/${job.id}/logs`);
-          return logs.trim() ? `===== job: ${job.name} =====\n${logs}` : "";
-        } catch {
-          return "";
-        }
-      }),
-    );
-
-    const combined = logParts.filter(Boolean).join("\n");
-    const ansiEscapes = /\u001B\[[0-9;]*m/g;
-    return combined
-      .replace(ansiEscapes, "")
-      .split("\n")
-      .slice(-config.checks.logMaxLines)
-      .join("\n");
   } catch {
-    return "";
+    return undefined;
   }
-}
-
-/**
- * Extract the last `maxLines` `##[error]`-marked lines from GitHub Actions logs,
- * stripping the workflow-command prefix and any leading timestamp.
- *
- * Falls back to the last `maxLines` raw lines when no `##[error]` markers are found
- * (for example, jobs that do not emit workflow commands). Checks without a `runId`
- * do not have fetched logs, so they will not have an `errorExcerpt`.
- */
-export function extractErrorLines(logs: string, maxLines: number): string {
-  if (maxLines <= 0) return "";
-  const lines = logs.split("\n");
-  const errorLines = lines.filter((l) => ERROR_MARKER_RE.test(l));
-  const source = errorLines.length > 0 ? errorLines : lines.filter(Boolean);
-  const tail = source.slice(-maxLines);
-  return tail
-    .map((l) => {
-      // Strip optional timestamp + `##[error]` prefix:
-      // "2026-04-23T09:53:06.123Z ##[error]Error: foo" → "Error: foo"
-      return l.replace(/^.*##\[error\]/, "").trim();
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-function classifyLogs(check: ClassifiedCheck, logs: string): FailureKind {
-  if (check.conclusion === "TIMED_OUT") return "timeout";
-  if (TIMEOUT_PATTERNS.some((re) => re.test(logs))) return "timeout";
-
-  if (check.conclusion === "CANCELLED" && INFRA_PATTERNS.some((re) => re.test(logs))) {
-    return "infrastructure";
-  }
-
-  if (!logs.trim()) return "infrastructure";
-
-  if (/flaky|timing|race condition|retry/i.test(logs)) return "flaky";
-
-  return "actionable";
+  // Match by name. For matrix jobs sharing a check name, prefer a failing one.
+  const matches = allJobs.filter((j) => j.name === checkName);
+  const job = matches.find((j) => j.conclusion === "failure") ?? matches[0];
+  const failedStep = job?.steps?.find((s) => s.conclusion === "failure");
+  return failedStep?.name;
 }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -35,11 +35,16 @@ export function triageFailingChecks(
 
 async function triageCheck(check: ClassifiedCheck, repo: RepoInfo): Promise<TriagedCheck> {
   const failureKind = check.runId === null ? "actionable" : classifyConclusion(check.conclusion);
-  if (failureKind !== "actionable" || check.runId === null) {
+  if (check.runId === null) {
     return { ...check, failureKind };
   }
-  const failedStep = await fetchFailedStep(check.runId, check.name, repo);
-  return { ...check, failureKind, failedStep };
+  const jobInfo = await fetchJobInfo(check.runId, check.name, repo);
+  return {
+    ...check,
+    failureKind,
+    workflowName: jobInfo?.workflowName,
+    ...(failureKind === "actionable" && { failedStep: jobInfo?.failedStep }),
+  };
 }
 
 function classifyConclusion(c: CheckConclusion): FailureKind {
@@ -52,16 +57,22 @@ interface JobsResponse {
   jobs: Array<{
     id: number;
     name: string;
+    workflow_name?: string;
     conclusion: string | null;
     steps?: Array<{ name: string; number: number; conclusion: string | null }>;
   }>;
 }
 
-async function fetchFailedStep(
+interface JobInfo {
+  workflowName?: string;
+  failedStep?: string;
+}
+
+async function fetchJobInfo(
   runId: string,
   checkName: string,
   repo: RepoInfo,
-): Promise<string | undefined> {
+): Promise<JobInfo | undefined> {
   const { owner, name } = repo;
   const perPage = 100;
   const allJobs: JobsResponse["jobs"] = [];
@@ -81,5 +92,8 @@ async function fetchFailedStep(
   const matches = allJobs.filter((j) => j.name === checkName);
   const job = matches.find((j) => j.conclusion === "failure") ?? matches[0];
   const failedStep = job?.steps?.find((s) => s.conclusion === "failure");
-  return failedStep?.name;
+  return {
+    workflowName: job?.workflow_name,
+    failedStep: failedStep?.name,
+  };
 }

--- a/src/checks/triage.mts
+++ b/src/checks/triage.mts
@@ -12,6 +12,12 @@
  * For all checks with a non-null runId, the jobs API is called once per runId
  * (results are cached across checks that share a run) to fetch workflow name
  * and, for actionable checks, the first failed step name. No log fetching is done.
+ *
+ * Note on infrastructure-killed FAILURE runs: GitHub reports these as
+ * conclusion === "FAILURE", so they classify as "actionable". The jobs API
+ * surfaces their failedStep (e.g. "Set up job") which gives the agent a
+ * GitHub-native signal to distinguish runner setup deaths from real test
+ * failures — without any log-pattern analysis at the CLI level.
  */
 
 import { rest } from "../github/http.mts";

--- a/src/cli-parser.iterate-fix.mock.test.mts
+++ b/src/cli-parser.iterate-fix.mock.test.mts
@@ -373,7 +373,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
         runId: "run-2",
         detailsUrl: "https://github.com/owner/repo/actions/runs/2",
         failureKind: "actionable",
-        errorExcerpt: "AssertionError: expected 1 to equal 2",
+        failedStep: "Run tests",
       },
     ] as import("./types.mts").RelevantCheck[];
     mockRunIterate.mockResolvedValue(result);
@@ -391,8 +391,8 @@ describe("main — iterate text format (fix_code and checks)", () => {
     expect(out).toContain("- ✓ `lint` — SUCCESS");
     // Failing check: ✗ bullet with failureKind, conclusion, runId
     expect(out).toContain("- ✗ `test` (actionable) — FAILURE · `run-2`");
-    // errorExcerpt rendered as blockquote
-    expect(out).toContain("  > AssertionError: expected 1 to equal 2");
+    // failedStep rendered as blockquote
+    expect(out).toContain("  > Run tests");
   });
 
   it("## Checks — external detailsUrl renders `external` prefix; no-ID renders `(no runId)`", async () => {
@@ -410,7 +410,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
         conclusion: "FAILURE",
         runId: null,
         detailsUrl: null,
-        failureKind: "infrastructure",
+        failureKind: "cancelled",
       },
     ] as import("./types.mts").RelevantCheck[];
     mockRunIterate.mockResolvedValue(result);
@@ -421,7 +421,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
     expect(out).toContain(
       "- ✗ `codecov/patch` (actionable) — FAILURE · external `https://app.codecov.io/gh/owner/repo/pull/42`",
     );
-    expect(out).toContain("- ✗ `mystery` (infrastructure) — FAILURE · (no runId)");
+    expect(out).toContain("- ✗ `mystery` (cancelled) — FAILURE · (no runId)");
   });
 
   it("## Checks section renders in rerun_ci, mark_ready, cancel, rebase, escalate, fix_code when checks is non-empty", async () => {

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -124,10 +124,8 @@ export function formatChecksSection(checks: RelevantCheck[]): string | null {
           ? `external \`${c.detailsUrl}\``
           : "(no runId)";
       lines.push(`- ✗ \`${c.name}\`${kind} — ${c.conclusion} · ${locator}`);
-      if (c.errorExcerpt) {
-        for (const eLine of c.errorExcerpt.split("\n")) {
-          lines.push(`  > ${eLine}`);
-        }
+      if (c.failedStep) {
+        lines.push(`  > ${c.failedStep}`);
       }
     }
   }

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -123,7 +123,8 @@ export function formatChecksSection(checks: RelevantCheck[]): string | null {
         : c.detailsUrl
           ? `external \`${c.detailsUrl}\``
           : "(no runId)";
-      lines.push(`- ✗ \`${c.name}\`${kind} — ${c.conclusion} · ${locator}`);
+      const prefix = c.workflowName ? `${c.workflowName} › ` : "";
+      lines.push(`- ✗ \`${prefix}${c.name}\`${kind} — ${c.conclusion} · ${locator}`);
       if (c.failedStep) {
         lines.push(`  > ${c.failedStep}`);
       }

--- a/src/commands/iterate.base-checks.mock.test.mts
+++ b/src/commands/iterate.base-checks.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.base-checks.mock.test.mts
+++ b/src/commands/iterate.base-checks.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -222,8 +216,8 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
       event: "pull_request",
       runId: "run-50",
       category: "failing" as const,
-      failureKind: "infrastructure" as const,
-      errorExcerpt: "Runner error: the runner crashed",
+      failureKind: "cancelled" as const,
+      failedStep: undefined,
     };
     const passingChecks = ["lint", "typecheck", "test", "e2e", "security"].map((name) => ({
       name,
@@ -261,8 +255,7 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
     expect(result.checks).toHaveLength(6);
     const failing = result.checks.find((c) => c.name === "build");
     expect(failing).toBeDefined();
-    expect(failing!.failureKind).toBe("infrastructure");
-    expect(failing!.errorExcerpt).toBe("Runner error: the runner crashed");
+    expect(failing!.failureKind).toBe("cancelled");
     const passNames = result.checks
       .filter((c) => c.conclusion === "SUCCESS")
       .map((c) => c.name)
@@ -270,17 +263,16 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
     expect(passNames).toEqual(["e2e", "lint", "security", "test", "typecheck"]);
   });
 
-  it("flaky+BEHIND → rebase action with failing check still in base.checks", async () => {
-    const flakyCheck = {
-      name: "flaky-test",
+  it("cancelled+BEHIND → rerun_ci action with failing check still in base.checks", async () => {
+    const cancelledCheck = {
+      name: "ci",
       status: "COMPLETED" as const,
-      conclusion: "FAILURE" as const,
+      conclusion: "CANCELLED" as const,
       detailsUrl: "https://github.com/owner/repo/actions/runs/60",
       event: "pull_request",
       runId: "run-60",
       category: "failing" as const,
-      failureKind: "flaky" as const,
-      errorExcerpt: "Test is flaky: failed 1/3 runs",
+      failureKind: "cancelled" as const,
     };
     mockRunCheck.mockResolvedValue(
       makeReport({
@@ -296,7 +288,7 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
         },
         checks: {
           passing: [],
-          failing: [flakyCheck],
+          failing: [cancelledCheck],
           inProgress: [],
           skipped: [],
           filtered: [],
@@ -313,11 +305,10 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
 
     const result = await runIterate(makeOpts());
 
-    expect(result.action).toBe("rebase");
+    expect(result.action).toBe("rerun_ci");
     expect(result.checks).toHaveLength(1);
-    expect(result.checks[0]!.name).toBe("flaky-test");
-    expect(result.checks[0]!.failureKind).toBe("flaky");
-    expect(result.checks[0]!.errorExcerpt).toBe("Test is flaky: failed 1/3 runs");
+    expect(result.checks[0]!.name).toBe("ci");
+    expect(result.checks[0]!.failureKind).toBe("cancelled");
   });
 
   it("cooldown path returns checks: []", async () => {

--- a/src/commands/iterate.classify.mock.test.mts
+++ b/src/commands/iterate.classify.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.classify.mock.test.mts
+++ b/src/commands/iterate.classify.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-actionable.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-actionable.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -218,7 +212,6 @@ function makeActionableCheck(runId: string, name = "typecheck") {
     runId,
     category: "failing" as const,
     failureKind: "actionable" as const,
-    logExcerpt: "error TS2345: type mismatch",
   };
 }
 

--- a/src/commands/iterate.fix-code-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-projection.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.fix-code-projection.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -218,7 +212,6 @@ function makeActionableCheck(runId: string, name = "typecheck") {
     runId,
     category: "failing" as const,
     failureKind: "actionable" as const,
-    logExcerpt: "error TS2345: type mismatch",
   };
 }
 
@@ -328,7 +321,6 @@ describe("runIterate — fix_code agent projection", () => {
       expect(c.runId).toBe("run-55");
       expect(c.detailsUrl).toBeDefined();
       expect(c.failureKind).toBe("actionable");
-      expect(c).not.toHaveProperty("logExcerpt");
       expect(c).not.toHaveProperty("conclusion");
       expect(c).not.toHaveProperty("category");
     }

--- a/src/commands/iterate.orchestrator.mock.test.mts
+++ b/src/commands/iterate.orchestrator.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.orchestrator.mock.test.mts
+++ b/src/commands/iterate.orchestrator.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -372,7 +366,6 @@ describe("runIterate — triage via runCheck", () => {
       runId: "run-3",
       category: "failing" as const,
       failureKind: "actionable" as const,
-      logExcerpt: "error TS2345: type mismatch",
     };
     mockRunCheck.mockResolvedValue(
       makeReport({

--- a/src/commands/iterate.render-escalate-fields.mock.test.mts
+++ b/src/commands/iterate.render-escalate-fields.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.render-escalate-fields.mock.test.mts
+++ b/src/commands/iterate.render-escalate-fields.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.render-humanmessage.mock.test.mts
+++ b/src/commands/iterate.render-humanmessage.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -273,7 +274,6 @@ describe("runIterate — prescriptive fields: escalate humanMessage", () => {
       expect(result.escalate.humanMessage).toMatch(/base-branch-unknown/);
     }
   });
-
 
   it("escalates with base-branch-unknown on CONFLICTS-only when baseBranch is empty (no resolve IDs, but rebase still needed)", async () => {
     // Guards the `|| hasConflicts` branch of the fix_code base-branch-unknown

--- a/src/commands/iterate.render-humanmessage.mock.test.mts
+++ b/src/commands/iterate.render-humanmessage.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -280,53 +274,6 @@ describe("runIterate — prescriptive fields: escalate humanMessage", () => {
     }
   });
 
-  it("escalates with base-branch-unknown when rebase would run but baseBranch is empty", async () => {
-    const flakyCheck = {
-      name: "flaky",
-      status: "COMPLETED" as const,
-      conclusion: "FAILURE" as const,
-      detailsUrl: "https://github.com/owner/repo/actions/runs/30",
-      event: "pull_request",
-      runId: "run-30",
-      category: "failing" as const,
-      failureKind: "flaky" as const,
-    };
-    mockRunCheck.mockResolvedValue(
-      makeReport({
-        status: "FAILING",
-        baseBranch: "",
-        mergeStatus: {
-          status: "BEHIND",
-          state: "OPEN",
-          isDraft: false,
-          mergeable: "MERGEABLE",
-          reviewDecision: null,
-          copilotReviewInProgress: false,
-          mergeStateStatus: "BEHIND",
-        },
-        checks: {
-          passing: [],
-          failing: [flakyCheck],
-          inProgress: [],
-          skipped: [],
-          filtered: [],
-          filteredNames: [],
-          blockedByFilteredCheck: false,
-        },
-      }),
-    );
-    mockUpdateReadyDelay.mockResolvedValue({
-      isReady: false,
-      shouldCancel: false,
-      remainingSeconds: 600,
-    });
-
-    const result = await runIterate(makeOpts());
-    expect(result.action).toBe("escalate");
-    if (result.action === "escalate") {
-      expect(result.escalate.triggers).toEqual(["base-branch-unknown"]);
-    }
-  });
 
   it("escalates with base-branch-unknown on CONFLICTS-only when baseBranch is empty (no resolve IDs, but rebase still needed)", async () => {
     // Guards the `|| hasConflicts` branch of the fix_code base-branch-unknown

--- a/src/commands/iterate.render-resolve-cmd.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.render-resolve-cmd.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -350,66 +344,5 @@ describe("runIterate — prescriptive fields: log strings", () => {
   });
 });
 
-describe("runIterate — prescriptive fields: rebase", () => {
-  it("rebase result includes baseBranch, reason, and shellScript with dirty-worktree guard", async () => {
-    const flakyCheck = {
-      name: "flaky",
-      status: "COMPLETED" as const,
-      conclusion: "FAILURE" as const,
-      detailsUrl: "https://github.com/owner/repo/actions/runs/30",
-      event: "pull_request",
-      runId: "run-30",
-      category: "failing" as const,
-      failureKind: "flaky" as const,
-    };
-    mockRunCheck.mockResolvedValue(
-      makeReport({
-        status: "FAILING",
-        mergeStatus: {
-          status: "BEHIND",
-          state: "OPEN",
-          isDraft: false,
-          mergeable: "MERGEABLE",
-          reviewDecision: null,
-          copilotReviewInProgress: false,
-          mergeStateStatus: "BEHIND",
-        },
-        checks: {
-          passing: [],
-          failing: [flakyCheck],
-          inProgress: [],
-          skipped: [],
-          filtered: [],
-          filteredNames: [],
-          blockedByFilteredCheck: false,
-        },
-      }),
-    );
-    mockUpdateReadyDelay.mockResolvedValue({
-      isReady: false,
-      shouldCancel: false,
-      remainingSeconds: 600,
-    });
-    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "git" && args[0] === "log")
-        return Promise.resolve({ stdout: String(NOW - 60), stderr: "" });
-      if (cmd === "git" && args[0] === "rev-parse")
-        return Promise.resolve({ stdout: "abc123\n", stderr: "" });
-      if (cmd === "gh" && args[1] === "view")
-        return Promise.resolve({ stdout: "main\n", stderr: "" });
-      return Promise.resolve({ stdout: "", stderr: "" });
-    });
-
-    const result = await runIterate(makeOpts());
-    expect(result.action).toBe("rebase");
-    if (result.action === "rebase") {
-      expect(result.baseBranch).toBe("main");
-      expect(result.rebase.reason).toMatch(/behind main/i);
-      expect(result.rebase.shellScript).toMatch(/git diff --quiet/);
-      expect(result.rebase.shellScript).toMatch(/git rebase origin\/main/);
-      expect(result.rebase.shellScript).toMatch(/--force-with-lease/);
-    }
-  });
-});
 
 // renderResolveCommand and buildResolveCommand tests moved to iterate.render-resolve-cmd.mock.test.mts

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -343,6 +344,5 @@ describe("runIterate — prescriptive fields: log strings", () => {
     }
   });
 });
-
 
 // renderResolveCommand and buildResolveCommand tests moved to iterate.render-resolve-cmd.mock.test.mts

--- a/src/commands/iterate.stall.mock.test.mts
+++ b/src/commands/iterate.stall.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.stall.mock.test.mts
+++ b/src/commands/iterate.stall.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.steps.mock.test.mts
+++ b/src/commands/iterate.steps.mock.test.mts
@@ -156,7 +156,8 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],
+    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,

--- a/src/commands/iterate.steps.mock.test.mts
+++ b/src/commands/iterate.steps.mock.test.mts
@@ -156,13 +156,7 @@ function defaultConfig() {
       fetchReviewSummaries: true,
     },
     checks: {
-      ciTriggerEvents: ["pull_request", "pull_request_target"],
-      timeoutPatterns: [],
-      infraPatterns: [],
-      logMaxLines: 50,
-      logMaxChars: 3000,
-      errorLines: 1,
-    },
+      ciTriggerEvents: ["pull_request", "pull_request_target"],    },
     mergeStatus: { blockingReviewerLogins: ["copilot"] },
     actions: {
       autoResolveOutdated: true,
@@ -275,7 +269,7 @@ describe("runIterate — rerun_ci", () => {
       event: "pull_request",
       runId: "run-20",
       category: "failing" as const,
-      failureKind: "infrastructure" as const,
+      failureKind: "cancelled" as const,
     };
     const check2 = {
       name: "test-step-2",
@@ -285,7 +279,7 @@ describe("runIterate — rerun_ci", () => {
       event: "pull_request",
       runId: "run-20", // same runId
       category: "failing" as const,
-      failureKind: "infrastructure" as const,
+      failureKind: "cancelled" as const,
     };
     mockRunCheck.mockResolvedValue(
       makeReport({
@@ -314,22 +308,22 @@ describe("runIterate — rerun_ci", () => {
       expect(result.reran).toHaveLength(1);
       expect(result.reran[0].runId).toBe("run-20");
       expect(result.reran[0].checkNames).toEqual(["test-step-1", "test-step-2"]);
-      expect(result.reran[0].failureKind).toBe("infrastructure");
+      expect(result.reran[0].failureKind).toBe("cancelled");
     }
   });
 });
 
-describe("runIterate — rebase", () => {
-  it("returns action: rebase when flaky failure + BEHIND", async () => {
-    const flakyCheck = {
-      name: "flaky-test",
+describe("runIterate — cancelled + BEHIND", () => {
+  it("returns rerun_ci (not rebase) for cancelled failure when branch is BEHIND", async () => {
+    const cancelledCheck = {
+      name: "ci",
       status: "COMPLETED" as const,
-      conclusion: "FAILURE" as const,
+      conclusion: "CANCELLED" as const,
       detailsUrl: "https://github.com/owner/repo/actions/runs/30",
       event: "pull_request",
       runId: "run-30",
       category: "failing" as const,
-      failureKind: "flaky" as const,
+      failureKind: "cancelled" as const,
     };
     mockRunCheck.mockResolvedValue(
       makeReport({
@@ -345,7 +339,7 @@ describe("runIterate — rebase", () => {
         },
         checks: {
           passing: [],
-          failing: [flakyCheck],
+          failing: [cancelledCheck],
           inProgress: [],
           skipped: [],
           filtered: [],
@@ -362,7 +356,7 @@ describe("runIterate — rebase", () => {
 
     const result = await runIterate(makeOpts());
 
-    expect(result.action).toBe("rebase");
+    expect(result.action).toBe("rerun_ci");
     expect(result.mergeStateStatus).toBe("BEHIND");
   });
 });

--- a/src/commands/iterate/helpers.mts
+++ b/src/commands/iterate/helpers.mts
@@ -37,6 +37,7 @@ export function buildRelevantChecks(report: ShepherdReport): RelevantCheck[] {
         runId: c.runId,
         detailsUrl: c.detailsUrl || null,
         failureKind: c.failureKind,
+        workflowName: c.workflowName,
         failedStep: c.failedStep,
       },
     ];

--- a/src/commands/iterate/helpers.mts
+++ b/src/commands/iterate/helpers.mts
@@ -37,7 +37,7 @@ export function buildRelevantChecks(report: ShepherdReport): RelevantCheck[] {
         runId: c.runId,
         detailsUrl: c.detailsUrl || null,
         failureKind: c.failureKind,
-        errorExcerpt: c.errorExcerpt,
+        failedStep: c.failedStep,
       },
     ];
   });

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -15,7 +15,7 @@ import { classifyReviewSummaries } from "./classify.mts";
 import { applyStallGuard } from "./stall.mts";
 import { buildWaitLog } from "./render.mts";
 import { handleFixCode } from "./fix-code.mts";
-import { buildRerunCiResult, handleRebase } from "./steps.mts";
+import { buildRerunCiResult } from "./steps.mts";
 import type { IterateCommandOptions, IterateResult, IterateResultBase } from "../../types.mts";
 
 export async function runIterate(opts: IterateCommandOptions): Promise<IterateResult> {
@@ -132,7 +132,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   }
 
   const transientChecks = report.checks.failing.filter(
-    (f) => f.failureKind === "timeout" || f.failureKind === "infrastructure",
+    (f) => f.failureKind === "timeout" || f.failureKind === "cancelled",
   );
   if (transientChecks.length > 0) {
     return buildRerunCiResult(
@@ -143,19 +143,6 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       stallTimeoutSeconds,
       headSha,
       report,
-      reviewSummaryIds,
-    );
-  }
-
-  const hasFlaky = report.checks.failing.some((f) => f.failureKind === "flaky");
-  if (hasFlaky && report.mergeStatus.status === "BEHIND" && config.actions.autoRebase) {
-    return handleRebase(
-      base,
-      report,
-      stallKey,
-      stallTimeoutSeconds,
-      headSha,
-      prNumber,
       reviewSummaryIds,
     );
   }

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -132,7 +132,8 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   }
 
   const transientChecks = report.checks.failing.filter(
-    (f) => f.failureKind === "timeout" || f.failureKind === "cancelled",
+    (f) =>
+      (f.failureKind === "timeout" || f.failureKind === "cancelled") && f.runId !== null,
   );
   if (transientChecks.length > 0) {
     return buildRerunCiResult(

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -132,8 +132,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   }
 
   const transientChecks = report.checks.failing.filter(
-    (f) =>
-      (f.failureKind === "timeout" || f.failureKind === "cancelled") && f.runId !== null,
+    (f) => (f.failureKind === "timeout" || f.failureKind === "cancelled") && f.runId !== null,
   );
   if (transientChecks.length > 0) {
     return buildRerunCiResult(

--- a/src/commands/iterate/steps.mts
+++ b/src/commands/iterate/steps.mts
@@ -1,12 +1,5 @@
 import { applyStallGuard } from "./stall.mts";
-import {
-  validateBaseBranch,
-  buildRebaseShellScript,
-  buildEscalateSuggestion,
-  buildEscalateHumanMessage,
-} from "./escalate.mts";
 import type {
-  EscalateDetails,
   IterateResult,
   IterateResultBase,
   ShepherdReport,
@@ -52,53 +45,6 @@ export async function buildRerunCiResult(
       action: "rerun_ci" as const,
       reran,
       log: `RERUN NEEDED — ${reran.length} CI run${reran.length === 1 ? "" : "s"}: ${runSummaries.join(", ")}`,
-    } as IterateResult,
-    report,
-    reviewSummaryIds,
-  );
-}
-
-export async function handleRebase(
-  base: IterateResultBase,
-  report: ShepherdReport,
-  stallKey: { owner: string; repo: string; pr: number },
-  stallTimeoutSeconds: number,
-  headSha: string,
-  prNumber: number,
-  reviewSummaryIds: string[],
-): Promise<IterateResult> {
-  const baseLookup = validateBaseBranch(report.baseBranch);
-  if (baseLookup.isFallback) {
-    const fallbackEscalateBase: Omit<EscalateDetails, "humanMessage"> = {
-      triggers: ["base-branch-unknown"],
-      unresolvedThreads: [],
-      ambiguousComments: [],
-      changesRequestedReviews: [],
-      suggestion: buildEscalateSuggestion(["base-branch-unknown"], baseLookup.failureReason),
-    };
-    return {
-      ...base,
-      action: "escalate",
-      escalate: {
-        ...fallbackEscalateBase,
-        humanMessage: buildEscalateHumanMessage(fallbackEscalateBase, prNumber),
-      },
-    };
-  }
-  return applyStallGuard(
-    stallKey,
-    stallTimeoutSeconds,
-    headSha,
-    base,
-    prNumber,
-    {
-      ...base,
-      baseBranch: baseLookup.branch,
-      action: "rebase" as const,
-      rebase: {
-        reason: `Branch is behind ${baseLookup.branch} — rebasing to pick up latest changes and clear flaky failures`,
-        shellScript: buildRebaseShellScript(baseLookup.branch),
-      },
     } as IterateResult,
     report,
     reviewSummaryIds,

--- a/src/commands/iterate/steps.mts
+++ b/src/commands/iterate/steps.mts
@@ -27,13 +27,15 @@ export async function buildRerunCiResult(
         runId: c.runId,
         checkNames: [c.name],
         failureKind: c.failureKind as "timeout" | "cancelled",
+        workflowName: c.workflowName,
       });
     }
   }
   const reran = [...runMap.values()];
-  const runSummaries = reran.map(
-    ({ runId, checkNames, failureKind }) => `${runId} (${checkNames.join(", ")} — ${failureKind})`,
-  );
+  const runSummaries = reran.map(({ runId, checkNames, failureKind, workflowName }) => {
+    const prefix = workflowName ? `${workflowName} › ` : "";
+    return `${runId} (${prefix}${checkNames.join(", ")} — ${failureKind})`;
+  });
   return applyStallGuard(
     stallKey,
     stallTimeoutSeconds,

--- a/src/commands/iterate/steps.mts
+++ b/src/commands/iterate/steps.mts
@@ -33,7 +33,7 @@ export async function buildRerunCiResult(
       runMap.set(c.runId, {
         runId: c.runId,
         checkNames: [c.name],
-        failureKind: c.failureKind as "timeout" | "infrastructure",
+        failureKind: c.failureKind as "timeout" | "cancelled",
       });
     }
   }

--- a/src/config.json
+++ b/src/config.json
@@ -27,23 +27,7 @@
     "fetchReviewSummaries": true
   },
   "checks": {
-    "ciTriggerEvents": ["pull_request", "pull_request_target"],
-    "timeoutPatterns": [
-      "cancel timeout",
-      "exceeded the maximum execution time",
-      "job was cancelled"
-    ],
-    "infraPatterns": [
-      "runner error",
-      "service unavailable",
-      "ETIMEOUT",
-      "ECONNRESET",
-      "lost communication with the server",
-      "the hosted runner lost connection"
-    ],
-    "logMaxLines": 50,
-    "logMaxChars": 3000,
-    "errorLines": 1
+    "ciTriggerEvents": ["pull_request", "pull_request_target"]
   },
   "mergeStatus": {
     "blockingReviewerLogins": ["copilot"]

--- a/src/config/compat.mts
+++ b/src/config/compat.mts
@@ -98,7 +98,7 @@ export function applyCompat(raw: Record<string, unknown>): Record<string, unknow
     out["resolve"] = resolveOut;
   }
 
-  // Renamed checks keys
+  // Renamed/removed checks keys
   const checks = out["checks"] as Record<string, unknown> | undefined;
   if (checks) {
     const checksOut = { ...checks };
@@ -109,19 +109,21 @@ export function applyCompat(raw: Record<string, unknown>): Record<string, unknow
       checksOut["ciTriggerEvents"] = checksOut["ciTriggerEvents"] ?? checks["relevantEvents"];
       delete checksOut["relevantEvents"];
     }
-    if ("logLinesKept" in checks) {
-      process.stderr.write(
-        `pr-shepherd: config key "checks.logLinesKept" renamed to "checks.logMaxLines".\n`,
-      );
-      checksOut["logMaxLines"] = checksOut["logMaxLines"] ?? checks["logLinesKept"];
-      delete checksOut["logLinesKept"];
-    }
-    if ("logExcerptMaxChars" in checks) {
-      process.stderr.write(
-        `pr-shepherd: config key "checks.logExcerptMaxChars" renamed to "checks.logMaxChars".\n`,
-      );
-      checksOut["logMaxChars"] = checksOut["logMaxChars"] ?? checks["logExcerptMaxChars"];
-      delete checksOut["logExcerptMaxChars"];
+    for (const gone of [
+      "timeoutPatterns",
+      "infraPatterns",
+      "logMaxLines",
+      "logMaxChars",
+      "errorLines",
+      "logLinesKept",
+      "logExcerptMaxChars",
+    ]) {
+      if (gone in checks) {
+        process.stderr.write(
+          `pr-shepherd: config key "checks.${gone}" has been removed and has no effect.\n`,
+        );
+        delete checksOut[gone];
+      }
     }
     out["checks"] = checksOut;
   }

--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -43,12 +43,6 @@ export interface PrShepherdConfig {
   };
   checks: {
     ciTriggerEvents: string[];
-    timeoutPatterns: string[];
-    infraPatterns: string[];
-    logMaxLines: number;
-    logMaxChars: number;
-    /** Number of trailing `##[error]`-marked lines to surface per failing check. Default 1. */
-    errorLines: number;
   };
   mergeStatus: {
     blockingReviewerLogins: string[];

--- a/src/config/load.test.mts
+++ b/src/config/load.test.mts
@@ -38,7 +38,7 @@ describe("loadConfig — no rc file", () => {
     const result = loadConfig();
     expect(result.resolve.concurrency).toBe(4);
     expect(result.iterate.fixAttemptsPerThread).toBe(3);
-    expect(result.checks.logMaxLines).toBe(50);
+    expect(result.checks.ciTriggerEvents).toEqual(["pull_request", "pull_request_target"]);
   });
 
   it("defaults iterate.minimizeReviewSummaries to {bots:true, humans:true, approvals:false}", async () => {
@@ -86,10 +86,10 @@ describe("loadConfig — deep merge", () => {
   });
 
   it("replaces arrays outright rather than concatenating", async () => {
-    writeFileSync(join(tmpDir, RC), "checks:\n  timeoutPatterns:\n    - only-this\n");
+    writeFileSync(join(tmpDir, RC), "checks:\n  ciTriggerEvents:\n    - push\n");
     const loadConfig = await freshLoadConfig();
     const result = loadConfig();
-    expect(result.checks.timeoutPatterns).toEqual(["only-this"]);
+    expect(result.checks.ciTriggerEvents).toEqual(["push"]);
   });
 });
 
@@ -216,25 +216,23 @@ describe("loadConfig — checks renames", () => {
     );
   });
 
-  it("maps logLinesKept → logMaxLines and warns", async () => {
+  it("warns and strips logLinesKept (removed)", async () => {
     writeFileSync(join(tmpDir, RC), "checks:\n  logLinesKept: 100\n");
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const loadConfig = await freshLoadConfig();
-    const result = loadConfig();
-    expect(result.checks.logMaxLines).toBe(100);
+    loadConfig();
     expect(stderrSpy.mock.calls.map((c) => c[0]).join("")).toContain(
-      '"checks.logLinesKept" renamed',
+      '"checks.logLinesKept" has been removed',
     );
   });
 
-  it("maps logExcerptMaxChars → logMaxChars and warns", async () => {
+  it("warns and strips logExcerptMaxChars (removed)", async () => {
     writeFileSync(join(tmpDir, RC), "checks:\n  logExcerptMaxChars: 9999\n");
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const loadConfig = await freshLoadConfig();
-    const result = loadConfig();
-    expect(result.checks.logMaxChars).toBe(9999);
+    loadConfig();
     expect(stderrSpy.mock.calls.map((c) => c[0]).join("")).toContain(
-      '"checks.logExcerptMaxChars" renamed',
+      '"checks.logExcerptMaxChars" has been removed',
     );
   });
 });

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -25,7 +25,13 @@ export function toAgentComment(c: PrComment): AgentComment {
 }
 
 export function toAgentCheck(c: TriagedCheck): AgentCheck {
-  return { name: c.name, runId: c.runId, detailsUrl: c.detailsUrl, failureKind: c.failureKind, failedStep: c.failedStep };
+  return {
+    name: c.name,
+    runId: c.runId,
+    detailsUrl: c.detailsUrl,
+    failureKind: c.failureKind,
+    failedStep: c.failedStep,
+  };
 }
 
 /**

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -2,8 +2,9 @@
  * Projections for the agent-facing iterate output.
  *
  * These strip fields that are always-false by the time items reach iterate
- * (isResolved, isOutdated, isMinimized, createdAtUnix) and metadata that the
- * monitor prompt never reads (detailsUrl, event, status, conclusion, category).
+ * (isResolved, isOutdated, isMinimized, createdAtUnix) and check metadata the
+ * monitor prompt never reads (event, status, conclusion, category).
+ * detailsUrl is preserved in AgentCheck as a fallback for external status checks.
  * The original domain types are preserved for check command output.
  */
 

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -30,6 +30,7 @@ export function toAgentCheck(c: TriagedCheck): AgentCheck {
     runId: c.runId,
     detailsUrl: c.detailsUrl,
     failureKind: c.failureKind,
+    ...(c.workflowName !== undefined && { workflowName: c.workflowName }),
     ...(c.failedStep !== undefined && { failedStep: c.failedStep }),
   };
 }

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -25,7 +25,7 @@ export function toAgentComment(c: PrComment): AgentComment {
 }
 
 export function toAgentCheck(c: TriagedCheck): AgentCheck {
-  return { name: c.name, runId: c.runId, detailsUrl: c.detailsUrl, failureKind: c.failureKind };
+  return { name: c.name, runId: c.runId, detailsUrl: c.detailsUrl, failureKind: c.failureKind, failedStep: c.failedStep };
 }
 
 /**

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -3,8 +3,8 @@
  *
  * These strip fields that are always-false by the time items reach iterate
  * (isResolved, isOutdated, isMinimized, createdAtUnix) and metadata that the
- * monitor prompt never reads (detailsUrl, event, status, conclusion, category,
- * logExcerpt). The original domain types are preserved for check command output.
+ * monitor prompt never reads (detailsUrl, event, status, conclusion, category).
+ * The original domain types are preserved for check command output.
  */
 
 import type {
@@ -30,7 +30,7 @@ export function toAgentCheck(c: TriagedCheck): AgentCheck {
     runId: c.runId,
     detailsUrl: c.detailsUrl,
     failureKind: c.failureKind,
-    failedStep: c.failedStep,
+    ...(c.failedStep !== undefined && { failedStep: c.failedStep }),
   };
 }
 

--- a/src/reporters/agent.test.mts
+++ b/src/reporters/agent.test.mts
@@ -33,7 +33,6 @@ function makeCheck(runId: string | null, name = "typecheck"): TriagedCheck {
     runId,
     category: "failing",
     failureKind: "actionable",
-    logExcerpt: "error TS2345",
   };
 }
 
@@ -63,7 +62,7 @@ describe("toAgentComment", () => {
 });
 
 describe("toAgentCheck", () => {
-  it("keeps name/runId/detailsUrl/failureKind and drops logExcerpt/conclusion/category", () => {
+  it("keeps name/runId/detailsUrl/failureKind and drops conclusion/category; omits failedStep when absent", () => {
     const result = toAgentCheck(makeCheck("run-1"));
     expect(result).toEqual({
       name: "typecheck",

--- a/src/reporters/check-instructions.mts
+++ b/src/reporters/check-instructions.mts
@@ -27,45 +27,33 @@ export function buildCheckInstructions(report: ShepherdReport): string[] {
   );
 
   // 2. Rebase policy (only emit when relevant)
-  const anyFlaky = checks.failing.some((c) => c.failureKind === "flaky");
   if (mergeStatus.status === "CONFLICTS") {
     instructions.push(
       "Rebase required: the branch has merge conflicts that must be resolved before this PR can land.",
     );
-  } else if (mergeStatus.status === "BEHIND" && anyFlaky) {
-    instructions.push(
-      "Rebase recommended: the PR is behind the base branch and has a flaky failure — this is the canonical rebase signal. Run `git fetch origin && git rebase origin/<baseBranch>` then `git push --force-with-lease`.".replace(
-        "<baseBranch>",
-        report.baseBranch,
-      ),
-    );
   } else if (mergeStatus.status === "BEHIND") {
     instructions.push(
-      "The PR is behind the base branch. A rebase is optional if all CI checks pass; rebase if a flaky failure appears after rechecking.",
+      "The PR is behind the base branch. A rebase is optional if all CI checks pass.",
     );
   }
 
   // 3. CI budget policy — one instruction per failing check
   for (const c of checks.failing) {
     if (c.failureKind === "actionable") {
-      const diagnosisSource = c.logExcerpt
-        ? "investigate the log excerpt in the output above"
-        : `open the check details (${c.detailsUrl}) to diagnose the failure`;
+      const diagnosisHint = c.failedStep
+        ? `the failure was in step \`${c.failedStep}\` — fetch the run log with \`gh run view ${c.runId ?? "<runId>"} --log-failed\` to diagnose`
+        : c.runId
+          ? `fetch the run log with \`gh run view ${c.runId} --log-failed\` to diagnose the failure`
+          : `open the check details (${c.detailsUrl}) to diagnose the failure`;
       instructions.push(
-        `Fix code failure: \`${c.name}\` (actionable) — ${diagnosisSource} and apply a fix.`,
+        `Fix code failure: \`${c.name}\` (actionable) — ${diagnosisHint} and apply a fix.`,
       );
-    } else if (c.failureKind === "infrastructure" || c.failureKind === "timeout") {
+    } else if (c.failureKind === "cancelled" || c.failureKind === "timeout") {
       const rerunCmd = c.runId
         ? `gh run rerun ${c.runId} --failed`
         : `gh run rerun <runId> --failed`;
       instructions.push(
         `Re-run transient failure: \`${c.name}\` [${c.failureKind}] — run \`${rerunCmd}\`.`,
-      );
-    } else if (c.failureKind === "flaky") {
-      const rebasing =
-        mergeStatus.status === "BEHIND" ? " Rebase first — see rebase instruction above." : "";
-      instructions.push(
-        `Do not cancel flaky failure: \`${c.name}\` [flaky]. Do NOT cancel the run.${rebasing}`,
       );
     }
   }

--- a/src/reporters/check-instructions.test.mts
+++ b/src/reporters/check-instructions.test.mts
@@ -97,17 +97,17 @@ describe("buildCheckInstructions — rebase policy", () => {
     expect(steps.some((s) => s.includes("Rebase required"))).toBe(true);
   });
 
-  it("emits rebase-recommended for BEHIND + flaky failure", () => {
+  it("emits rebase-optional for BEHIND + actionable failure", () => {
     const failing: TriagedCheck = {
       ...makeCheck({ name: "tests", category: "failing", conclusion: "FAILURE" }),
-      failureKind: "flaky",
+      failureKind: "actionable",
     };
     const report = makeReport({
       mergeStatus: { ...makeReport().mergeStatus, status: "BEHIND" },
       checks: { ...makeReport().checks, failing: [failing] },
     });
     const steps = buildCheckInstructions(report);
-    expect(steps.some((s) => s.includes("Rebase recommended"))).toBe(true);
+    expect(steps.some((s) => s.includes("A rebase is optional"))).toBe(true);
   });
 
   it("emits rebase-optional for BEHIND + no flaky failures", () => {
@@ -135,10 +135,10 @@ describe("buildCheckInstructions — CI budget policy", () => {
     expect(steps.some((s) => s.includes("Fix code failure") && s.includes("lint"))).toBe(true);
   });
 
-  it("emits rerun with runId for infrastructure failure", () => {
+  it("emits rerun with runId for cancelled failure", () => {
     const failing: TriagedCheck = {
       ...makeCheck({ name: "build", category: "failing", conclusion: "CANCELLED", runId: "99999" }),
-      failureKind: "infrastructure",
+      failureKind: "cancelled",
     };
     const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
     const steps = buildCheckInstructions(report);
@@ -153,30 +153,6 @@ describe("buildCheckInstructions — CI budget policy", () => {
     const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
     const steps = buildCheckInstructions(report);
     expect(steps.some((s) => s.includes("gh run rerun <runId> --failed"))).toBe(true);
-  });
-
-  it("emits do-not-cancel for flaky failure", () => {
-    const failing: TriagedCheck = {
-      ...makeCheck({ name: "e2e", category: "failing", conclusion: "FAILURE" }),
-      failureKind: "flaky",
-    };
-    const report = makeReport({ checks: { ...makeReport().checks, failing: [failing] } });
-    const steps = buildCheckInstructions(report);
-    expect(steps.some((s) => s.includes("Do not cancel") && s.includes("e2e"))).toBe(true);
-  });
-
-  it("appends rebase-first note to flaky step when BEHIND", () => {
-    const failing: TriagedCheck = {
-      ...makeCheck({ name: "e2e", category: "failing", conclusion: "FAILURE" }),
-      failureKind: "flaky",
-    };
-    const report = makeReport({
-      mergeStatus: { ...makeReport().mergeStatus, status: "BEHIND" },
-      checks: { ...makeReport().checks, failing: [failing] },
-    });
-    const steps = buildCheckInstructions(report);
-    const flakStep = steps.find((s) => s.includes("Do not cancel") && s.includes("e2e"));
-    expect(flakStep).toContain("Rebase first");
   });
 
   it("emits no CI budget steps when no failing checks", () => {

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -39,7 +39,7 @@ export function formatText(report: ShepherdReport): string {
       const prefix = triaged.workflowName ? `${triaged.workflowName} › ` : "";
       parts.push(`- ${prefix}${c.name}${kind}: ${c.conclusion ?? c.status}`);
       if (triaged.failedStep) {
-        parts.push(`  failed step: ${triaged.failedStep}`);
+        parts.push(`    failed step: ${triaged.failedStep}`);
       }
     }
     parts.push("");

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -166,4 +166,3 @@ export function formatText(report: ShepherdReport): string {
 function firstLine(text: string): string {
   return (text.split("\n")[0] ?? "").trim().slice(0, 120);
 }
-

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -36,9 +36,10 @@ export function formatText(report: ShepherdReport): string {
     for (const c of failing) {
       const triaged = c as TriagedCheck;
       const kind = triaged.failureKind ? ` [${triaged.failureKind}]` : "";
-      parts.push(`- ${c.name}${kind}: ${c.conclusion ?? c.status}`);
-      if (triaged.logExcerpt) {
-        parts.push(indent(triaged.logExcerpt.split("\n").slice(-10).join("\n"), "    "));
+      const prefix = triaged.workflowName ? `${triaged.workflowName} › ` : "";
+      parts.push(`- ${prefix}${c.name}${kind}: ${c.conclusion ?? c.status}`);
+      if (triaged.failedStep) {
+        parts.push(`  failed step: ${triaged.failedStep}`);
       }
     }
     parts.push("");
@@ -166,9 +167,3 @@ function firstLine(text: string): string {
   return (text.split("\n")[0] ?? "").trim().slice(0, 120);
 }
 
-function indent(text: string, prefix: string): string {
-  return text
-    .split("\n")
-    .map((l) => prefix + l)
-    .join("\n");
-}

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -137,32 +137,29 @@ describe("formatText — failed checks", () => {
     expect(out).not.toContain("[");
   });
 
-  it("indents logExcerpt with 4 spaces", () => {
+  it("renders failedStep when present", () => {
     const failing: TriagedCheck = {
       ...makeCheck({ category: "failing", conclusion: "FAILURE" }),
       failureKind: "actionable",
-      logExcerpt: "error: something went wrong",
+      failedStep: "Run tests",
     };
     const report = makeReport({
       checks: { ...makeReport().checks, failing: [failing] },
     });
     const out = formatText(report);
-    expect(out).toContain("    error: something went wrong");
+    expect(out).toContain("    failed step: Run tests");
   });
 
-  it("takes only the last 10 lines of logExcerpt", () => {
-    const allLines = Array.from({ length: 15 }, (_, i) => `line ${i + 1}`);
+  it("omits failed step line when failedStep is absent", () => {
     const failing: TriagedCheck = {
       ...makeCheck({ category: "failing", conclusion: "FAILURE" }),
       failureKind: "actionable",
-      logExcerpt: allLines.join("\n"),
     };
     const report = makeReport({
       checks: { ...makeReport().checks, failing: [failing] },
     });
     const out = formatText(report);
-    expect(out).toContain("line 15");
-    expect(out).not.toContain("line 5"); // first 5 lines should be excluded
+    expect(out).not.toContain("failed step:");
   });
 });
 

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -63,7 +63,7 @@ export type FailureKind = "timeout" | "cancelled" | "actionable";
 
 export interface TriagedCheck extends ClassifiedCheck {
   failureKind?: FailureKind;
-  /** Workflow display name (e.g. `"CI"`). Available for all checks with a runId. */
+  /** Workflow display name (e.g. `"CI"`). Populated when available from the jobs API; may be `undefined` on fetch failure or when no matching job is found. */
   workflowName?: string;
   /** For `actionable` failures: name of the first failed step in the matched job (e.g. `"Run tests"`). */
   failedStep?: string;

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -59,14 +59,12 @@ export interface ClassifiedCheck extends CheckRun {
   category: CheckCategory;
 }
 
-export type FailureKind = "timeout" | "infrastructure" | "actionable" | "flaky";
+export type FailureKind = "timeout" | "cancelled" | "actionable";
 
 export interface TriagedCheck extends ClassifiedCheck {
   failureKind?: FailureKind;
-  /** Truncated tail of the log excerpt retained for classification/debugging, bounded by configured line/char limits. */
-  logExcerpt?: string;
-  /** Last N `##[error]`-marked lines (or last N raw lines as fallback). Compact error summary. */
-  errorExcerpt?: string;
+  /** For `actionable` failures: name of the first failed step in the matched job (e.g. `"Run tests"`). */
+  failedStep?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -63,6 +63,8 @@ export type FailureKind = "timeout" | "cancelled" | "actionable";
 
 export interface TriagedCheck extends ClassifiedCheck {
   failureKind?: FailureKind;
+  /** Workflow display name (e.g. `"CI"`). Available for all checks with a runId. */
+  workflowName?: string;
   /** For `actionable` failures: name of the first failed step in the matched job (e.g. `"Run tests"`). */
   failedStep?: string;
 }

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -125,6 +125,8 @@ export interface ReranRun {
   /** Check names within this run that triggered the rerun (multiple steps can share a run). */
   checkNames: string[];
   failureKind: "timeout" | "cancelled";
+  /** Workflow display name (e.g. `"CI"`). */
+  workflowName?: string;
 }
 
 export interface IterateResultRerunCi extends IterateResultBase {

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -60,7 +60,7 @@ export interface IterateResultBase {
    * completed (status === COMPLETED), and not skipped/neutral.
    *
    * Includes both passing and failing checks. Failing entries carry `failureKind`
-   * and `errorExcerpt`. Empty (`[]`) during the `cooldown` early-return (no sweep ran).
+   * and `failedStep`. Empty (`[]`) during the `cooldown` early-return (no sweep ran).
    */
   checks: RelevantCheck[];
 }
@@ -124,7 +124,7 @@ export interface ReranRun {
   runId: string;
   /** Check names within this run that triggered the rerun (multiple steps can share a run). */
   checkNames: string[];
-  failureKind: "timeout" | "infrastructure";
+  failureKind: "timeout" | "cancelled";
 }
 
 export interface IterateResultRerunCi extends IterateResultBase {

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -102,7 +102,7 @@ export interface AgentCheck {
   /** Fallback for checks where runId is null (e.g. external status checks). */
   detailsUrl: string | null;
   failureKind?: FailureKind;
-  /** Workflow display name (e.g. `"CI"`). Available for all checks with a runId. */
+  /** Workflow display name (e.g. `"CI"`). Populated on a best-effort basis when available from the jobs API. */
   workflowName?: string;
   /** For `actionable` failures: name of the first failed step (e.g. `"Run tests"`, `"Set up job"`). */
   failedStep?: string;

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -102,6 +102,8 @@ export interface AgentCheck {
   /** Fallback for checks where runId is null (e.g. external status checks). */
   detailsUrl: string | null;
   failureKind?: FailureKind;
+  /** Workflow display name (e.g. `"CI"`). Available for all checks with a runId. */
+  workflowName?: string;
   /** For `actionable` failures: name of the first failed step (e.g. `"Run tests"`, `"Set up job"`). */
   failedStep?: string;
 }
@@ -124,6 +126,8 @@ export interface RelevantCheck {
   detailsUrl: string | null;
   /** Present for non-SUCCESS conclusions. */
   failureKind?: FailureKind;
+  /** Workflow display name (e.g. `"CI"`). Available for all checks with a runId. */
+  workflowName?: string;
   /** For `actionable` failures: name of the first failed step in the matched job. */
   failedStep?: string;
 }

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -93,7 +93,7 @@ export interface AgentComment {
 
 /**
  * Check shape emitted to the monitor agent.
- * The agent fetches full logs on demand via `gh run view <runId> --log-failed`
+ * The agent fetches failed job logs on demand via `gh run view <runId> --log-failed`
  * when `runId` is available, and falls back to `detailsUrl` otherwise.
  */
 export interface AgentCheck {

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -92,8 +92,8 @@ export interface AgentComment {
 }
 
 /**
- * Check shape emitted to the monitor agent — no log excerpt.
- * The agent fetches logs on demand via `gh run view <runId> --log-failed`
+ * Check shape emitted to the monitor agent.
+ * The agent fetches full logs on demand via `gh run view <runId> --log-failed`
  * when `runId` is available, and falls back to `detailsUrl` otherwise.
  */
 export interface AgentCheck {
@@ -102,6 +102,8 @@ export interface AgentCheck {
   /** Fallback for checks where runId is null (e.g. external status checks). */
   detailsUrl: string | null;
   failureKind?: FailureKind;
+  /** For `actionable` failures: name of the first failed step (e.g. `"Run tests"`, `"Set up job"`). */
+  failedStep?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,11 +124,8 @@ export interface RelevantCheck {
   detailsUrl: string | null;
   /** Present for non-SUCCESS conclusions. */
   failureKind?: FailureKind;
-  /**
-   * Last `checks.errorLines` `##[error]`-marked log lines (fallback: last N raw lines).
-   * Present for non-SUCCESS conclusions when logs were fetched.
-   */
-  errorExcerpt?: string;
+  /** For `actionable` failures: name of the first failed step in the matched job. */
+  failedStep?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Drop all CLI-level log-pattern classification**: \`timeoutPatterns\`, \`infraPatterns\`, \`logMaxLines\`, \`logMaxChars\`, \`errorLines\` config keys are removed. \`FailureKind\` shrinks from four values to three, all derived solely from GitHub's \`conclusion\` field.
- **New \`FailureKind\` taxonomy**: \`timeout\` (TIMED_OUT), \`cancelled\` (CANCELLED / STARTUP_FAILURE / STALE), \`actionable\` (FAILURE / ACTION_REQUIRED). The \`flaky\` and \`infrastructure\` kinds are gone.
- **\`failedStep\` replaces \`errorExcerpt\` / \`logExcerpt\`**: For \`actionable\` failures, triage calls the \`jobs?filter=latest\` endpoint and returns the name of the first failed step (e.g. \`"Run tests"\`, \`"Set up job"\`). No log fetching — the downstream agent reads full logs when it needs them.
- **\`workflowName\` surfaced for all checks with a runId**: The jobs API is called once per unique runId (cached) for all failing checks — not just actionable ones — so the workflow display name appears in triage output for timeout and cancelled runs too.
- **Infrastructure-killed FAILURE runs surface as \`actionable\` with \`failedStep: "Set up job"\`**: GitHub reports runner-death runs as \`conclusion === "FAILURE"\`, so they map to \`actionable\`. The \`failedStep\` from the jobs API (e.g. \`"Set up job"\`) gives the agent a GitHub-native signal to distinguish runner setup deaths from real code failures — without log-pattern analysis.
- **Flaky+BEHIND→rebase dispatch removed**: This path was purely log-pattern-driven (no GitHub-native flaky signal). BEHIND PRs now fall through to \`wait\`/\`mark_ready\` like any other non-failing PR.

Fixes #93.

## Test plan

- [ ] \`npm run test\` — all tests pass
- [ ] \`npm run typecheck\` (via build) — clean
- [ ] On a branch with a CANCELLED run: \`node bin/index.mjs check\` reports \`failureKind: "cancelled"\` with \`workflowName\` populated and no \`failedStep\`
- [ ] On a FAILURE run (real test failure): reports \`failureKind: "actionable"\` with \`failedStep: "<step name>"\`
- [ ] JSON and text output both surface \`failedStep\` and \`workflowName\` for actionable failures (format parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)