### PR TITLE
fix: treat all BLOCKED+clean PRs as READY — exit via ready-delay, not stall-timeout

### DIFF
--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -47,6 +47,7 @@ GitHub sometimes updates `mergeStateStatus` to `'DRAFT'` before the `isDraft` bo
 `deriveMergeStatus` sets `status: "BLOCKED"` whenever `mergeStateStatus` is `BLOCKED`. However, `computeStatus` in `check.mts` overrides this to `ShepherdStatus: "READY"` when all of the following are true:
 
 - `verdict.allPassed` — no failing or in-progress CI checks.
+- `verdict.hasChecks` — at least one relevant (non-filtered, non-skipped) check has completed. Prevents a PR with zero relevant checks (CI never started, or all checks filtered/skipped) from prematurely triggering READY before any check has reported.
 - No unresolved threads, comments, or changes-requested reviews.
 - `mergeStatus.status === "BLOCKED"` (from `deriveMergeStatus`).
 - `mergeStatus.copilotReviewInProgress === false` — a bot review still pending is shepherd's problem, not a hand-off case.

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -42,19 +42,20 @@ GitHub sometimes updates `mergeStateStatus` to `'DRAFT'` before the `isDraft` bo
 
 `state` (OPEN/MERGED/CLOSED) is passed through directly from `BatchPrData` without any transformation. It is used by `iterate.mts` at step 2.5 to cancel the loop for terminal PRs. The merge status derivation logic itself does not branch on `state` — it always derives a `status` regardless of PR state.
 
-### BLOCKED + REVIEW_REQUIRED → ShepherdStatus READY
+### BLOCKED + no remaining shepherd work → ShepherdStatus READY
 
 `deriveMergeStatus` sets `status: "BLOCKED"` whenever `mergeStateStatus` is `BLOCKED`. However, `computeStatus` in `check.mts` overrides this to `ShepherdStatus: "READY"` when all of the following are true:
 
 - `verdict.allPassed` — no failing or in-progress CI checks.
 - No unresolved threads, comments, or changes-requested reviews.
 - `mergeStatus.status === "BLOCKED"` (from `deriveMergeStatus`).
-- `mergeStatus.copilotReviewInProgress === false` — bot review pending means the blocking reason is not solely a human.
-- `mergeStatus.reviewDecision === "REVIEW_REQUIRED"` — explicitly awaiting human approval.
+- `mergeStatus.copilotReviewInProgress === false` — a bot review still pending is shepherd's problem, not a hand-off case.
+
+The specific reason GitHub is BLOCKED (`reviewDecision === "REVIEW_REQUIRED"`, `"APPROVED"` with insufficient approvals, signed-commit policy, etc.) is not consulted — it is informational only, surfaced in the iterate output for human/agent readers but not used to gate state. Shepherd cannot resolve any of these on its own.
 
 In this case `mergeStatus.status` in the report is still `BLOCKED` (truthful about the GitHub merge state), but the top-level `ShepherdStatus` is `READY`, signalling that shepherd has nothing more to do. The ready-delay timer starts, and `action: cancel` is emitted after it elapses.
 
-Any `BLOCKED` case that does not satisfy all of the above conditions (e.g. Copilot review in progress, unresolved threads, or `reviewDecision` is null) maps to `ShepherdStatus: "PENDING"` rather than `"FAILING"`. The same applies to `UNSTABLE` (non-required checks are red but merge is not fully blocked) and `BEHIND` (head branch is out of date). `FAILING` is reserved for red CI checks (`verdict.anyFailing`) and merge conflicts (`CONFLICTS`).
+A `BLOCKED` case that does not satisfy the above (e.g. Copilot review in progress, unresolved threads, or failing CI) maps to `ShepherdStatus: "PENDING"`. The same applies to `UNSTABLE` (non-required checks are red but merge is not fully blocked) and `BEHIND` (head branch is out of date). `FAILING` is reserved for red CI checks (`verdict.anyFailing`) and merge conflicts (`CONFLICTS`).
 
 ## Copilot detection
 

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -6,7 +6,7 @@
 
 The ready-delay prevents shepherd from cancelling the loop the instant CI goes green. It waits for a configurable window of consecutive READY status before emitting `action: cancel`. This gives reviewers time to post comments before the loop exits.
 
-The timer also starts when the PR is READY solely because a human reviewer hasn't approved yet (`reviewDecision === REVIEW_REQUIRED` with all CI green and no unresolved work). From shepherd's perspective the PR is ready for human review — it has nothing more to do — so the same ready-delay countdown applies and the loop cancels once it elapses.
+The timer also starts when the PR is BLOCKED but shepherd has nothing left to do — all CI is green, no unresolved threads or comments, no Copilot review pending. This covers any branch-protection reason: awaiting a first human review (`REVIEW_REQUIRED`), awaiting additional approvals (`APPROVED` but not enough), required signed commits, or other policy. From shepherd's perspective these are all hand-off states — it cannot resolve them — so the ready-delay countdown applies and the loop cancels once it elapses.
 
 ## The `updateReadyDelay` function
 

--- a/src/checks/classify.mts
+++ b/src/checks/classify.mts
@@ -58,6 +58,8 @@ function classify(check: CheckRun, relevantEvents: Set<string>): ClassifiedCheck
 export interface CiVerdict {
   /** True when all relevant (non-filtered, non-skipped) checks passed. */
   allPassed: boolean;
+  /** True when at least one relevant (non-filtered, non-skipped) check exists. */
+  hasChecks: boolean;
   /** True when at least one check is still running/queued. */
   anyInProgress: boolean;
   /** True when at least one check failed. */
@@ -74,7 +76,8 @@ export function getCiVerdict(classified: ClassifiedCheck[]): CiVerdict {
   // When there are no relevant checks (e.g. docs-only PR where all checks are filtered/skipped),
   // treat as allPassed rather than blocking — there's nothing to fail.
   const allPassed = !anyInProgress && !anyFailing;
+  const hasChecks = relevant.length > 0;
   const filteredNames = classified.filter((c) => c.category === "filtered").map((c) => c.name);
 
-  return { allPassed, anyInProgress, anyFailing, filteredNames };
+  return { allPassed, hasChecks, anyInProgress, anyFailing, filteredNames };
 }

--- a/src/cli-parser.iterate-fixtures.mts
+++ b/src/cli-parser.iterate-fixtures.mts
@@ -7,6 +7,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
     status: "IN_PROGRESS" as const,
     state: "OPEN" as const,
     mergeStateStatus: "BLOCKED" as const,
+    reviewDecision: null as null,
     copilotReviewInProgress: false,
     isDraft: false,
     shouldCancel: false,

--- a/src/cli-parser.iterate-summary.mock.test.mts
+++ b/src/cli-parser.iterate-summary.mock.test.mts
@@ -43,6 +43,7 @@ function makeFixCodeResult(): IterateResult & { action: "fix_code" } {
     status: "IN_PROGRESS" as const,
     state: "OPEN" as const,
     mergeStateStatus: "BLOCKED" as const,
+    reviewDecision: null,
     copilotReviewInProgress: false,
     isDraft: false,
     shouldCancel: false,

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -20,7 +20,11 @@ export function formatIterateResult(result: IterateResult, opts?: { verbose?: bo
   const verbose = opts?.verbose ?? false;
 
   const heading = `# PR #${result.pr} [${result.action.toUpperCase()}]`;
-  const baseLine = `**status** \`${result.status}\` · **merge** \`${result.mergeStateStatus}\` · **state** \`${result.state}\` · **repo** \`${result.repo}\``;
+  const reviewDecisionSeg =
+    result.mergeStateStatus === "BLOCKED" && result.reviewDecision
+      ? ` · **reviewDecision** \`${result.reviewDecision}\``
+      : "";
+  const baseLine = `**status** \`${result.status}\` · **merge** \`${result.mergeStateStatus}\`${reviewDecisionSeg} · **state** \`${result.state}\` · **repo** \`${result.repo}\``;
 
   let summaryLine: string;
   if (verbose) {

--- a/src/cli/iterate-lean.mts
+++ b/src/cli/iterate-lean.mts
@@ -13,6 +13,8 @@ export function projectIterateLean(result: IterateResult): unknown {
     status: result.status,
     state: result.state,
     mergeStateStatus: result.mergeStateStatus,
+    ...(result.mergeStateStatus === "BLOCKED" &&
+      result.reviewDecision !== null && { reviewDecision: result.reviewDecision }),
     ...(result.copilotReviewInProgress && { copilotReviewInProgress: true }),
     ...(result.isDraft && { isDraft: true }),
     summary: {

--- a/src/cli/iterate-lean.test.mts
+++ b/src/cli/iterate-lean.test.mts
@@ -94,6 +94,34 @@ describe("projectIterateLean", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // reviewDecision
+  // ---------------------------------------------------------------------------
+
+  it("omits reviewDecision when mergeStateStatus is not BLOCKED", () => {
+    const result = { ...makeIterateResult("wait"), mergeStateStatus: "CLEAN" as const, reviewDecision: "APPROVED" as const };
+    const lean = projectIterateLean(result) as Record<string, unknown>;
+    expect(lean.reviewDecision).toBeUndefined();
+  });
+
+  it("omits reviewDecision when BLOCKED but null", () => {
+    // fixture already has mergeStateStatus=BLOCKED, reviewDecision=null
+    const lean = projectIterateLean(makeIterateResult("wait")) as Record<string, unknown>;
+    expect(lean.reviewDecision).toBeUndefined();
+  });
+
+  it("includes reviewDecision when BLOCKED and non-null", () => {
+    const result = { ...makeIterateResult("wait"), reviewDecision: "REVIEW_REQUIRED" as const };
+    const lean = projectIterateLean(result) as Record<string, unknown>;
+    expect(lean.reviewDecision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("includes reviewDecision=APPROVED when BLOCKED with insufficient approvals", () => {
+    const result = { ...makeIterateResult("wait"), reviewDecision: "APPROVED" as const };
+    const lean = projectIterateLean(result) as Record<string, unknown>;
+    expect(lean.reviewDecision).toBe("APPROVED");
+  });
+
+  // ---------------------------------------------------------------------------
   // cooldown
   // ---------------------------------------------------------------------------
 

--- a/src/cli/iterate-lean.test.mts
+++ b/src/cli/iterate-lean.test.mts
@@ -98,7 +98,11 @@ describe("projectIterateLean", () => {
   // ---------------------------------------------------------------------------
 
   it("omits reviewDecision when mergeStateStatus is not BLOCKED", () => {
-    const result = { ...makeIterateResult("wait"), mergeStateStatus: "CLEAN" as const, reviewDecision: "APPROVED" as const };
+    const result = {
+      ...makeIterateResult("wait"),
+      mergeStateStatus: "CLEAN" as const,
+      reviewDecision: "APPROVED" as const,
+    };
     const lean = projectIterateLean(result) as Record<string, unknown>;
     expect(lean.reviewDecision).toBeUndefined();
   });

--- a/src/commands/check-status.mts
+++ b/src/commands/check-status.mts
@@ -15,16 +15,16 @@ export function computeStatus(
   // These merge-blocking states become PENDING (not FAILING) once CI is resolved.
   if (verdict.anyFailing) return "FAILING";
   if (verdict.anyInProgress) return "IN_PROGRESS";
-  // BLOCKED solely because a human reviewer hasn't approved yet — shepherd is done, hand off.
-  // copilotReviewInProgress means a bot still owes a review, which is not this case.
+  // BLOCKED with no remaining shepherd work — hand off via ready-delay regardless of why GitHub
+  // is BLOCKED (review pending, insufficient approvals, branch-protection rule, etc.).
+  // copilotReviewInProgress is still excluded — a bot review is shepherd's problem, not a hand-off.
   if (
     verdict.allPassed &&
     unresolvedThreads === 0 &&
     unresolvedComments === 0 &&
     changesRequestedReviews === 0 &&
     mergeStatus.status === "BLOCKED" &&
-    !mergeStatus.copilotReviewInProgress &&
-    mergeStatus.reviewDecision === "REVIEW_REQUIRED"
+    !mergeStatus.copilotReviewInProgress
   ) {
     return "READY";
   }

--- a/src/commands/check-status.mts
+++ b/src/commands/check-status.mts
@@ -17,9 +17,12 @@ export function computeStatus(
   if (verdict.anyInProgress) return "IN_PROGRESS";
   // BLOCKED with no remaining shepherd work — hand off via ready-delay regardless of why GitHub
   // is BLOCKED (review pending, insufficient approvals, branch-protection rule, etc.).
+  // Requires hasChecks so that a PR with zero relevant checks (CI never started, or all
+  // filtered/skipped) doesn't prematurely trigger READY before any check has reported.
   // copilotReviewInProgress is still excluded — a bot review is shepherd's problem, not a hand-off.
   if (
     verdict.allPassed &&
+    verdict.hasChecks &&
     unresolvedThreads === 0 &&
     unresolvedComments === 0 &&
     changesRequestedReviews === 0 &&

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -263,7 +263,11 @@ describe("runCheck — BLOCKED + clean (hand off to humans)", () => {
 
   it("returns PENDING when BLOCKED with zero relevant checks (CI never started)", async () => {
     mockFetchPrBatch.mockResolvedValue({
-      data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED", checks: [] }),
+      data: makeBatchData({
+        mergeStateStatus: "BLOCKED",
+        reviewDecision: "REVIEW_REQUIRED",
+        checks: [],
+      }),
     });
     const report = await runCheck(BASE_OPTS);
     expect(report.status).toBe("PENDING");

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -182,10 +182,10 @@ describe("runCheck — computeStatus precedence", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Human approval pending — BLOCKED + REVIEW_REQUIRED
+// BLOCKED + clean — hand off to humans via ready-delay
 // ---------------------------------------------------------------------------
 
-describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () => {
+describe("runCheck — BLOCKED + clean (hand off to humans)", () => {
   it("returns READY when CI passed and only human approval is missing", async () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED" }),
@@ -245,12 +245,20 @@ describe("runCheck — BLOCKED + REVIEW_REQUIRED (human approval pending)", () =
     expect(report.status).toBe("PENDING");
   });
 
-  it("returns PENDING when BLOCKED but reviewDecision is null (other branch protection)", async () => {
+  it("returns READY when BLOCKED with reviewDecision null (other branch protection — still hand off)", async () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: null }),
     });
     const report = await runCheck(BASE_OPTS);
-    expect(report.status).toBe("PENDING");
+    expect(report.status).toBe("READY");
+  });
+
+  it("returns READY when BLOCKED with reviewDecision APPROVED (insufficient approvals)", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: "APPROVED" }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("READY");
   });
 });
 

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -260,6 +260,14 @@ describe("runCheck — BLOCKED + clean (hand off to humans)", () => {
     const report = await runCheck(BASE_OPTS);
     expect(report.status).toBe("READY");
   });
+
+  it("returns PENDING when BLOCKED with zero relevant checks (CI never started)", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED", checks: [] }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("PENDING");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -423,34 +423,22 @@ describe("runIterate — BLOCKED + clean (hand off to humans via ready-delay)", 
     ["APPROVED (insufficient approvals)", "APPROVED" as const],
     ["null (other branch protection)", null],
   ])(
-    "reviewDecision=%s: returns wait during ready-delay window",
+    "reviewDecision=%s: wait during window then cancel after elapsed",
     async (_label, reviewDecision) => {
       mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
+
       mockUpdateReadyDelay.mockResolvedValue({
         isReady: true,
         shouldCancel: false,
         remainingSeconds: 300,
       });
+      expect((await runIterate(makeOpts())).action).toBe("wait");
 
-      const result = await runIterate(makeOpts());
-      expect(result.action).toBe("wait");
-    },
-  );
-
-  it.each([
-    ["REVIEW_REQUIRED", "REVIEW_REQUIRED" as const],
-    ["APPROVED (insufficient approvals)", "APPROVED" as const],
-    ["null (other branch protection)", null],
-  ])(
-    "reviewDecision=%s: returns cancel when ready-delay has elapsed",
-    async (_label, reviewDecision) => {
-      mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
       mockUpdateReadyDelay.mockResolvedValue({
         isReady: true,
         shouldCancel: true,
         remainingSeconds: 0,
       });
-
       const result = await runIterate(makeOpts());
       expect(result.action).toBe("cancel");
       expect(result.shouldCancel).toBe(true);

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -404,22 +404,28 @@ describe("runIterate — escalate (pr-level-changes-requested with actionable co
 // Human approval pending — cancel after ready-delay elapses
 // ---------------------------------------------------------------------------
 
-describe("runIterate — human approval pending (BLOCKED + REVIEW_REQUIRED)", () => {
-  const blockedApprovalReport = makeReport({
+function makeBlockedReadyReport(reviewDecision: "REVIEW_REQUIRED" | "APPROVED" | null) {
+  return makeReport({
     status: "READY",
     mergeStatus: {
       status: "BLOCKED",
       state: "OPEN" as const,
       isDraft: false,
       mergeable: "MERGEABLE",
-      reviewDecision: "REVIEW_REQUIRED",
+      reviewDecision,
       copilotReviewInProgress: false,
       mergeStateStatus: "BLOCKED",
     },
   });
+}
 
-  it("returns action: wait during the ready-delay window", async () => {
-    mockRunCheck.mockResolvedValue(blockedApprovalReport);
+describe("runIterate — BLOCKED + clean (hand off to humans via ready-delay)", () => {
+  it.each([
+    ["REVIEW_REQUIRED", "REVIEW_REQUIRED" as const],
+    ["APPROVED (insufficient approvals)", "APPROVED" as const],
+    ["null (other branch protection)", null],
+  ])("reviewDecision=%s: returns wait during ready-delay window", async (_label, reviewDecision) => {
+    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
     mockUpdateReadyDelay.mockResolvedValue({
       isReady: true,
       shouldCancel: false,
@@ -430,8 +436,12 @@ describe("runIterate — human approval pending (BLOCKED + REVIEW_REQUIRED)", ()
     expect(result.action).toBe("wait");
   });
 
-  it("returns action: cancel when ready-delay has elapsed", async () => {
-    mockRunCheck.mockResolvedValue(blockedApprovalReport);
+  it.each([
+    ["REVIEW_REQUIRED", "REVIEW_REQUIRED" as const],
+    ["APPROVED (insufficient approvals)", "APPROVED" as const],
+    ["null (other branch protection)", null],
+  ])("reviewDecision=%s: returns cancel when ready-delay has elapsed", async (_label, reviewDecision) => {
+    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
     mockUpdateReadyDelay.mockResolvedValue({
       isReady: true,
       shouldCancel: true,

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -422,34 +422,40 @@ describe("runIterate — BLOCKED + clean (hand off to humans via ready-delay)", 
     ["REVIEW_REQUIRED", "REVIEW_REQUIRED" as const],
     ["APPROVED (insufficient approvals)", "APPROVED" as const],
     ["null (other branch protection)", null],
-  ])("reviewDecision=%s: returns wait during ready-delay window", async (_label, reviewDecision) => {
-    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
-    mockUpdateReadyDelay.mockResolvedValue({
-      isReady: true,
-      shouldCancel: false,
-      remainingSeconds: 300,
-    });
+  ])(
+    "reviewDecision=%s: returns wait during ready-delay window",
+    async (_label, reviewDecision) => {
+      mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
+      mockUpdateReadyDelay.mockResolvedValue({
+        isReady: true,
+        shouldCancel: false,
+        remainingSeconds: 300,
+      });
 
-    const result = await runIterate(makeOpts());
-    expect(result.action).toBe("wait");
-  });
+      const result = await runIterate(makeOpts());
+      expect(result.action).toBe("wait");
+    },
+  );
 
   it.each([
     ["REVIEW_REQUIRED", "REVIEW_REQUIRED" as const],
     ["APPROVED (insufficient approvals)", "APPROVED" as const],
     ["null (other branch protection)", null],
-  ])("reviewDecision=%s: returns cancel when ready-delay has elapsed", async (_label, reviewDecision) => {
-    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
-    mockUpdateReadyDelay.mockResolvedValue({
-      isReady: true,
-      shouldCancel: true,
-      remainingSeconds: 0,
-    });
+  ])(
+    "reviewDecision=%s: returns cancel when ready-delay has elapsed",
+    async (_label, reviewDecision) => {
+      mockRunCheck.mockResolvedValue(makeBlockedReadyReport(reviewDecision));
+      mockUpdateReadyDelay.mockResolvedValue({
+        isReady: true,
+        shouldCancel: true,
+        remainingSeconds: 0,
+      });
 
-    const result = await runIterate(makeOpts());
-    expect(result.action).toBe("cancel");
-    expect(result.shouldCancel).toBe(true);
-  });
+      const result = await runIterate(makeOpts());
+      expect(result.action).toBe("cancel");
+      expect(result.shouldCancel).toBe(true);
+    },
+  );
 });
 
 describe("runIterate — escalate (thread-missing-location)", () => {

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -400,9 +400,7 @@ describe("runIterate — escalate (pr-level-changes-requested with actionable co
   });
 });
 
-// ---------------------------------------------------------------------------
 // Human approval pending — cancel after ready-delay elapses
-// ---------------------------------------------------------------------------
 
 function makeBlockedReadyReport(reviewDecision: "REVIEW_REQUIRED" | "APPROVED" | null) {
   return makeReport({

--- a/src/commands/iterate/helpers.mts
+++ b/src/commands/iterate/helpers.mts
@@ -99,6 +99,7 @@ export function buildCooldownResult(prNumber: number, readyDelaySeconds: number)
     status: "UNKNOWN",
     state: "UNKNOWN" as const,
     mergeStateStatus: "UNKNOWN",
+    reviewDecision: null,
     copilotReviewInProgress: false,
     isDraft: false,
     shouldCancel: false,

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -48,6 +48,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       repo: report.repo,
       status: report.status,
       mergeStateStatus: report.mergeStatus.mergeStateStatus,
+      reviewDecision: report.mergeStatus.reviewDecision,
       copilotReviewInProgress: report.mergeStatus.copilotReviewInProgress,
       isDraft: report.mergeStatus.isDraft,
       shouldCancel: true,
@@ -81,6 +82,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     status: report.status,
     state: report.mergeStatus.state,
     mergeStateStatus: report.mergeStatus.mergeStateStatus,
+    reviewDecision: report.mergeStatus.reviewDecision,
     copilotReviewInProgress: report.mergeStatus.copilotReviewInProgress,
     isDraft: report.mergeStatus.isDraft,
     shouldCancel: readyState.shouldCancel,
@@ -91,11 +93,15 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   };
 
   if (readyState.shouldCancel) {
+    const cancelNote =
+      base.mergeStateStatus === "BLOCKED"
+        ? "is awaiting human review — ready-delay elapsed"
+        : "has been ready for review — ready-delay elapsed";
     return {
       ...base,
       action: "cancel",
       reason: "ready-delay-elapsed",
-      log: `CANCEL: PR #${base.pr} has been ready for review — ready-delay elapsed, stopping monitor`,
+      log: `CANCEL: PR #${base.pr} ${cancelNote}, stopping monitor`,
     };
   }
 

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -93,15 +93,16 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   };
 
   if (readyState.shouldCancel) {
-    const cancelNote =
-      base.mergeStateStatus === "BLOCKED"
-        ? "is awaiting human review — ready-delay elapsed"
-        : "has been ready for review — ready-delay elapsed";
+    let cancelNote: string;
+    if (base.mergeStateStatus !== "BLOCKED") cancelNote = "has been ready for review";
+    else if (base.reviewDecision === "REVIEW_REQUIRED") cancelNote = "is awaiting human review";
+    else if (base.reviewDecision === "APPROVED") cancelNote = "is awaiting additional approvals";
+    else cancelNote = "is awaiting human review or branch protection resolution";
     return {
       ...base,
       action: "cancel",
       reason: "ready-delay-elapsed",
-      log: `CANCEL: PR #${base.pr} ${cancelNote}, stopping monitor`,
+      log: `CANCEL: PR #${base.pr} ${cancelNote} — ready-delay elapsed, stopping monitor`,
     };
   }
 

--- a/src/commands/iterate/render.mts
+++ b/src/commands/iterate/render.mts
@@ -155,7 +155,9 @@ export function buildWaitLog(base: IterateResultBase): string {
       parts.push("branch is behind base");
       break;
     case "BLOCKED":
-      parts.push("blocked by pending reviews or required status checks");
+      if (base.reviewDecision === "REVIEW_REQUIRED") parts.push("awaiting human review");
+      else if (base.reviewDecision === "APPROVED") parts.push("awaiting additional approvals");
+      else parts.push("awaiting human review or branch protection");
       break;
     case "DRAFT":
       parts.push("PR is a draft");

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -36,7 +36,7 @@ export type MergeStateStatus =
   | "UNKNOWN"
   | "UNSTABLE";
 
-type ReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
+export type ReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 
 // ---------------------------------------------------------------------------
 // Check runs

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -8,7 +8,7 @@ import type {
   RelevantCheck,
   ShepherdStatus,
 } from "./report.mts";
-import type { MergeStateStatus, Review } from "./github.mts";
+import type { MergeStateStatus, Review, ReviewDecision } from "./github.mts";
 
 export type ShepherdAction =
   | "cooldown"
@@ -46,6 +46,7 @@ export interface IterateResultBase {
   /** `'UNKNOWN'` during the cooldown early-return (no sweep has been run yet). */
   state: "OPEN" | "CLOSED" | "MERGED" | "UNKNOWN";
   mergeStateStatus: MergeStateStatus;
+  reviewDecision: ReviewDecision;
   copilotReviewInProgress: boolean;
   isDraft: boolean;
   shouldCancel: boolean;


### PR DESCRIPTION
## Summary

- Drops `reviewDecision === "REVIEW_REQUIRED"` gate from `computeStatus` — any BLOCKED PR where CI is green, no unresolved threads/comments/changesRequested, and no Copilot review pending is now `READY` regardless of why GitHub is BLOCKED
- Fixes the case where a PR blocked on a second required approver (reviewDecision=`APPROVED`) or other branch-protection rule would stay `PENDING` until stall-timeout fired and escalated
- Surfaces `reviewDecision` in iterate text/JSON output (only when BLOCKED and non-null) and refines the WAIT/CANCEL log messages to name the block reason
- Updates docs, tests, and the ready-delay doc to reflect the broader rule

## Test plan

- [x] `npm test` — 702/702 passing
- [x] All new cases in `check.mock.test.mts` (BLOCKED+null→READY, BLOCKED+APPROVED→READY)
- [x] `iterate.escalate.mock.test.mts` — expanded to cover all reviewDecision variants via `it.each`
- [x] `iterate-lean.test.mts` — 4 new tests for reviewDecision gating in JSON lean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)