### PR TITLE
refactor: add `monitor` CLI subcommand; thin skills; remove dead flags

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -5,9 +5,10 @@
 ```
 pr-shepherd -v|--version
 pr-shepherd check [PR]
-pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha> | --last-push-time <ts>]
+pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
-pr-shepherd iterate [PR] [--cooldown-seconds N] [--ready-delay Nm] [--last-push-time N] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
+pr-shepherd iterate [PR] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
+pr-shepherd monitor [PR]
 pr-shepherd status PR1 [PR2 …]
 ```
 
@@ -130,7 +131,6 @@ Dismissed reviews (1): PRR_kwDO123
 | `--dismiss-review-ids`   | Comma-separated `CHANGES_REQUESTED` review IDs to dismiss                    |
 | `--message`              | Dismiss message (required when `--dismiss-review-ids` is set)                |
 | `--require-sha`          | Poll GitHub until the PR head matches this SHA before mutating               |
-| `--last-push-time`       | Unix timestamp of the most recent push (used internally by the monitor loop) |
 
 `--require-sha` polls `GET /repos/{owner}/{repo}/pulls/{pr}` for `headRefOid` until it matches, then issues the mutations — ensures reviewers see the fix before threads are closed. Exit code: always `0`. `--message` must describe the specific fix; it is shown to the reviewer on GitHub.
 
@@ -226,20 +226,18 @@ If `commit-suggestion` exits `1`, apply the fix manually as a regular code edit.
 One monitor tick: classifies current PR state and emits a single action. Used by the cron loop — the monitor skill calls this on each tick and follows the `## Instructions` section verbatim. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
 
 ```sh
-pr-shepherd iterate 42 --no-cache \
-  --ready-delay 10m \
-  --last-push-time "$(git log -1 --format=%ct HEAD)"
+pr-shepherd iterate 42 --no-cache
+pr-shepherd iterate 42 --no-cache --ready-delay 15m  # override ready-delay for this run
 ```
 
 **Flags:**
 
-| Flag                          | Default | Description                                                     |
-| ----------------------------- | ------- | --------------------------------------------------------------- |
-| `--ready-delay Nm`            | `10m`   | Settle window before the loop cancels after READY               |
-| `--cooldown-seconds N`        | `30`    | Wait after a push before reading CI                             |
-| `--last-push-time N`          | —       | Unix timestamp hint embedded in the result                      |
-| `--stall-timeout <duration>`  | `30m`   | Override the stall-detection window (e.g. `--stall-timeout 1h`) |
-| `--no-auto-mark-ready`        | false   | Skip converting draft → ready-for-review                        |
+| Flag                          | Default                            | Description                                                     |
+| ----------------------------- | ---------------------------------- | --------------------------------------------------------------- |
+| `--ready-delay Nm`            | `watch.readyDelayMinutes` in config | Settle window before the loop cancels after READY               |
+| `--cooldown-seconds N`        | `iterate.cooldownSeconds` in config | Wait after a push before reading CI                             |
+| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`) |
+| `--no-auto-mark-ready`        | false                              | Skip converting draft → ready-for-review                        |
 | `--no-auto-cancel-actionable` | false   | Skip cancelling actionable failing runs                         |
 
 **Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Example for `[WAIT]`:
@@ -304,6 +302,48 @@ See [actions.md](actions.md) for all eight actions and their complete output sha
 Both `--format=text` (default Markdown) and `--format=json` carry equivalent information — every field exposed in JSON has a corresponding Markdown representation, and vice versa.
 
 Exit codes: `0` wait/cooldown/rerun_ci/mark_ready · `1` fix_code/rebase · `2` cancel · `3` escalate
+
+### pr-shepherd monitor [PR]
+
+Bootstrap command for `/pr-shepherd:monitor`. Reads `watch.{interval, maxTurns, expiresHours}` from config and emits a `## Loop invocation` block containing the exact `/loop` args string (interval, flags, and full prompt body). The monitor skill invokes this command and passes the block contents to `/loop` via the Skill tool.
+
+```sh
+npx pr-shepherd monitor        # infer PR from current branch
+npx pr-shepherd monitor 42
+```
+
+**Example output:**
+
+```markdown
+# PR #42 [MONITOR]
+
+Loop tag: `# pr-shepherd-loop:pr=42`
+
+## Loop prompt
+
+# pr-shepherd-loop:pr=42
+
+**IMPORTANT — recurrence rules:**
+...
+
+## Loop invocation
+
+\`\`\`loop
+4m --max-turns 50 --expires 8h
+
+# pr-shepherd-loop:pr=42
+...
+\`\`\`
+
+## Instructions
+
+1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the loop prompt in `## Loop prompt` once inline then stop — do not create a duplicate loop.
+2. Otherwise, invoke the `/loop` skill via the Skill tool, passing the entire contents of the \`\`\`loop\`\`\` block above as the `args` parameter.
+```
+
+All loop parameters (`interval`, `maxTurns`, `expiresHours`) come from `.pr-shepherdrc.yml` or the built-in defaults (`watch.*` config keys). Use `--format=json` to inspect the raw values programmatically.
+
+Exit code: `0`
 
 ### pr-shepherd status PR1 [PR2 …]
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -123,14 +123,14 @@ Dismissed reviews (1): PRR_kwDO123
 
 **Flags:**
 
-| Flag                     | Description                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------- |
-| `--fetch`                | Fetch mode (default when no mutation flags are given)                        |
-| `--resolve-thread-ids`   | Comma-separated thread IDs to mark resolved                                  |
-| `--minimize-comment-ids` | Comma-separated comment or review-summary IDs to minimize                    |
-| `--dismiss-review-ids`   | Comma-separated `CHANGES_REQUESTED` review IDs to dismiss                    |
-| `--message`              | Dismiss message (required when `--dismiss-review-ids` is set)                |
-| `--require-sha`          | Poll GitHub until the PR head matches this SHA before mutating               |
+| Flag                     | Description                                                    |
+| ------------------------ | -------------------------------------------------------------- |
+| `--fetch`                | Fetch mode (default when no mutation flags are given)          |
+| `--resolve-thread-ids`   | Comma-separated thread IDs to mark resolved                    |
+| `--minimize-comment-ids` | Comma-separated comment or review-summary IDs to minimize      |
+| `--dismiss-review-ids`   | Comma-separated `CHANGES_REQUESTED` review IDs to dismiss      |
+| `--message`              | Dismiss message (required when `--dismiss-review-ids` is set)  |
+| `--require-sha`          | Poll GitHub until the PR head matches this SHA before mutating |
 
 `--require-sha` polls `GET /repos/{owner}/{repo}/pulls/{pr}` for `headRefOid` until it matches, then issues the mutations — ensures reviewers see the fix before threads are closed. Exit code: always `0`. `--message` must describe the specific fix; it is shown to the reviewer on GitHub.
 
@@ -232,13 +232,13 @@ pr-shepherd iterate 42 --no-cache --ready-delay 15m  # override ready-delay for 
 
 **Flags:**
 
-| Flag                          | Default                            | Description                                                     |
-| ----------------------------- | ---------------------------------- | --------------------------------------------------------------- |
-| `--ready-delay Nm`            | `watch.readyDelayMinutes` in config | Settle window before the loop cancels after READY               |
-| `--cooldown-seconds N`        | `iterate.cooldownSeconds` in config | Wait after a push before reading CI                             |
+| Flag                          | Default                                 | Description                                                     |
+| ----------------------------- | --------------------------------------- | --------------------------------------------------------------- |
+| `--ready-delay Nm`            | `watch.readyDelayMinutes` in config     | Settle window before the loop cancels after READY               |
+| `--cooldown-seconds N`        | `iterate.cooldownSeconds` in config     | Wait after a push before reading CI                             |
 | `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`) |
-| `--no-auto-mark-ready`        | false                              | Skip converting draft → ready-for-review                        |
-| `--no-auto-cancel-actionable` | false   | Skip cancelling actionable failing runs                         |
+| `--no-auto-mark-ready`        | false                                   | Skip converting draft → ready-for-review                        |
+| `--no-auto-cancel-actionable` | false                                   | Skip cancelling actionable failing runs                         |
 
 **Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Example for `[WAIT]`:
 
@@ -314,7 +314,7 @@ npx pr-shepherd monitor 42
 
 **Example output:**
 
-```markdown
+````markdown
 # PR #42 [MONITOR]
 
 Loop tag: `# pr-shepherd-loop:pr=42`
@@ -328,18 +328,19 @@ Loop tag: `# pr-shepherd-loop:pr=42`
 
 ## Loop invocation
 
-\`\`\`loop
+```loop
 4m --max-turns 50 --expires 8h
 
 # pr-shepherd-loop:pr=42
+
 ...
-\`\`\`
+```
 
 ## Instructions
 
 1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the loop prompt in `## Loop prompt` once inline then stop — do not create a duplicate loop.
-2. Otherwise, invoke the `/loop` skill via the Skill tool, passing the entire contents of the \`\`\`loop\`\`\` block above as the `args` parameter.
-```
+2. Otherwise, invoke the `/loop` skill via the Skill tool, passing the entire contents of the `loop` block above as the `args` parameter.
+````
 
 All loop parameters (`interval`, `maxTurns`, `expiresHours`) come from `.pr-shepherdrc.yml` or the built-in defaults (`watch.*` config keys). Use `--format=json` to inspect the raw values programmatically.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,8 @@ The default of 4 minutes is chosen to keep Claude's prompt cache warm — the ca
 - **Raise** if you want a lighter polling footprint.
 - **Lower** if you want faster detection of CI state changes (costs more API budget).
 
+> These `watch.*` keys are the only way to tune the loop interval and ready-delay. The `/pr-shepherd:monitor` skill reads them from config via `npx pr-shepherd monitor` — there are no per-invocation flags.
+
 ### `watch.readyDelayMinutes` — default `10`
 
 After the PR first reaches READY status (all checks green, no open threads), shepherd continues to loop for this many minutes before cancelling the loop. This settle window gives reviewers time to request changes or for a Copilot review to finish.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,18 +6,16 @@ Three Claude Code skills are included in the plugin.
 
 ## `/pr-shepherd:monitor`
 
-Start continuous CI monitoring for a PR. Creates a `/loop` cron job that fires every 4 minutes, calls `pr-shepherd iterate`, and dispatches on the JSON action result. The loop cancels automatically after the PR is merged/closed or after a 10-minute settle window when the PR is clean.
+Start continuous CI monitoring for a PR. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval, max-turns, expires, and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd iterate`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
 
 ```
-/pr-shepherd:monitor                     # infer PR from current branch
+/pr-shepherd:monitor        # infer PR from current branch
 /pr-shepherd:monitor 42
-/pr-shepherd:monitor 42 every 8m
-/pr-shepherd:monitor 42 --ready-delay 15m
 ```
 
-The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-minute TTL).
+The polling interval and ready-delay come from `watch.interval` and `watch.readyDelayMinutes` in `.pr-shepherdrc.yml` (defaults: 4 minutes and 10 minutes). The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-minute TTL).
 
-**Loop deduplication:** Before creating a loop, the skill checks `CronList` for a job tagged `# pr-shepherd-loop:pr=<N>`. If one exists, it runs one iteration inline instead of creating a duplicate.
+**Loop deduplication:** The CLI output's `## Instructions` handles dedup — the skill checks `CronList` for a job tagged `# pr-shepherd-loop:pr=<N>` and runs one iteration inline if one already exists, instead of creating a duplicate.
 
 ## `/pr-shepherd:check`
 

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -10,7 +10,7 @@ The `/pr-shepherd:monitor <PR>` slash command starts a cron loop that polls PR s
 
 1. **User runs `/pr-shepherd:monitor <PR>`**
    - The skill runs `npx pr-shepherd monitor <PR>`, which reads `watch.*` config and emits a bootstrap Markdown block.
-   - The skill follows `## Instructions` in that output: checks for an existing loop (dedup), then invokes the `/loop` skill with the pre-built args+prompt from the ```` ```loop ```` block.
+   - The skill follows `## Instructions` in that output: checks for an existing loop (dedup), then invokes the `/loop` skill with the pre-built args+prompt from the ` ```loop ` block.
 
 2. **`/loop` schedules cron ticks**
    - `/loop` schedules a tick at the interval from config (default `4m`, configurable via `watch.interval`).

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The `/pr-shepherd:monitor <PR>` slash command starts a cron loop that polls PR status every 4 minutes. This document explains how all the pieces fit together.
+The `/pr-shepherd:monitor <PR>` slash command starts a cron loop that polls PR status at the configured interval (default `4m`, set via `watch.interval`). This document explains how all the pieces fit together.
 
 ## Lifecycle
 
@@ -40,9 +40,9 @@ User                    Main Agent              shepherd iterate
  |                          |                        |
  |-- /pr-shepherd:monitor <PR> ------> |                        |
  |                          |-- CronCreate           |
- |                          |   every 4m             |
+ |                          |   every <interval>     |
  |                          |                        |
- |                  [cron tick every 4m]             |
+ |            [cron tick every <interval>]           |
  |                          |-- iterate <PR> ------> |
  |                          |                        |-- GraphQL fetch
  |                          |                        |-- classify

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -9,17 +9,17 @@ The `/pr-shepherd:monitor <PR>` slash command starts a cron loop that polls PR s
 ## Lifecycle
 
 1. **User runs `/pr-shepherd:monitor <PR>`**
-   - The `/pr-shepherd:monitor` skill invokes the `/loop` skill to schedule a cron job that fires every 4 minutes.
-   - Each cron tick runs `shepherd iterate` inline and acts on the text output.
+   - The skill runs `npx pr-shepherd monitor <PR>`, which reads `watch.*` config and emits a bootstrap Markdown block.
+   - The skill follows `## Instructions` in that output: checks for an existing loop (dedup), then invokes the `/loop` skill with the pre-built args+prompt from the ```` ```loop ```` block.
 
 2. **`/loop` schedules cron ticks**
-   - `/loop` schedules a tick every 4 minutes (configurable via `watch.interval`).
+   - `/loop` schedules a tick at the interval from config (default `4m`, configurable via `watch.interval`).
    - The loop runs until the `cancel` action fires or the user cancels manually.
 
 3. **Each tick runs `shepherd iterate`**
    - The cron prompt runs (single Bash invocation):
      ```bash
-     pr-shepherd iterate <PR> --ready-delay <READY_DELAY> --last-push-time "$(git log -1 --format=%ct HEAD)"
+     pr-shepherd iterate <PR> --no-cache
      ```
    - Exit codes 0, 1, 2, and 3 are all valid (not errors).
 
@@ -63,5 +63,4 @@ User                    Main Agent              shepherd iterate
 
 - The cron prompt does not fetch GitHub directly — it consumes only the structured output emitted by `shepherd iterate` (text by default, or JSON with `--format=json`; both carry the same information). The `fix_code` action includes GitHub-derived excerpts (threads, comments, check output), but the full GraphQL response is never read by the loop.
 - Code changes (fix_code, rebase) are handled inline by the cron prompt — no separate agent is spawned.
-- The 4-minute interval is the default and can be overridden with `every <interval>` in the `/shepherd` argument.
-- The ready-delay (default 10 minutes) is passed through as `--ready-delay`. See [ready-delay.md](ready-delay.md).
+- The loop interval (default `4m`) and the ready-delay (default 10 minutes) are read from `watch.interval` and `watch.readyDelayMinutes` in `.pr-shepherdrc.yml`. There is no per-invocation override — change the config file to adjust these values. See [ready-delay.md](ready-delay.md) and [configuration.md](configuration.md).

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
 2. **Run the bootstrap command and follow its instructions:**
 
    ```bash
-   npx pr-shepherd monitor <N>
+   npx pr-shepherd monitor <PR_NUMBER>
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: monitor
 description: "Start continuous CI monitoring — marks PR ready for review when all checks pass"
-argument-hint: "[PR number or URL] [every <interval>] [--ready-delay <duration>]"
+argument-hint: "[PR number or URL]"
 user-invocable: true
 allowed-tools:
   ["Bash", "Read", "Grep", "Edit", "Write", "Glob", "Skill", "CronCreate", "CronList", "CronDelete"]
@@ -11,62 +11,17 @@ allowed-tools:
 
 ## Arguments: $ARGUMENTS
 
-## Resolve PR number
+## Steps
 
-1. Strip any trailing `every <N> <unit>` interval clause from `$ARGUMENTS` first.
-2. Extract `--ready-delay <duration>` if present (e.g. `--ready-delay 15m`). Default: `10m`. Keep the raw duration string (e.g. `10m`) — do **not** convert to seconds.
-3. If the remaining text contains a PR number or GitHub PR URL, extract the number.
-4. Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
-5. If no PR found, report an error and stop.
+1. **Resolve PR number:**
+   - If `$ARGUMENTS` contains a PR number or GitHub PR URL, extract the number.
+   - Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
+   - If no PR found, report an error and stop.
 
-## Start the loop
+2. **Run the bootstrap command and follow its instructions:**
 
-**Before starting:** List existing cron jobs with `CronList`.
+   ```bash
+   npx pr-shepherd monitor <N>
+   ```
 
-- If any job's prompt contains `# pr-shepherd-loop:pr=<PR_NUMBER>`, **do not cancel+recreate** — perform one iteration now by following the logic in the CronCreate prompt below, then return.
-
-**Run the loop:**
-
-Invoke `/loop <INTERVAL> --max-turns 50 --expires 8h` via the Skill tool. Use the interval from the argument if provided (e.g. `every 30 minutes` → `30m`), otherwise use `4m`. The loop prompt should be:
-
-```
-# pr-shepherd-loop:pr=<PR_NUMBER>
-
-**IMPORTANT — recurrence rules:**
-- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.
-- End the turn cleanly after completing the actions below. The cron job handles the next fire.
-
-**Self-dedup:** Run `CronList`. If more than one job contains `# pr-shepherd-loop:pr=<PR_NUMBER>`, keep the lowest job ID and `CronDelete` the rest (ignore errors — a concurrent runner may have already deleted them).
-
-Run in a single Bash call:
-  npx pr-shepherd iterate <PR_NUMBER> --ready-delay <READY_DELAY_DURATION> --no-cache --last-push-time "$(git log -1 --format=%ct HEAD)"
-(`<READY_DELAY_DURATION>` is the raw duration string, e.g. `10m` — never a bare number of seconds)
-
-Exit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #<N> [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.
-
-The output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.
-
-```
-
-**Do NOT call ScheduleWakeup** — the cron job handles its own recurrence. Calling ScheduleWakeup with a `/loop` prompt would create a duplicate cron job on the next fire.
-
-The default 4-minute interval is chosen for two reasons:
-
-1. CI checks typically take 2-3 minutes to complete so concurrent agents won't stack.
-2. 4 minutes keeps iterations within the 5-minute prompt cache TTL.
-
-## Each iteration
-
-The loop prompt above handles each iteration directly — no subagent is spawned. The same iterate command can be run manually at any time:
-
-```bash
-npx pr-shepherd iterate <PR_NUMBER> --ready-delay <READY_DELAY_DURATION> --no-cache --last-push-time "$(git log -1 --format=%ct HEAD)"
-```
-
-To stop monitoring manually, use `/loop cancel` or close the session.
-
-## Handling multiple PRs
-
-To monitor several PRs simultaneously, run `/pr-shepherd:monitor <PR>` once per PR.
-Each call creates its own cron job. Before creating a new loop, run `CronList`
-to verify a loop for that PR doesn't already exist.
+   Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve
 description: "Resolve all inline review comments on the current PR"
-argument-hint: "[PR number or URL] [--thread-id ID | --comment-id ID] [--require-sha SHA]"
+argument-hint: "[PR number or URL]"
 user-invocable: true
 allowed-tools: ["Bash", "Read", "Grep", "Edit", "Write", "Glob", "Skill"]
 ---
@@ -14,10 +14,9 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
 
 ## Steps
 
-1. **Parse `$ARGUMENTS`:**
-   - Extract and remove any `--thread-id ID`, `--comment-id ID`, or `--require-sha SHA` flags.
-   - Look for a PR number or GitHub PR URL in the remaining text.
-   - If not found, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
+1. **Resolve PR number:**
+   - If `$ARGUMENTS` contains a PR number or GitHub PR URL, extract the number.
+   - Otherwise, infer: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --json number --jq '.[0].number'`
    - If no PR found, report an error and stop.
 
 2. **Short-circuit if merged:**

--- a/src/cli-parser.monitor.mock.test.mts
+++ b/src/cli-parser.monitor.mock.test.mts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
+vi.mock("./commands/resolve.mts", () => ({
+  runResolveFetch: vi.fn(),
+  runResolveMutate: vi.fn(),
+}));
+vi.mock("./commands/commit-suggestion.mts", () => ({
+  runCommitSuggestion: vi.fn(),
+}));
+vi.mock("./commands/iterate.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+  return { ...actual, runIterate: vi.fn() };
+});
+vi.mock("./commands/status.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/status.mts")>();
+  return {
+    ...actual,
+    runStatus: vi.fn(),
+    formatStatusTable: vi.fn().mockReturnValue("status table"),
+  };
+});
+vi.mock("./commands/monitor.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/monitor.mts")>();
+  return { ...actual, runMonitor: vi.fn() };
+});
+vi.mock("./github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
+}));
+
+import { main } from "./cli-parser.mts";
+import { runMonitor } from "./commands/monitor.mts";
+import { runStatus } from "./commands/status.mts";
+
+const mockRunMonitor = vi.mocked(runMonitor);
+const mockRunStatus = vi.mocked(runStatus);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stdoutSpy: any;
+let stderrSpy: any;
+
+function getStdout(): string {
+  return stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
+}
+
+const MONITOR_RESULT = {
+  prNumber: 42,
+  loopTag: "# pr-shepherd-loop:pr=42",
+  loopInvocation: "4m --max-turns 50 --expires 8h\n\n# pr-shepherd-loop:pr=42\nBODY",
+  loopPrompt: "# pr-shepherd-loop:pr=42\nBODY",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  mockRunStatus.mockResolvedValue([]);
+  mockRunMonitor.mockResolvedValue(MONITOR_RESULT);
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+describe("main — monitor", () => {
+  it("dispatches to runMonitor and emits formatted output", async () => {
+    await main(["node", "shepherd", "monitor", "42"]);
+    expect(mockRunMonitor).toHaveBeenCalledTimes(1);
+    expect(mockRunMonitor).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 42 }));
+    const out = getStdout();
+    expect(out).toContain("# PR #42 [MONITOR]");
+  });
+
+  it("emits JSON when --format=json", async () => {
+    await main(["node", "shepherd", "monitor", "42", "--format=json"]);
+    const out = getStdout();
+    const parsed = JSON.parse(out.trim()) as typeof MONITOR_RESULT;
+    expect(parsed.prNumber).toBe(42);
+    expect(parsed.loopTag).toBe("# pr-shepherd-loop:pr=42");
+  });
+
+  it("exits 1 and writes to stderr when unknown args are passed", async () => {
+    await main(["node", "shepherd", "monitor", "42", "--ready-delay", "10m"]);
+    expect(process.exitCode).toBe(1);
+    const err = stderrSpy.mock.calls.map((c: string[]) => c[0]).join("");
+    expect(err).toContain("Unknown arguments");
+    expect(mockRunMonitor).not.toHaveBeenCalled();
+  });
+
+  it("exits 1 and writes to stderr when runMonitor throws", async () => {
+    mockRunMonitor.mockRejectedValue(new Error("No open PR found for current branch."));
+    await main(["node", "shepherd", "monitor"]);
+    expect(process.exitCode).toBe(1);
+    const err = stderrSpy.mock.calls.map((c: string[]) => c[0]).join("");
+    expect(err).toContain("No open PR found");
+  });
+});

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -6,13 +6,13 @@
  *   pr-shepherd check [PR] [--format text|json] [--no-cache] [--cache-ttl N]
  *   pr-shepherd resolve [PR] [--fetch] [--resolve-thread-ids A,B] [--minimize-comment-ids X,Y]
  *                            [--dismiss-review-ids Q] [--message MSG] [--require-sha SHA]
- *                            [--last-push-time N]
  *   pr-shepherd commit-suggestion [PR] --thread-id ID [--message MSG] [--description DESC]
  *                                      [--dry-run] [--format text|json]
  *   (--message is required unless --dry-run is set)
- *   pr-shepherd iterate [PR] [--format text|json] [--cooldown-seconds N] [--ready-delay Nm] [--last-push-time N]
+ *   pr-shepherd iterate [PR] [--format text|json] [--cooldown-seconds N] [--ready-delay Nm]
  *                              [--stall-timeout <duration>] [--no-auto-mark-ready]
  *                              [--no-auto-cancel-actionable]
+ *   pr-shepherd monitor [PR] [--format text|json]
  *   pr-shepherd status PR1 [PR2 …]
  */
 
@@ -24,7 +24,7 @@ import { formatJson } from "./reporters/json.mts";
 import { formatText } from "./reporters/text.mts";
 import { parseCommonArgs, getFlag, hasFlag, parseList, statusToExitCode } from "./cli/args.mts";
 import { formatFetchResult, formatMutateResult } from "./cli/formatters.mts";
-import { handleCommitSuggestion, handleIterate, handleStatus } from "./cli/handlers.mts";
+import { handleCommitSuggestion, handleIterate, handleMonitor, handleStatus } from "./cli/handlers.mts";
 
 // ---------------------------------------------------------------------------
 // Entry
@@ -53,13 +53,16 @@ export async function main(argv: string[]): Promise<void> {
     case "iterate":
       await handleIterate(args.slice(1));
       break;
+    case "monitor":
+      await handleMonitor(args.slice(1));
+      break;
     case "status":
       await handleStatus(args.slice(1));
       break;
     default:
       process.stderr.write(`Unknown subcommand: ${subcommand ?? "(none)"}\n`);
       process.stderr.write(
-        "Usage: pr-shepherd <check|resolve|commit-suggestion|iterate|status> [options]\n" +
+        "Usage: pr-shepherd <check|resolve|commit-suggestion|iterate|monitor|status> [options]\n" +
           "       pr-shepherd --version | -v\n",
       );
       process.exitCode = 1;

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -24,7 +24,12 @@ import { formatJson } from "./reporters/json.mts";
 import { formatText } from "./reporters/text.mts";
 import { parseCommonArgs, getFlag, hasFlag, parseList, statusToExitCode } from "./cli/args.mts";
 import { formatFetchResult, formatMutateResult } from "./cli/formatters.mts";
-import { handleCommitSuggestion, handleIterate, handleMonitor, handleStatus } from "./cli/handlers.mts";
+import {
+  handleCommitSuggestion,
+  handleIterate,
+  handleMonitor,
+  handleStatus,
+} from "./cli/handlers.mts";
 
 // ---------------------------------------------------------------------------
 // Entry

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -12,7 +12,6 @@ import type { GlobalOptions } from "../types.mts";
 const FLAGS_WITH_VALUES = new Set([
   "--format",
   "--cache-ttl",
-  "--last-push-time",
   "--ready-delay",
   "--cooldown-seconds",
   "--stall-timeout",

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -24,6 +24,18 @@ const FLAGS_WITH_VALUES = new Set([
   "--dismiss-review-ids",
 ]);
 
+// Boolean flags that do NOT consume the next argument. Any --flag not in this
+// set and not in FLAGS_WITH_VALUES is treated conservatively as value-taking
+// for PR-number detection — so removed flags don't silently cause their
+// numeric value to be misidentified as the PR number.
+const BOOLEAN_FLAGS = new Set([
+  "--no-cache",
+  "--fetch",
+  "--no-auto-mark-ready",
+  "--no-auto-cancel-actionable",
+  "--dry-run",
+]);
+
 // ---------------------------------------------------------------------------
 // Strict integer parsing
 // ---------------------------------------------------------------------------
@@ -85,7 +97,9 @@ export function parseCommonArgs(args: string[]): ParsedArgs {
   }
 
   // Find the first positional arg that looks like a PR number, skipping values
-  // that belong to flags in FLAGS_WITH_VALUES (subcommand flags included).
+  // that belong to value-taking flags. Any --flag not in BOOLEAN_FLAGS is
+  // treated conservatively as value-taking so that removed flags don't cause
+  // their numeric value to be misidentified as the PR number.
   const skipForPrDetect = new Set<number>();
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -93,6 +107,13 @@ export function parseCommonArgs(args: string[]): ParsedArgs {
       skipForPrDetect.add(i);
       if (i + 1 < args.length) skipForPrDetect.add(i + 1);
       i += 1;
+    } else if (arg.startsWith("--") && !arg.includes("=") && !BOOLEAN_FLAGS.has(arg)) {
+      // Unknown non-boolean flag: conservatively skip the next non-flag arg.
+      skipForPrDetect.add(i);
+      if (i + 1 < args.length && !args[i + 1]!.startsWith("--")) {
+        skipForPrDetect.add(i + 1);
+        i += 1;
+      }
     } else {
       const eqIdx = arg.indexOf("=");
       if (eqIdx > 0 && FLAGS_WITH_VALUES.has(arg.slice(0, eqIdx))) {

--- a/src/cli/args.test.mts
+++ b/src/cli/args.test.mts
@@ -141,6 +141,11 @@ describe("parseCommonArgs — PR number detection", () => {
     expect(prNumber).toBeUndefined();
   });
 
+  it("does NOT treat unknown flag values as PR numbers", () => {
+    const { prNumber } = parseCommonArgs(["--last-push-time", "100", "42"]);
+    expect(prNumber).toBe(42);
+  });
+
   it("supports --format=json inline form", () => {
     const { global: g } = parseCommonArgs(["--format=json", "42"]);
     expect(g.format).toBe("json");

--- a/src/cli/args.test.mts
+++ b/src/cli/args.test.mts
@@ -141,11 +141,6 @@ describe("parseCommonArgs — PR number detection", () => {
     expect(prNumber).toBeUndefined();
   });
 
-  it("does NOT treat --last-push-time value as PR number", () => {
-    const { prNumber } = parseCommonArgs(["--last-push-time", "100", "42"]);
-    expect(prNumber).toBe(42);
-  });
-
   it("supports --format=json inline form", () => {
     const { global: g } = parseCommonArgs(["--format=json", "42"]);
     expect(g.format).toBe("json");

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -100,9 +100,22 @@ export async function handleIterate(args: string[]): Promise<void> {
 }
 
 export async function handleMonitor(args: string[]): Promise<void> {
-  const { prNumber, global: globalOpts } = parseCommonArgs(args);
+  const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
 
-  const result = await runMonitor({ ...globalOpts, prNumber });
+  if (extra.length > 0) {
+    process.stderr.write(`Unknown arguments: ${extra.join(" ")}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  let result;
+  try {
+    result = await runMonitor({ ...globalOpts, prNumber });
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
 
   process.stdout.write(
     globalOpts.format === "json"

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -1,5 +1,6 @@
 import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
 import { runIterate } from "../commands/iterate.mts";
+import { runMonitor, formatMonitorResult } from "../commands/monitor.mts";
 import { runStatus, formatStatusTable } from "../commands/status.mts";
 import { getRepoInfo } from "../github/client.mts";
 import { loadConfig } from "../config/load.mts";
@@ -64,10 +65,6 @@ export async function handleCommitSuggestion(args: string[]): Promise<void> {
 export async function handleIterate(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
 
-  const lastPushTimeStr = getFlag(extra, "--last-push-time");
-  const lastPushTime = lastPushTimeStr
-    ? parseIntStrict(lastPushTimeStr, "--last-push-time")
-    : undefined;
   const readyDelayStr = getFlag(extra, "--ready-delay");
   const cfg = loadConfig();
   const readyDelaySeconds =
@@ -86,7 +83,6 @@ export async function handleIterate(args: string[]): Promise<void> {
   const result = await runIterate({
     ...globalOpts,
     prNumber,
-    lastPushTime,
     readyDelaySeconds,
     cooldownSeconds,
     stallTimeoutSeconds,
@@ -101,6 +97,18 @@ export async function handleIterate(args: string[]): Promise<void> {
   }
 
   process.exitCode = iterateActionToExitCode(result.action);
+}
+
+export async function handleMonitor(args: string[]): Promise<void> {
+  const { prNumber, global: globalOpts } = parseCommonArgs(args);
+
+  const result = await runMonitor({ ...globalOpts, prNumber });
+
+  process.stdout.write(
+    globalOpts.format === "json"
+      ? `${JSON.stringify(result, null, 2)}\n`
+      : `${formatMonitorResult(result)}\n`,
+  );
 }
 
 export async function handleStatus(args: string[]): Promise<void> {

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -32,7 +32,6 @@ import type { GlobalOptions, ShepherdReport, ClassifiedCheck, BatchPrData } from
 export interface CheckCommandOptions extends GlobalOptions {
   /** When true, auto-resolve outdated threads. */
   autoResolve?: boolean;
-  lastPushTime?: number;
   /** When true, skip fetching logs for failing checks (no failureKind set). */
   skipTriage?: boolean;
 }
@@ -160,6 +159,5 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
     changesRequestedReviews: batchData.changesRequestedReviews,
     reviewSummaries: batchData.reviewSummaries,
     approvedReviews: batchData.approvedReviews,
-    lastPushTime: opts.lastPushTime,
   };
 }

--- a/src/commands/iterate.base-checks.mock.test.mts
+++ b/src/commands/iterate.base-checks.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.classify.mock.test.mts
+++ b/src/commands/iterate.classify.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.fix-code-actionable.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.fix-code-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.fix-code-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.fix-code-projection.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -110,7 +110,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.orchestrator.mock.test.mts
+++ b/src/commands/iterate.orchestrator.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.render-escalate-fields.mock.test.mts
+++ b/src/commands/iterate.render-escalate-fields.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.render-humanmessage.mock.test.mts
+++ b/src/commands/iterate.render-humanmessage.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.render-resolve-cmd.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.stall.mock.test.mts
+++ b/src/commands/iterate.stall.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/iterate.steps.mock.test.mts
+++ b/src/commands/iterate.steps.mock.test.mts
@@ -112,7 +112,6 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     changesRequestedReviews: [],
     reviewSummaries: [],
     approvedReviews: [],
-    lastPushTime: undefined,
     ...overrides,
   };
 }

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -41,6 +41,15 @@ describe("runMonitor", () => {
     expect(result.prNumber).toBe(42);
   });
 
+  it("throws a clear error when interval is not a valid duration string", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      watch: { interval: "every 4 minutes", maxTurns: 50, expiresHours: 8, readyDelayMinutes: 10 },
+    } as unknown as PrShepherdConfig);
+    await expect(
+      runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 42 }),
+    ).rejects.toThrow("watch.interval must be a duration string");
+  });
+
   it("throws a clear error when expiresHours is not a positive integer", async () => {
     vi.mocked(loadConfig).mockReturnValue({
       watch: { interval: "4m", maxTurns: 50, expiresHours: "8h", readyDelayMinutes: 10 },

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -22,7 +22,12 @@ describe("runMonitor", () => {
   });
 
   it("returns prNumber, loopTag, loopInvocation, loopPrompt for explicit PR", async () => {
-    const result = await runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 99 });
+    const result = await runMonitor({
+      format: "text",
+      noCache: false,
+      cacheTtlSeconds: 300,
+      prNumber: 99,
+    });
     expect(result.prNumber).toBe(99);
     expect(result.loopTag).toBe("# pr-shepherd-loop:pr=99");
     expect(result.loopInvocation).toContain("4m --max-turns 50 --expires 8h");
@@ -40,7 +45,12 @@ describe("runMonitor", () => {
     vi.mocked(loadConfig).mockReturnValue({
       watch: { interval: "8m", maxTurns: 30, expiresHours: 4, readyDelayMinutes: 10 },
     } as unknown as PrShepherdConfig);
-    const result = await runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 42 });
+    const result = await runMonitor({
+      format: "text",
+      noCache: false,
+      cacheTtlSeconds: 300,
+      prNumber: 42,
+    });
     expect(result.loopInvocation).toMatch(/^8m --max-turns 30 --expires 4h/);
   });
 });

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../github/client.mts", () => ({
+  getCurrentPrNumber: vi.fn().mockResolvedValue(42),
+}));
+
+vi.mock("../config/load.mts", () => ({
+  loadConfig: vi.fn(),
+}));
+
+import { runMonitor, formatMonitorResult } from "./monitor.mts";
+import { loadConfig } from "../config/load.mts";
+import type { PrShepherdConfig } from "../config/load.mts";
+
+const defaultConfig = {
+  watch: { interval: "4m", maxTurns: 50, expiresHours: 8, readyDelayMinutes: 10 },
+} as unknown as PrShepherdConfig;
+
+describe("runMonitor", () => {
+  beforeEach(() => {
+    vi.mocked(loadConfig).mockReturnValue(defaultConfig);
+  });
+
+  it("returns prNumber, loopTag, loopInvocation, loopPrompt for explicit PR", async () => {
+    const result = await runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 99 });
+    expect(result.prNumber).toBe(99);
+    expect(result.loopTag).toBe("# pr-shepherd-loop:pr=99");
+    expect(result.loopInvocation).toContain("4m --max-turns 50 --expires 8h");
+    expect(result.loopInvocation).toContain("# pr-shepherd-loop:pr=99");
+    expect(result.loopInvocation).toContain("npx pr-shepherd iterate 99 --no-cache");
+    expect(result.loopPrompt).toContain("pr-shepherd-loop:pr=99");
+  });
+
+  it("infers PR number from branch when none provided", async () => {
+    const result = await runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300 });
+    expect(result.prNumber).toBe(42);
+  });
+
+  it("respects config overrides for interval/maxTurns/expiresHours", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      watch: { interval: "8m", maxTurns: 30, expiresHours: 4, readyDelayMinutes: 10 },
+    } as unknown as PrShepherdConfig);
+    const result = await runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 42 });
+    expect(result.loopInvocation).toMatch(/^8m --max-turns 30 --expires 4h/);
+  });
+});
+
+describe("formatMonitorResult", () => {
+  it("emits MONITOR heading, loop tag, loop fenced block, and instructions", () => {
+    const result = {
+      prNumber: 42,
+      loopTag: "# pr-shepherd-loop:pr=42",
+      loopInvocation: "4m --max-turns 50 --expires 8h\n\n# pr-shepherd-loop:pr=42\nBODY",
+      loopPrompt: "# pr-shepherd-loop:pr=42\nBODY",
+    };
+    const md = formatMonitorResult(result);
+    expect(md).toContain("# PR #42 [MONITOR]");
+    expect(md).toContain("Loop tag: `# pr-shepherd-loop:pr=42`");
+    expect(md).toContain("```loop\n4m --max-turns 50 --expires 8h");
+    expect(md).toContain("## Instructions");
+    expect(md).toContain("## Loop prompt");
+  });
+});

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -41,6 +41,24 @@ describe("runMonitor", () => {
     expect(result.prNumber).toBe(42);
   });
 
+  it("throws a clear error when expiresHours is not a positive integer", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      watch: { interval: "4m", maxTurns: 50, expiresHours: "8h", readyDelayMinutes: 10 },
+    } as unknown as PrShepherdConfig);
+    await expect(
+      runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 42 }),
+    ).rejects.toThrow("watch.expiresHours must be a positive integer");
+  });
+
+  it("throws a clear error when maxTurns is not a positive integer", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      watch: { interval: "4m", maxTurns: 0, expiresHours: 8, readyDelayMinutes: 10 },
+    } as unknown as PrShepherdConfig);
+    await expect(
+      runMonitor({ format: "text", noCache: false, cacheTtlSeconds: 300, prNumber: 42 }),
+    ).rejects.toThrow("watch.maxTurns must be a positive integer");
+  });
+
   it("respects config overrides for interval/maxTurns/expiresHours", async () => {
     vi.mocked(loadConfig).mockReturnValue({
       watch: { interval: "8m", maxTurns: 30, expiresHours: 4, readyDelayMinutes: 10 },

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -2,9 +2,7 @@ import { getCurrentPrNumber } from "../github/client.mts";
 import { loadConfig } from "../config/load.mts";
 import type { GlobalOptions } from "../types.mts";
 
-export interface MonitorCommandOptions extends GlobalOptions {
-  prNumber?: number;
-}
+export interface MonitorCommandOptions extends GlobalOptions {}
 
 export interface MonitorResult {
   prNumber: number;
@@ -23,10 +21,19 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   }
 
   const { interval, maxTurns, expiresHours } = config.watch;
+  if (!Number.isFinite(expiresHours) || expiresHours <= 0 || !Number.isInteger(expiresHours)) {
+    throw new Error(
+      `Invalid config: watch.expiresHours must be a positive integer, got ${JSON.stringify(expiresHours)}`,
+    );
+  }
+  if (!Number.isFinite(maxTurns) || maxTurns <= 0 || !Number.isInteger(maxTurns)) {
+    throw new Error(
+      `Invalid config: watch.maxTurns must be a positive integer, got ${JSON.stringify(maxTurns)}`,
+    );
+  }
   const loopTag = `# pr-shepherd-loop:pr=${prNumber}`;
   const loopPrompt = buildLoopPrompt(prNumber, loopTag);
-  const expiresNum = parseInt(String(expiresHours), 10);
-  const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresNum}h`;
+  const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresHours}h`;
   const loopInvocation = `${loopArgs}\n\n${loopPrompt}`;
 
   return { prNumber, loopTag, loopInvocation, loopPrompt };

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -25,7 +25,8 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   const { interval, maxTurns, expiresHours } = config.watch;
   const loopTag = `# pr-shepherd-loop:pr=${prNumber}`;
   const loopPrompt = buildLoopPrompt(prNumber, loopTag);
-  const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresHours}h`;
+  const expiresNum = parseInt(String(expiresHours), 10);
+  const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresNum}h`;
   const loopInvocation = `${loopArgs}\n\n${loopPrompt}`;
 
   return { prNumber, loopTag, loopInvocation, loopPrompt };

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -21,6 +21,11 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   }
 
   const { interval, maxTurns, expiresHours } = config.watch;
+  if (typeof interval !== "string" || !/^\d+[smhd]$/.test(interval)) {
+    throw new Error(
+      `Invalid config: watch.interval must be a duration string like "4m" or "1h", got ${JSON.stringify(interval)}`,
+    );
+  }
   if (!Number.isFinite(expiresHours) || expiresHours <= 0 || !Number.isInteger(expiresHours)) {
     throw new Error(
       `Invalid config: watch.expiresHours must be a positive integer, got ${JSON.stringify(expiresHours)}`,

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -1,0 +1,86 @@
+import { getCurrentPrNumber } from "../github/client.mts";
+import { loadConfig } from "../config/load.mts";
+import type { GlobalOptions } from "../types.mts";
+
+export interface MonitorCommandOptions extends GlobalOptions {
+  prNumber?: number;
+}
+
+export interface MonitorResult {
+  prNumber: number;
+  loopTag: string;
+  /** The full args string to pass to /loop via Skill: "<interval> --max-turns N --expires Nh\n\n<prompt>" */
+  loopInvocation: string;
+  /** The bare loop prompt body (for inline single-iteration use). */
+  loopPrompt: string;
+}
+
+export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorResult> {
+  const config = loadConfig();
+  const prNumber = opts.prNumber ?? (await getCurrentPrNumber());
+  if (prNumber === null) {
+    throw new Error("No open PR found for current branch. Pass a PR number explicitly.");
+  }
+
+  const { interval, maxTurns, expiresHours } = config.watch;
+  const loopTag = `# pr-shepherd-loop:pr=${prNumber}`;
+  const loopPrompt = buildLoopPrompt(prNumber, loopTag);
+  const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresHours}h`;
+  const loopInvocation = `${loopArgs}\n\n${loopPrompt}`;
+
+  return { prNumber, loopTag, loopInvocation, loopPrompt };
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+export function formatMonitorResult(result: MonitorResult): string {
+  const { prNumber, loopTag, loopInvocation, loopPrompt } = result;
+
+  return [
+    `# PR #${prNumber} [MONITOR]`,
+    "",
+    `Loop tag: \`${loopTag}\``,
+    "",
+    "## Loop prompt",
+    "",
+    loopPrompt,
+    "",
+    "## Loop invocation",
+    "",
+    "```loop",
+    loopInvocation,
+    "```",
+    "",
+    "## Instructions",
+    "",
+    `1. Run \`CronList\`. If any job's prompt contains \`${loopTag}\`, run the loop prompt in \`## Loop prompt\` once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
+    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool, passing the entire contents of the \`\`\`loop\`\`\` block above as the \`args\` parameter (include the interval/flags line and the blank line and the full prompt body).`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+function buildLoopPrompt(prNumber: number, loopTag: string): string {
+  return [
+    loopTag,
+    "",
+    "**IMPORTANT — recurrence rules:**",
+    "- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.",
+    "- End the turn cleanly after completing the actions below. The cron job handles the next fire.",
+    "",
+    `**Self-dedup:** Run \`CronList\`. If more than one job contains \`${loopTag}\`, keep the lowest job ID and \`CronDelete\` the rest (ignore errors — a concurrent runner may have already deleted them).`,
+    "",
+    "Run in a single Bash call:",
+    `  npx pr-shepherd iterate ${prNumber} --no-cache`,
+    "",
+    "Exit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #" +
+      prNumber +
+      " [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.",
+    "",
+    "The output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
+  ].join("\n");
+}

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -169,7 +169,6 @@ export type IterateResult =
 export interface IterateCommandOptions extends GlobalOptions {
   cooldownSeconds?: number;
   readyDelaySeconds?: number;
-  lastPushTime?: number;
   noAutoMarkReady?: boolean;
   noAutoCancelActionable?: boolean;
   /** Override the stall-timeout threshold (seconds). Defaults to config.iterate.stallTimeoutMinutes * 60. */

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -55,7 +55,6 @@ export interface ShepherdReport {
   reviewSummaries: Review[];
   /** APPROVED reviews not yet minimized — opt-in minimize target. */
   approvedReviews: Review[];
-  lastPushTime?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New `pr-shepherd monitor [PR]` CLI subcommand** — reads `watch.{interval,maxTurns,expiresHours}` from config and emits a complete `/loop` bootstrap block (interval + flags + full recurring iterate prompt) plus `## Instructions`. The monitor skill is now a thin 20-line dispatcher (run CLI, print output, follow instructions), matching the resolve skill pattern.
- **Removed dead `--last-push-time` flag** — was parsed but never read by any formatter, reporter, or iterate step; deleted end-to-end including types, tests, and docs.
- **Removed per-invocation overrides from the monitor skill** — `--ready-delay` and `every <interval>` are gone from the skill's argument surface. Loop parameters come from `watch.*` config keys. The `--ready-delay` flag remains on `pr-shepherd iterate` as a manual-run escape hatch.
- **Cleaned up vestigial resolve skill flag parsing** — `--thread-id`, `--comment-id`, `--require-sha` were extracted from `$ARGUMENTS` but never forwarded to the CLI; removed from the argument-hint and step 1.

## Test plan

- [ ] `npm test` — all 617 tests pass
- [ ] `npx pr-shepherd monitor 42` — emits `[MONITOR]` heading, loop tag, `## Loop invocation` block with config values interpolated (no `<PLACEHOLDER>` strings), and numbered `## Instructions`
- [ ] `npx pr-shepherd monitor 42 --format=json` — valid JSON with `prNumber`, `loopTag`, `loopInvocation`, `loopPrompt`
- [ ] `/pr-shepherd:monitor` — thin skill runs CLI bootstrap, follows instructions; CronList dedup still works
- [ ] No `lastPushTime`, `READY_DELAY_DURATION`, or hardcoded `--max-turns 50`/`--expires 8h` in skills after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)