### PR TITLE
feat: surface cancel reason in heading and as structured field

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -171,10 +171,12 @@ Stops the monitor loop — no further iterations needed.
 
 **Exit code:** 2
 
+**`reason` field:** The result carries a structured `reason` discriminator — `"merged"`, `"closed"`, or `"ready-delay-elapsed"` — as a first-class field in both JSON and Markdown output. JSON consumers should branch on `reason` rather than parsing `log`.
+
 **Markdown output:**
 
 ```markdown
-# PR #42 [CANCEL]
+# PR #42 [CANCEL] — merged
 
 **status** `READY` · **merge** `CLEAN` · **state** `MERGED` · **repo** `owner/repo`
 **summary** 5 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 0 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** true
@@ -186,6 +188,8 @@ CANCEL: PR #42 is merged — stopping monitor
 1. Invoke `/loop cancel` via the Skill tool.
 2. Stop.
 ```
+
+Other heading variants: `# PR #42 [CANCEL] — closed`, `# PR #42 [CANCEL] — ready-delay-elapsed`.
 
 Other body-line variants: `CANCEL: PR #42 is closed — stopping monitor`, `CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping monitor`.
 

--- a/src/cli-parser.iterate-fixtures.mts
+++ b/src/cli-parser.iterate-fixtures.mts
@@ -46,7 +46,12 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
     };
   }
   if (action === "cancel")
-    return { ...base, action: "cancel", log: "CANCEL: PR #42 — stopping monitor" };
+    return {
+      ...base,
+      action: "cancel",
+      reason: "ready-delay-elapsed" as const,
+      log: "CANCEL: PR #42 — stopping monitor",
+    };
   if (action === "escalate") {
     return {
       ...base,

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -27,7 +27,7 @@ vi.mock("./github/client.mts", () => ({
 import { main } from "./cli-parser.mts";
 import { runIterate } from "./commands/iterate.mts";
 import { runStatus } from "./commands/status.mts";
-import type { IterateResult } from "./types.mts";
+import type { CancelReason, IterateResult } from "./types.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 
 const mockRunIterate = vi.mocked(runIterate);
@@ -144,11 +144,12 @@ describe("main — iterate text format", () => {
     expect(out).toContain("1. The CLI already marked the PR ready for review");
   });
 
-  it("cancel: heading includes [CANCEL] tag and ## Instructions with loop-cancel steps", async () => {
+  it("cancel: heading includes [CANCEL] tag with reason and ## Instructions with loop-cancel steps", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain("# PR #42 [CANCEL]");
+    expect(out).toContain("— ready-delay-elapsed");
     expect(out).toContain("## Instructions");
     expect(out).toContain("1. Invoke `/loop cancel` via the Skill tool.");
     expect(out).toContain("2. Stop.");
@@ -180,6 +181,25 @@ describe("main — iterate text format", () => {
     const parsed = JSON.parse(out);
     expect(parsed.action).toBe("wait");
     expect(parsed.pr).toBe(42);
+  });
+
+  it("cancel json: emits reason field so consumers can branch without parsing log", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
+    await main(["node", "shepherd", "iterate", "42", "--format", "json"]);
+    const parsed = JSON.parse(getStdout().trimEnd());
+    expect(parsed.action).toBe("cancel");
+    expect(parsed.reason).toBe("ready-delay-elapsed");
+  });
+
+  it("cancel text: each CancelReason value appears in the heading", async () => {
+    const reasons: CancelReason[] = ["merged", "closed", "ready-delay-elapsed"];
+    for (const reason of reasons) {
+      const base = makeIterateResult("cancel") as Extract<IterateResult, { action: "cancel" }>;
+      mockRunIterate.mockResolvedValue({ ...base, reason });
+      await main(["node", "shepherd", "iterate", "42"]);
+      const out = getStdout();
+      expect(out).toContain(`# PR #42 [CANCEL] — ${reason}`);
+    }
   });
 
   // Per CLAUDE.md output-format invariant: text and JSON must surface equivalent

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -66,8 +66,9 @@ export function formatIterateResult(result: IterateResult): string {
     }
 
     case "cancel": {
+      const cancelHeading = `# PR #${result.pr} [CANCEL] — ${result.reason}`;
       const parts = [
-        header,
+        [cancelHeading, "", baseLine, summaryLine].join("\n"),
         result.log,
         "## Instructions",
         "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.",

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -66,9 +66,8 @@ export function formatIterateResult(result: IterateResult): string {
     }
 
     case "cancel": {
-      const cancelHeading = `# PR #${result.pr} [CANCEL] — ${result.reason}`;
       const parts = [
-        [cancelHeading, "", baseLine, summaryLine].join("\n"),
+        [`${heading} — ${result.reason}`, "", baseLine, summaryLine].join("\n"),
         result.log,
         "## Instructions",
         "1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.",

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -231,7 +231,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
     }
   });
 
-  it("cancel.log mentions PR state when PR is merged", async () => {
+  it("cancel.log mentions PR state and reason=merged when PR is merged", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
         mergeStatus: {
@@ -249,12 +249,37 @@ describe("runIterate — prescriptive fields: log strings", () => {
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("cancel");
     if (result.action === "cancel") {
+      expect(result.reason).toBe("merged");
       expect(result.log).toMatch(/CANCEL/);
       expect(result.log).toMatch(/merged/i);
     }
   });
 
-  it("cancel.log mentions ready-delay when shouldCancel from ready-delay", async () => {
+  it("cancel.reason=closed and log mentions closed when PR is closed", async () => {
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        mergeStatus: {
+          status: "UNKNOWN",
+          state: "CLOSED",
+          isDraft: false,
+          mergeable: "UNKNOWN",
+          reviewDecision: null,
+          copilotReviewInProgress: false,
+          mergeStateStatus: "UNKNOWN",
+        },
+      }),
+    );
+
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("cancel");
+    if (result.action === "cancel") {
+      expect(result.reason).toBe("closed");
+      expect(result.log).toMatch(/CANCEL/);
+      expect(result.log).toMatch(/closed/i);
+    }
+  });
+
+  it("cancel.log mentions ready-delay and reason=ready-delay-elapsed when shouldCancel from ready-delay", async () => {
     mockRunCheck.mockResolvedValue(makeReport());
     mockUpdateReadyDelay.mockResolvedValue({
       isReady: true,
@@ -265,6 +290,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("cancel");
     if (result.action === "cancel") {
+      expect(result.reason).toBe("ready-delay-elapsed");
       expect(result.log).toMatch(/CANCEL/);
       expect(result.log).toMatch(/ready/i);
     }

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -57,6 +57,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       baseBranch: report.baseBranch,
       checks: buildRelevantChecks(report),
       action: "cancel",
+      reason: report.mergeStatus.state === "MERGED" ? "merged" : "closed",
       log: `CANCEL: PR #${report.pr} is ${state} — stopping monitor`,
     };
   }
@@ -93,6 +94,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     return {
       ...base,
       action: "cancel",
+      reason: "ready-delay-elapsed",
       log: `CANCEL: PR #${base.pr} has been ready for review — ready-delay elapsed, stopping monitor`,
     };
   }

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -74,8 +74,11 @@ interface IterateResultWait extends IterateResultBase {
   log: string;
 }
 
+export type CancelReason = "merged" | "closed" | "ready-delay-elapsed";
+
 interface IterateResultCancel extends IterateResultBase {
   action: "cancel";
+  reason: CancelReason;
   log: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds `CancelReason = "merged" | "closed" | "ready-delay-elapsed"` to `IterateResultCancel` so callers can branch on reason without parsing `log`
- Heading now reads `# PR #N [CANCEL] — merged` (etc.) so the cause is visible on the first line even when output is collapsed by an agent
- JSON output carries `reason` natively via `JSON.stringify`
- Docs updated: `docs/actions.md` cancel section shows updated heading format and documents the `reason` field

## Test plan

- [ ] All 663 existing tests pass (`npm test`)
- [ ] New test: `cancel.reason=closed` for closed-PR path
- [ ] New assertion: merged path sets `reason: "merged"`, ready-delay path sets `reason: "ready-delay-elapsed"`
- [ ] New test: each `CancelReason` value renders in the Markdown heading
- [ ] New test: JSON format emits `reason` field on cancel
- [ ] `npm run typecheck && npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)