### PR TITLE
refactor: de-duplicate monitor output; rename loopInvocation → loopArgs

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -327,7 +327,7 @@ Loop args: `4m --max-turns 50 --expires 8h`
 ## Instructions
 
 1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
-2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: the `Loop args` line above, a blank line, then the full `## Loop prompt` body.
+2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval/flags string — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
 
 All loop parameters (`interval`, `maxTurns`, `expiresHours`) come from `.pr-shepherdrc.yml` or the built-in defaults (`watch.*` config keys). Use `--format=json` to inspect the raw values programmatically.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -311,7 +311,7 @@ npx pr-shepherd monitor 42
 
 **Example output:**
 
-````markdown
+```markdown
 # PR #42 [MONITOR]
 
 Loop tag: `# pr-shepherd-loop:pr=42`
@@ -328,7 +328,7 @@ Loop args: `4m --max-turns 50 --expires 8h`
 
 1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
 2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: the `Loop args` line above, a blank line, then the full `## Loop prompt` body.
-````
+```
 
 All loop parameters (`interval`, `maxTurns`, `expiresHours`) come from `.pr-shepherdrc.yml` or the built-in defaults (`watch.*` config keys). Use `--format=json` to inspect the raw values programmatically.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -302,7 +302,7 @@ Exit codes: `0` wait/cooldown/rerun_ci/mark_ready · `1` fix_code/rebase · `2` 
 
 ### pr-shepherd monitor [PR]
 
-Bootstrap command for `/pr-shepherd:monitor`. Reads `watch.{interval, maxTurns, expiresHours}` from config and emits a `## Loop invocation` block containing the exact `/loop` args string (interval, flags, and full prompt body). The monitor skill invokes this command and passes the block contents to `/loop` via the Skill tool.
+Bootstrap command for `/pr-shepherd:monitor`. Reads `watch.{interval, maxTurns, expiresHours}` from config and emits the loop prompt body (for inline single-iteration use) and a short `Loop args` line (interval + flags). The monitor skill invokes this command and follows its `## Instructions` to either run one iteration inline (if a loop already exists) or start a new `/loop`.
 
 ```sh
 npx pr-shepherd monitor        # infer PR from current branch
@@ -315,6 +315,7 @@ npx pr-shepherd monitor 42
 # PR #42 [MONITOR]
 
 Loop tag: `# pr-shepherd-loop:pr=42`
+Loop args: `4m --max-turns 50 --expires 8h`
 
 ## Loop prompt
 
@@ -323,20 +324,10 @@ Loop tag: `# pr-shepherd-loop:pr=42`
 **IMPORTANT — recurrence rules:**
 ...
 
-## Loop invocation
-
-```loop
-4m --max-turns 50 --expires 8h
-
-# pr-shepherd-loop:pr=42
-
-...
-```
-
 ## Instructions
 
-1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the loop prompt in `## Loop prompt` once inline then stop — do not create a duplicate loop.
-2. Otherwise, invoke the `/loop` skill via the Skill tool, passing the entire contents of the `loop` block above as the `args` parameter.
+1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
+2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: the `Loop args` line above, a blank line, then the full `## Loop prompt` body.
 ````
 
 All loop parameters (`interval`, `maxTurns`, `expiresHours`) come from `.pr-shepherdrc.yml` or the built-in defaults (`watch.*` config keys). Use `--format=json` to inspect the raw values programmatically.

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -10,7 +10,7 @@ The `/pr-shepherd:monitor <PR>` slash command starts a cron loop that polls PR s
 
 1. **User runs `/pr-shepherd:monitor <PR>`**
    - The skill runs `npx pr-shepherd monitor <PR>`, which reads `watch.*` config and emits a bootstrap Markdown block.
-   - The skill follows `## Instructions` in that output: checks for an existing loop (dedup), then invokes the `/loop` skill with the pre-built args+prompt from the ` ```loop ` block.
+   - The skill follows `## Instructions` in that output: checks for an existing loop (dedup), then invokes the `/loop` skill with `args` built as the interval/flags value from the `Loop args` line concatenated with a blank line and the full `## Loop prompt` body.
 
 2. **`/loop` schedules cron ticks**
    - `/loop` schedules a tick at the interval from config (default `4m`, configurable via `watch.interval`).

--- a/src/cli-parser.monitor.mock.test.mts
+++ b/src/cli-parser.monitor.mock.test.mts
@@ -46,7 +46,7 @@ function getStdout(): string {
 const MONITOR_RESULT = {
   prNumber: 42,
   loopTag: "# pr-shepherd-loop:pr=42",
-  loopInvocation: "4m --max-turns 50 --expires 8h\n\n# pr-shepherd-loop:pr=42\nBODY",
+  loopArgs: "4m --max-turns 50 --expires 8h",
   loopPrompt: "# pr-shepherd-loop:pr=42\nBODY",
 };
 
@@ -80,6 +80,7 @@ describe("main — monitor", () => {
     const parsed = JSON.parse(out.trim()) as typeof MONITOR_RESULT;
     expect(parsed.prNumber).toBe(42);
     expect(parsed.loopTag).toBe("# pr-shepherd-loop:pr=42");
+    expect(parsed.loopArgs).toBe("4m --max-turns 50 --expires 8h");
   });
 
   it("exits 1 and writes to stderr when unknown args are passed", async () => {

--- a/src/commands/__snapshots__/monitor.mock.test.mts.snap
+++ b/src/commands/__snapshots__/monitor.mock.test.mts.snap
@@ -26,5 +26,5 @@ The output is Markdown. The first line is an H1 heading of the form \`# PR #<N> 
 ## Instructions
 
 1. Run \`CronList\`. If any job's prompt contains \`# pr-shepherd-loop:pr=42\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
-2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: the \`Loop args\` line above, a blank line, then the full \`## Loop prompt\` body."
+2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval/flags string — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body."
 `;

--- a/src/commands/__snapshots__/monitor.mock.test.mts.snap
+++ b/src/commands/__snapshots__/monitor.mock.test.mts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`formatMonitorResult > matches snapshot 1`] = `
+"# PR #42 [MONITOR]
+
+Loop tag: \`# pr-shepherd-loop:pr=42\`
+Loop args: \`4m --max-turns 50 --expires 8h\`
+
+## Loop prompt
+
+# pr-shepherd-loop:pr=42
+
+**IMPORTANT — recurrence rules:**
+- **Do NOT call \`ScheduleWakeup\` or \`/loop\`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and \`.git/index.lock\` collisions.
+- End the turn cleanly after completing the actions below. The cron job handles the next fire.
+
+**Self-dedup:** Run \`CronList\`. If more than one job contains \`# pr-shepherd-loop:pr=42\`, keep the lowest job ID and \`CronDelete\` the rest (ignore errors — a concurrent runner may have already deleted them).
+
+Run in a single Bash call:
+  npx pr-shepherd iterate 42
+
+Exit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with \`# PR #42 [\`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.
+
+The output is Markdown. The first line is an H1 heading of the form \`# PR #<N> [<ACTION>]\`. Every output ends with a \`## Instructions\` section — follow those numbered steps exactly.
+
+## Instructions
+
+1. Run \`CronList\`. If any job's prompt contains \`# pr-shepherd-loop:pr=42\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
+2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: the \`Loop args\` line above, a blank line, then the full \`## Loop prompt\` body."
+`;

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -8,7 +8,7 @@ vi.mock("../config/load.mts", () => ({
   loadConfig: vi.fn(),
 }));
 
-import { runMonitor, formatMonitorResult } from "./monitor.mts";
+import { runMonitor, formatMonitorResult, type MonitorResult } from "./monitor.mts";
 import { loadConfig } from "../config/load.mts";
 import type { PrShepherdConfig } from "../config/load.mts";
 
@@ -21,14 +21,21 @@ describe("runMonitor", () => {
     vi.mocked(loadConfig).mockReturnValue(defaultConfig);
   });
 
-  it("returns prNumber, loopTag, loopInvocation, loopPrompt for explicit PR", async () => {
+  it("returns prNumber, loopTag, loopArgs, loopPrompt for explicit PR", async () => {
     const result = await runMonitor({ format: "text", prNumber: 99 });
     expect(result.prNumber).toBe(99);
     expect(result.loopTag).toBe("# pr-shepherd-loop:pr=99");
-    expect(result.loopInvocation).toContain("4m --max-turns 50 --expires 8h");
-    expect(result.loopInvocation).toContain("# pr-shepherd-loop:pr=99");
-    expect(result.loopInvocation).toContain("npx pr-shepherd iterate 99");
-    expect(result.loopPrompt).toContain("pr-shepherd-loop:pr=99");
+    expect(result.loopArgs).toBe("4m --max-turns 50 --expires 8h");
+    expect(result.loopPrompt).toContain("# pr-shepherd-loop:pr=99");
+    expect(result.loopPrompt).toContain("npx pr-shepherd iterate 99");
+    // loopArgs is a short one-liner — not the combined invocation string
+    expect(result.loopArgs).not.toContain("npx pr-shepherd");
+  });
+
+  it("loopPrompt body is not doubled — key phrases appear exactly once", async () => {
+    const result = await runMonitor({ format: "text", prNumber: 42 });
+    expect(result.loopPrompt.split("npx pr-shepherd iterate 42").length - 1).toBe(1);
+    expect(result.loopPrompt.split("Self-dedup:").length - 1).toBe(1);
   });
 
   it("infers PR number from branch when none provided", async () => {
@@ -68,23 +75,51 @@ describe("runMonitor", () => {
       watch: { interval: "8m", maxTurns: 30, expiresHours: 4, readyDelayMinutes: 10 },
     } as unknown as PrShepherdConfig);
     const result = await runMonitor({ format: "text", prNumber: 42 });
-    expect(result.loopInvocation).toMatch(/^8m --max-turns 30 --expires 4h/);
+    expect(result.loopArgs).toMatch(/^8m --max-turns 30 --expires 4h/);
   });
 });
 
 describe("formatMonitorResult", () => {
-  it("emits MONITOR heading, loop tag, loop fenced block, and instructions", () => {
-    const result = {
-      prNumber: 42,
-      loopTag: "# pr-shepherd-loop:pr=42",
-      loopInvocation: "4m --max-turns 50 --expires 8h\n\n# pr-shepherd-loop:pr=42\nBODY",
-      loopPrompt: "# pr-shepherd-loop:pr=42\nBODY",
-    };
-    const md = formatMonitorResult(result);
+  const fixture: MonitorResult = {
+    prNumber: 42,
+    loopTag: "# pr-shepherd-loop:pr=42",
+    loopArgs: "4m --max-turns 50 --expires 8h",
+    loopPrompt:
+      "# pr-shepherd-loop:pr=42\n\n**IMPORTANT — recurrence rules:**\n- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.\n- End the turn cleanly after completing the actions below. The cron job handles the next fire.\n\n**Self-dedup:** Run `CronList`. If more than one job contains `# pr-shepherd-loop:pr=42`, keep the lowest job ID and `CronDelete` the rest (ignore errors — a concurrent runner may have already deleted them).\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42\n\nExit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #42 [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.\n\nThe output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
+  };
+
+  it("emits MONITOR heading, loop tag, loop args, loop prompt, and instructions", () => {
+    const md = formatMonitorResult(fixture);
     expect(md).toContain("# PR #42 [MONITOR]");
     expect(md).toContain("Loop tag: `# pr-shepherd-loop:pr=42`");
-    expect(md).toContain("```loop\n4m --max-turns 50 --expires 8h");
-    expect(md).toContain("## Instructions");
+    expect(md).toContain("Loop args: `4m --max-turns 50 --expires 8h`");
     expect(md).toContain("## Loop prompt");
+    expect(md).toContain("## Instructions");
+  });
+
+  it("does not emit a ```loop fenced block", () => {
+    const md = formatMonitorResult(fixture);
+    expect(md).not.toContain("```loop");
+  });
+
+  it("key prompt phrases appear exactly once — no body duplication", () => {
+    const md = formatMonitorResult(fixture);
+    expect(md.match(/npx pr-shepherd iterate 42/g)?.length).toBe(1);
+    expect(md.match(/Self-dedup:/g)?.length).toBe(1);
+  });
+
+  it("every ## heading is followed by a blank line", () => {
+    const md = formatMonitorResult(fixture);
+    const lines = md.split("\n");
+    lines.forEach((line, i) => {
+      if (line.startsWith("## ")) {
+        expect(lines[i + 1], `blank line after "${line}"`).toBe("");
+      }
+    });
+  });
+
+  it("matches snapshot", () => {
+    const md = formatMonitorResult(fixture);
+    expect(md).toMatchSnapshot();
   });
 });

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -7,9 +7,9 @@ export interface MonitorCommandOptions extends GlobalOptions {}
 export interface MonitorResult {
   prNumber: number;
   loopTag: string;
-  /** The full args string to pass to /loop via Skill: "<interval> --max-turns N --expires Nh\n\n<prompt>" */
-  loopInvocation: string;
-  /** The bare loop prompt body (for inline single-iteration use). */
+  /** The interval/flags line: "<interval> --max-turns N --expires Nh" */
+  loopArgs: string;
+  /** The loop prompt body. To build /loop args: `${loopArgs}\n\n${loopPrompt}` */
   loopPrompt: string;
 }
 
@@ -39,9 +39,8 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   const loopTag = `# pr-shepherd-loop:pr=${prNumber}`;
   const loopPrompt = buildLoopPrompt(prNumber, loopTag);
   const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresHours}h`;
-  const loopInvocation = `${loopArgs}\n\n${loopPrompt}`;
 
-  return { prNumber, loopTag, loopInvocation, loopPrompt };
+  return { prNumber, loopTag, loopArgs, loopPrompt };
 }
 
 // ---------------------------------------------------------------------------
@@ -49,27 +48,22 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
 // ---------------------------------------------------------------------------
 
 export function formatMonitorResult(result: MonitorResult): string {
-  const { prNumber, loopTag, loopInvocation, loopPrompt } = result;
+  const { prNumber, loopTag, loopArgs, loopPrompt } = result;
 
   return [
     `# PR #${prNumber} [MONITOR]`,
     "",
     `Loop tag: \`${loopTag}\``,
+    `Loop args: \`${loopArgs}\``,
     "",
     "## Loop prompt",
     "",
     loopPrompt,
     "",
-    "## Loop invocation",
-    "",
-    "```loop",
-    loopInvocation,
-    "```",
-    "",
     "## Instructions",
     "",
-    `1. Run \`CronList\`. If any job's prompt contains \`${loopTag}\`, run the loop prompt in \`## Loop prompt\` once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
-    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool, passing the entire contents of the \`\`\`loop\`\`\` block above as the \`args\` parameter (include the interval/flags line and the blank line and the full prompt body).`,
+    `1. Run \`CronList\`. If any job's prompt contains \`${loopTag}\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
+    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: the \`Loop args\` line above, a blank line, then the full \`## Loop prompt\` body.`,
   ].join("\n");
 }
 

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -63,7 +63,7 @@ export function formatMonitorResult(result: MonitorResult): string {
     "## Instructions",
     "",
     `1. Run \`CronList\`. If any job's prompt contains \`${loopTag}\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
-    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: the \`Loop args\` line above, a blank line, then the full \`## Loop prompt\` body.`,
+    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval/flags string — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body.`,
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

- The loop-prompt body was printed twice verbatim in `npx pr-shepherd monitor` output — once under `## Loop prompt` and again inside a ```` ```loop ```` fenced block, roughly doubling the output.
- Dropped the `## Loop invocation` fenced block. Now `loopArgs` (just the short interval/flags one-liner) appears in the header; `loopPrompt` (the body) appears once under `## Loop prompt`. Instructions tell the `/loop` consumer to concatenate them.
- Renamed `MonitorResult.loopInvocation` → `loopArgs` to reflect the narrower scope.
- Added snapshot + occurrence-count + heading-spacing tests for `formatMonitorResult` so the invariant is regression-guarded.

## Test plan

- [ ] `npm test` — all 624 tests pass, new snapshot written
- [ ] `node bin/index.mjs monitor 103` — body appears exactly once, `## Instructions` still clear
- [ ] `node bin/index.mjs monitor 103 --format=json | jq keys` — emits `loopArgs`, `loopPrompt`, not `loopInvocation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)