### PR TITLE
fix: surface derived mergeStatus on IterateResultBase, treat HAS_HOOKS like BLOCKED

### DIFF
--- a/src/cli-parser.iterate-fixtures.mts
+++ b/src/cli-parser.iterate-fixtures.mts
@@ -7,6 +7,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
     status: "IN_PROGRESS" as const,
     state: "OPEN" as const,
     mergeStateStatus: "BLOCKED" as const,
+    mergeStatus: "BLOCKED" as const,
     reviewDecision: null as null,
     copilotReviewInProgress: false,
     isDraft: false,

--- a/src/cli-parser.iterate-summary.mock.test.mts
+++ b/src/cli-parser.iterate-summary.mock.test.mts
@@ -43,6 +43,7 @@ function makeFixCodeResult(): IterateResult & { action: "fix_code" } {
     status: "IN_PROGRESS" as const,
     state: "OPEN" as const,
     mergeStateStatus: "BLOCKED" as const,
+    mergeStatus: "BLOCKED" as const,
     reviewDecision: null,
     copilotReviewInProgress: false,
     isDraft: false,

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -323,4 +323,46 @@ describe("main — iterate text format", () => {
     expect(parsed.summary.skipped).toBe(0);
     expect(parsed.summary.filtered).toBe(0);
   });
+
+  // ---------------------------------------------------------------------------
+  // HAS_HOOKS — derived BLOCKED, raw HAS_HOOKS
+  // ---------------------------------------------------------------------------
+
+  it("text: reviewDecision shown in heading when mergeStatus=BLOCKED from HAS_HOOKS raw", async () => {
+    const result = {
+      ...makeIterateResult("wait"),
+      mergeStateStatus: "HAS_HOOKS" as const,
+      mergeStatus: "BLOCKED" as const,
+      reviewDecision: "REVIEW_REQUIRED" as const,
+    };
+    mockRunIterate.mockResolvedValue(result);
+    await main(["node", "shepherd", "iterate", "42", "--verbose"]);
+    const text = getStdout();
+    expect(text).toContain("**reviewDecision** `REVIEW_REQUIRED`");
+  });
+
+  it("text: reviewDecision omitted from heading when mergeStatus=BLOCKED+HAS_HOOKS but null", async () => {
+    const result = {
+      ...makeIterateResult("wait"),
+      mergeStateStatus: "HAS_HOOKS" as const,
+      mergeStatus: "BLOCKED" as const,
+      reviewDecision: null,
+    };
+    mockRunIterate.mockResolvedValue(result);
+    await main(["node", "shepherd", "iterate", "42", "--verbose"]);
+    expect(getStdout()).not.toContain("reviewDecision");
+  });
+
+  it("json lean: reviewDecision included when mergeStatus=BLOCKED from HAS_HOOKS raw", async () => {
+    const result = {
+      ...makeIterateResult("wait"),
+      mergeStateStatus: "HAS_HOOKS" as const,
+      mergeStatus: "BLOCKED" as const,
+      reviewDecision: "REVIEW_REQUIRED" as const,
+    };
+    mockRunIterate.mockResolvedValue(result);
+    await main(["node", "shepherd", "iterate", "42", "--format", "json"]);
+    const parsed = JSON.parse(getStdout().trimEnd());
+    expect(parsed.reviewDecision).toBe("REVIEW_REQUIRED");
+  });
 });

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -21,7 +21,7 @@ export function formatIterateResult(result: IterateResult, opts?: { verbose?: bo
 
   const heading = `# PR #${result.pr} [${result.action.toUpperCase()}]`;
   const reviewDecisionSeg =
-    result.mergeStateStatus === "BLOCKED" && result.reviewDecision
+    result.mergeStatus === "BLOCKED" && result.reviewDecision
       ? ` · **reviewDecision** \`${result.reviewDecision}\``
       : "";
   const baseLine = `**status** \`${result.status}\` · **merge** \`${result.mergeStateStatus}\`${reviewDecisionSeg} · **state** \`${result.state}\` · **repo** \`${result.repo}\``;

--- a/src/cli/iterate-lean.mts
+++ b/src/cli/iterate-lean.mts
@@ -13,7 +13,7 @@ export function projectIterateLean(result: IterateResult): unknown {
     status: result.status,
     state: result.state,
     mergeStateStatus: result.mergeStateStatus,
-    ...(result.mergeStateStatus === "BLOCKED" &&
+    ...(result.mergeStatus === "BLOCKED" &&
       result.reviewDecision !== null && { reviewDecision: result.reviewDecision }),
     ...(result.copilotReviewInProgress && { copilotReviewInProgress: true }),
     ...(result.isDraft && { isDraft: true }),

--- a/src/cli/iterate-lean.test.mts
+++ b/src/cli/iterate-lean.test.mts
@@ -97,10 +97,11 @@ describe("projectIterateLean", () => {
   // reviewDecision
   // ---------------------------------------------------------------------------
 
-  it("omits reviewDecision when mergeStateStatus is not BLOCKED", () => {
+  it("omits reviewDecision when mergeStatus is not BLOCKED", () => {
     const result = {
       ...makeIterateResult("wait"),
       mergeStateStatus: "CLEAN" as const,
+      mergeStatus: "CLEAN" as const,
       reviewDecision: "APPROVED" as const,
     };
     const lean = projectIterateLean(result) as Record<string, unknown>;
@@ -108,12 +109,12 @@ describe("projectIterateLean", () => {
   });
 
   it("omits reviewDecision when BLOCKED but null", () => {
-    // fixture already has mergeStateStatus=BLOCKED, reviewDecision=null
+    // fixture already has mergeStatus=BLOCKED, reviewDecision=null
     const lean = projectIterateLean(makeIterateResult("wait")) as Record<string, unknown>;
     expect(lean.reviewDecision).toBeUndefined();
   });
 
-  it("includes reviewDecision when BLOCKED and non-null", () => {
+  it("includes reviewDecision when BLOCKED (BLOCKED raw) and non-null", () => {
     const result = { ...makeIterateResult("wait"), reviewDecision: "REVIEW_REQUIRED" as const };
     const lean = projectIterateLean(result) as Record<string, unknown>;
     expect(lean.reviewDecision).toBe("REVIEW_REQUIRED");
@@ -123,6 +124,28 @@ describe("projectIterateLean", () => {
     const result = { ...makeIterateResult("wait"), reviewDecision: "APPROVED" as const };
     const lean = projectIterateLean(result) as Record<string, unknown>;
     expect(lean.reviewDecision).toBe("APPROVED");
+  });
+
+  it("includes reviewDecision when mergeStatus=BLOCKED from HAS_HOOKS raw", () => {
+    const result = {
+      ...makeIterateResult("wait"),
+      mergeStateStatus: "HAS_HOOKS" as const,
+      mergeStatus: "BLOCKED" as const,
+      reviewDecision: "REVIEW_REQUIRED" as const,
+    };
+    const lean = projectIterateLean(result) as Record<string, unknown>;
+    expect(lean.reviewDecision).toBe("REVIEW_REQUIRED");
+  });
+
+  it("omits reviewDecision when HAS_HOOKS raw but mergeStatus=BLOCKED and null reviewDecision", () => {
+    const result = {
+      ...makeIterateResult("wait"),
+      mergeStateStatus: "HAS_HOOKS" as const,
+      mergeStatus: "BLOCKED" as const,
+      reviewDecision: null,
+    };
+    const lean = projectIterateLean(result) as Record<string, unknown>;
+    expect(lean.reviewDecision).toBeUndefined();
   });
 
   // ---------------------------------------------------------------------------

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -273,6 +273,16 @@ describe("runCheck — BLOCKED + clean (hand off to humans)", () => {
     const report = await runCheck(BASE_OPTS);
     expect(report.status).toBe("PENDING");
   });
+
+  it("returns READY when HAS_HOOKS (derived BLOCKED) and CI passed", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeStateStatus: "HAS_HOOKS", reviewDecision: "REVIEW_REQUIRED" }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.status).toBe("READY");
+    expect(report.mergeStatus.status).toBe("BLOCKED");
+    expect(report.mergeStatus.mergeStateStatus).toBe("HAS_HOOKS");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -404,10 +404,7 @@ describe("runIterate — escalate (pr-level-changes-requested with actionable co
 
 // Human approval pending — cancel after ready-delay elapses
 
-function makeBlockedReadyReport(
-  reviewDecision: "REVIEW_REQUIRED" | "APPROVED" | null,
-  mergeStateStatus: "BLOCKED" | "HAS_HOOKS" = "BLOCKED",
-) {
+function makeBlockedReadyReport(reviewDecision: "REVIEW_REQUIRED" | "APPROVED" | null) {
   return makeReport({
     status: "READY",
     mergeStatus: {
@@ -417,7 +414,7 @@ function makeBlockedReadyReport(
       mergeable: "MERGEABLE",
       reviewDecision,
       copilotReviewInProgress: false,
-      mergeStateStatus,
+      mergeStateStatus: "BLOCKED",
     },
   });
 }
@@ -449,35 +446,6 @@ describe("runIterate — BLOCKED + clean (hand off to humans via ready-delay)", 
       expect(result.shouldCancel).toBe(true);
     },
   );
-
-  it("HAS_HOOKS raw (derived BLOCKED): cancel-note uses branch-protection wording", async () => {
-    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(null, "HAS_HOOKS"));
-    mockUpdateReadyDelay.mockResolvedValue({
-      isReady: true,
-      shouldCancel: true,
-      remainingSeconds: 0,
-    });
-    const result = await runIterate(makeOpts());
-    expect(result.action).toBe("cancel");
-    if (result.action === "cancel") {
-      expect(result.log).toContain("branch protection");
-      expect(result.log).not.toContain("ready for review");
-    }
-  });
-
-  it("HAS_HOOKS raw (derived BLOCKED): wait log uses branch-protection wording", async () => {
-    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(null, "HAS_HOOKS"));
-    mockUpdateReadyDelay.mockResolvedValue({
-      isReady: true,
-      shouldCancel: false,
-      remainingSeconds: 300,
-    });
-    const result = await runIterate(makeOpts());
-    expect(result.action).toBe("wait");
-    if (result.action === "wait") {
-      expect(result.log).toContain("branch protection");
-    }
-  });
 });
 
 describe("runIterate — escalate (thread-missing-location)", () => {

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -404,7 +404,10 @@ describe("runIterate — escalate (pr-level-changes-requested with actionable co
 
 // Human approval pending — cancel after ready-delay elapses
 
-function makeBlockedReadyReport(reviewDecision: "REVIEW_REQUIRED" | "APPROVED" | null) {
+function makeBlockedReadyReport(
+  reviewDecision: "REVIEW_REQUIRED" | "APPROVED" | null,
+  mergeStateStatus: "BLOCKED" | "HAS_HOOKS" = "BLOCKED",
+) {
   return makeReport({
     status: "READY",
     mergeStatus: {
@@ -414,7 +417,7 @@ function makeBlockedReadyReport(reviewDecision: "REVIEW_REQUIRED" | "APPROVED" |
       mergeable: "MERGEABLE",
       reviewDecision,
       copilotReviewInProgress: false,
-      mergeStateStatus: "BLOCKED",
+      mergeStateStatus,
     },
   });
 }
@@ -446,6 +449,35 @@ describe("runIterate — BLOCKED + clean (hand off to humans via ready-delay)", 
       expect(result.shouldCancel).toBe(true);
     },
   );
+
+  it("HAS_HOOKS raw (derived BLOCKED): cancel-note uses branch-protection wording", async () => {
+    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(null, "HAS_HOOKS"));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: true,
+      remainingSeconds: 0,
+    });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("cancel");
+    if (result.action === "cancel") {
+      expect(result.log).toContain("branch protection");
+      expect(result.log).not.toContain("ready for review");
+    }
+  });
+
+  it("HAS_HOOKS raw (derived BLOCKED): wait log uses branch-protection wording", async () => {
+    mockRunCheck.mockResolvedValue(makeBlockedReadyReport(null, "HAS_HOOKS"));
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: false,
+      remainingSeconds: 300,
+    });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("wait");
+    if (result.action === "wait") {
+      expect(result.log).toContain("branch protection");
+    }
+  });
 });
 
 describe("runIterate — escalate (thread-missing-location)", () => {

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -367,3 +367,45 @@ describe("runIterate — prescriptive fields: log strings", () => {
 });
 
 // renderResolveCommand and buildResolveCommand tests moved to iterate.render-resolve-cmd.mock.test.mts
+
+// ---------------------------------------------------------------------------
+// HAS_HOOKS — derived BLOCKED, raw HAS_HOOKS
+// ---------------------------------------------------------------------------
+
+describe("runIterate — HAS_HOOKS (derived BLOCKED)", () => {
+  function makeHasHooksReport(reviewDecision: "REVIEW_REQUIRED" | null) {
+    return makeReport({
+      status: "READY",
+      mergeStatus: {
+        status: "BLOCKED",
+        state: "OPEN" as const,
+        isDraft: false,
+        mergeable: "MERGEABLE",
+        reviewDecision,
+        copilotReviewInProgress: false,
+        mergeStateStatus: "HAS_HOOKS",
+      },
+    });
+  }
+
+  it("cancel-note uses branch-protection wording when raw is HAS_HOOKS", async () => {
+    mockRunCheck.mockResolvedValue(makeHasHooksReport(null));
+    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: true, remainingSeconds: 0 });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("cancel");
+    if (result.action === "cancel") {
+      expect(result.log).toContain("branch protection");
+      expect(result.log).not.toContain("ready for review");
+    }
+  });
+
+  it("wait log uses branch-protection wording when raw is HAS_HOOKS", async () => {
+    mockRunCheck.mockResolvedValue(makeHasHooksReport(null));
+    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: false, remainingSeconds: 300 });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("wait");
+    if (result.action === "wait") {
+      expect(result.log).toContain("branch protection");
+    }
+  });
+});

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -231,6 +231,37 @@ describe("runIterate — prescriptive fields: log strings", () => {
     }
   });
 
+  it.each([
+    ["BEHIND", "BEHIND" as const, "branch is behind base"],
+    ["DRAFT", "DRAFT" as const, "PR is a draft"],
+    ["UNSTABLE", "UNSTABLE" as const, "some checks are unstable"],
+  ])("wait.log describes mergeStatus=%s", async (_label, mergeStatusVal, expectedPhrase) => {
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        status: "PENDING",
+        mergeStatus: {
+          status: mergeStatusVal,
+          state: "OPEN",
+          isDraft: mergeStatusVal === "DRAFT",
+          mergeable: "MERGEABLE",
+          reviewDecision: null,
+          copilotReviewInProgress: false,
+          mergeStateStatus: mergeStatusVal,
+        },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 0,
+    });
+    const result = await runIterate(makeOpts());
+    expect(result.action).toBe("wait");
+    if (result.action === "wait") {
+      expect(result.log).toContain(expectedPhrase);
+    }
+  });
+
   it("cancel.log mentions PR state and reason=merged when PR is merged", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -390,7 +390,11 @@ describe("runIterate — HAS_HOOKS (derived BLOCKED)", () => {
 
   it("cancel-note uses branch-protection wording when raw is HAS_HOOKS", async () => {
     mockRunCheck.mockResolvedValue(makeHasHooksReport(null));
-    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: true, remainingSeconds: 0 });
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: true,
+      remainingSeconds: 0,
+    });
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("cancel");
     if (result.action === "cancel") {
@@ -401,7 +405,11 @@ describe("runIterate — HAS_HOOKS (derived BLOCKED)", () => {
 
   it("wait log uses branch-protection wording when raw is HAS_HOOKS", async () => {
     mockRunCheck.mockResolvedValue(makeHasHooksReport(null));
-    mockUpdateReadyDelay.mockResolvedValue({ isReady: true, shouldCancel: false, remainingSeconds: 300 });
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: true,
+      shouldCancel: false,
+      remainingSeconds: 300,
+    });
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("wait");
     if (result.action === "wait") {

--- a/src/commands/iterate/helpers.mts
+++ b/src/commands/iterate/helpers.mts
@@ -99,6 +99,7 @@ export function buildCooldownResult(prNumber: number, readyDelaySeconds: number)
     status: "UNKNOWN",
     state: "UNKNOWN" as const,
     mergeStateStatus: "UNKNOWN",
+    mergeStatus: "UNKNOWN",
     reviewDecision: null,
     copilotReviewInProgress: false,
     isDraft: false,

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -48,6 +48,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       repo: report.repo,
       status: report.status,
       mergeStateStatus: report.mergeStatus.mergeStateStatus,
+      mergeStatus: report.mergeStatus.status,
       reviewDecision: report.mergeStatus.reviewDecision,
       copilotReviewInProgress: report.mergeStatus.copilotReviewInProgress,
       isDraft: report.mergeStatus.isDraft,
@@ -82,6 +83,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     status: report.status,
     state: report.mergeStatus.state,
     mergeStateStatus: report.mergeStatus.mergeStateStatus,
+    mergeStatus: report.mergeStatus.status,
     reviewDecision: report.mergeStatus.reviewDecision,
     copilotReviewInProgress: report.mergeStatus.copilotReviewInProgress,
     isDraft: report.mergeStatus.isDraft,
@@ -94,7 +96,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
 
   if (readyState.shouldCancel) {
     let cancelNote: string;
-    if (base.mergeStateStatus !== "BLOCKED") cancelNote = "has been ready for review";
+    if (base.mergeStatus !== "BLOCKED") cancelNote = "has been ready for review";
     else if (base.reviewDecision === "REVIEW_REQUIRED") cancelNote = "is awaiting human review";
     else if (base.reviewDecision === "APPROVED") cancelNote = "is awaiting additional approvals";
     else cancelNote = "is awaiting human review or branch protection resolution";

--- a/src/commands/iterate/render.mts
+++ b/src/commands/iterate/render.mts
@@ -156,21 +156,22 @@ export function buildWaitLog(base: IterateResultBase): string {
   const { summary, mergeStateStatus, remainingSeconds } = base;
   const parts: string[] = [`WAIT: ${summary.passing} passing, ${summary.inProgress} in-progress`];
 
-  switch (mergeStateStatus) {
-    case "BEHIND":
-      parts.push("branch is behind base");
-      break;
-    case "BLOCKED":
-      if (base.reviewDecision === "REVIEW_REQUIRED") parts.push("awaiting human review");
-      else if (base.reviewDecision === "APPROVED") parts.push("awaiting additional approvals");
-      else parts.push("awaiting human review or branch protection");
-      break;
-    case "DRAFT":
-      parts.push("PR is a draft");
-      break;
-    case "UNSTABLE":
-      parts.push("some checks are unstable");
-      break;
+  if (base.mergeStatus === "BLOCKED") {
+    if (base.reviewDecision === "REVIEW_REQUIRED") parts.push("awaiting human review");
+    else if (base.reviewDecision === "APPROVED") parts.push("awaiting additional approvals");
+    else parts.push("awaiting human review or branch protection");
+  } else {
+    switch (mergeStateStatus) {
+      case "BEHIND":
+        parts.push("branch is behind base");
+        break;
+      case "DRAFT":
+        parts.push("PR is a draft");
+        break;
+      case "UNSTABLE":
+        parts.push("some checks are unstable");
+        break;
+    }
   }
 
   if (remainingSeconds > 0) {

--- a/src/commands/iterate/render.mts
+++ b/src/commands/iterate/render.mts
@@ -153,25 +153,24 @@ export function buildFixInstructions(
 }
 
 export function buildWaitLog(base: IterateResultBase): string {
-  const { summary, mergeStateStatus, remainingSeconds } = base;
+  const { summary, remainingSeconds } = base;
   const parts: string[] = [`WAIT: ${summary.passing} passing, ${summary.inProgress} in-progress`];
 
-  if (base.mergeStatus === "BLOCKED") {
-    if (base.reviewDecision === "REVIEW_REQUIRED") parts.push("awaiting human review");
-    else if (base.reviewDecision === "APPROVED") parts.push("awaiting additional approvals");
-    else parts.push("awaiting human review or branch protection");
-  } else {
-    switch (mergeStateStatus) {
-      case "BEHIND":
-        parts.push("branch is behind base");
-        break;
-      case "DRAFT":
-        parts.push("PR is a draft");
-        break;
-      case "UNSTABLE":
-        parts.push("some checks are unstable");
-        break;
-    }
+  switch (base.mergeStatus) {
+    case "BLOCKED":
+      if (base.reviewDecision === "REVIEW_REQUIRED") parts.push("awaiting human review");
+      else if (base.reviewDecision === "APPROVED") parts.push("awaiting additional approvals");
+      else parts.push("awaiting human review or branch protection");
+      break;
+    case "BEHIND":
+      parts.push("branch is behind base");
+      break;
+    case "DRAFT":
+      parts.push("PR is a draft");
+      break;
+    case "UNSTABLE":
+      parts.push("some checks are unstable");
+      break;
   }
 
   if (remainingSeconds > 0) {

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -145,7 +145,7 @@ export function deriveVerdict(s: PrSummary): string {
   ) {
     return "READY";
   }
-  if (s.mergeStateStatus === "BLOCKED") return "BLOCKED";
+  if (s.mergeStateStatus === "BLOCKED" || s.mergeStateStatus === "HAS_HOOKS") return "BLOCKED";
   if (s.mergeStateStatus === "DIRTY") return "CONFLICTS";
   if (s.ciState === "PENDING" || s.ciState === "EXPECTED") return "IN PROGRESS";
   if (s.ciState === "FAILURE" || s.ciState === "ERROR") return "FAILING";

--- a/src/commands/status.test.mts
+++ b/src/commands/status.test.mts
@@ -92,6 +92,7 @@ describe("formatStatusTable — deriveVerdict precedence", () => {
       "READY",
     ],
     ["BLOCKED merge state", { mergeStateStatus: "BLOCKED", ciState: null }, "BLOCKED"],
+    ["HAS_HOOKS (branch protection — same verdict as BLOCKED)", { mergeStateStatus: "HAS_HOOKS", ciState: null }, "BLOCKED"],
     ["DIRTY (CONFLICTS)", { mergeStateStatus: "DIRTY", ciState: null }, "CONFLICTS"],
     ["PENDING ciState", { mergeStateStatus: "UNKNOWN", ciState: "PENDING" }, "IN PROGRESS"],
     ["EXPECTED ciState", { mergeStateStatus: "UNKNOWN", ciState: "EXPECTED" }, "IN PROGRESS"],

--- a/src/commands/status.test.mts
+++ b/src/commands/status.test.mts
@@ -92,7 +92,11 @@ describe("formatStatusTable — deriveVerdict precedence", () => {
       "READY",
     ],
     ["BLOCKED merge state", { mergeStateStatus: "BLOCKED", ciState: null }, "BLOCKED"],
-    ["HAS_HOOKS (branch protection — same verdict as BLOCKED)", { mergeStateStatus: "HAS_HOOKS", ciState: null }, "BLOCKED"],
+    [
+      "HAS_HOOKS (branch protection — same verdict as BLOCKED)",
+      { mergeStateStatus: "HAS_HOOKS", ciState: null },
+      "BLOCKED",
+    ],
     ["DIRTY (CONFLICTS)", { mergeStateStatus: "DIRTY", ciState: null }, "CONFLICTS"],
     ["PENDING ciState", { mergeStateStatus: "UNKNOWN", ciState: "PENDING" }, "IN PROGRESS"],
     ["EXPECTED ciState", { mergeStateStatus: "UNKNOWN", ciState: "EXPECTED" }, "IN PROGRESS"],

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -132,7 +132,7 @@ export interface Review {
 // Merge status
 // ---------------------------------------------------------------------------
 
-type ShepherdMergeStatus =
+export type ShepherdMergeStatus =
   | "CLEAN"
   | "BEHIND"
   | "CONFLICTS"

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -8,7 +8,7 @@ import type {
   RelevantCheck,
   ShepherdStatus,
 } from "./report.mts";
-import type { MergeStateStatus, Review, ReviewDecision } from "./github.mts";
+import type { MergeStateStatus, Review, ReviewDecision, ShepherdMergeStatus } from "./github.mts";
 
 export type ShepherdAction =
   | "cooldown"
@@ -46,6 +46,13 @@ export interface IterateResultBase {
   /** `'UNKNOWN'` during the cooldown early-return (no sweep has been run yet). */
   state: "OPEN" | "CLOSED" | "MERGED" | "UNKNOWN";
   mergeStateStatus: MergeStateStatus;
+  /**
+   * Shepherd-derived merge classification (from deriveMergeStatus). Use this
+   * (not raw mergeStateStatus) when gating on "is this PR merge-blocked?":
+   * it collapses BLOCKED+HAS_HOOKS into "BLOCKED" and accounts for
+   * copilotReviewInProgress and isDraft overrides.
+   */
+  mergeStatus: ShepherdMergeStatus;
   reviewDecision: ReviewDecision;
   copilotReviewInProgress: boolean;
   isDraft: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #114 — addresses all 5 unresolved inline Copilot comments.

**Root cause.** `deriveMergeStatus` collapses both `BLOCKED` and `HAS_HOOKS` raw `mergeStateStatus` values into shepherd `status: "BLOCKED"`, but PR #114's new code keyed off raw `mergeStateStatus === "BLOCKED"` literally. A `HAS_HOOKS`-blocked PR would get:
- Generic "has been ready for review" cancel-note instead of "awaiting human review or branch protection"
- No block-reason description in the wait log
- Missing `reviewDecision` in the text heading and lean JSON output

**Fix.** Add `mergeStatus: ShepherdMergeStatus` to `IterateResultBase`, populated from `report.mergeStatus.status`. All four call sites now key off the derived value. Also fixes `deriveVerdict` in `status.mts` (separate code path) with a one-line OR-check.

**Comment 2** (zero-relevant-checks edge case) was already addressed in the merged PR via `verdict.hasChecks` — no code change needed.

## Changes

- `src/types/github.mts` — export `ShepherdMergeStatus`
- `src/types/iterate.mts` — add `mergeStatus: ShepherdMergeStatus` to `IterateResultBase`
- `src/commands/iterate/index.mts` — populate `mergeStatus`; fix `cancelNote` to key off derived status
- `src/commands/iterate/helpers.mts` — populate `mergeStatus` in `buildCooldownResult`
- `src/commands/iterate/render.mts` — fix `buildWaitLog` BLOCKED branch to key off `base.mergeStatus`
- `src/cli/iterate-formatter.mts` — fix `reviewDecision` heading gate
- `src/cli/iterate-lean.mts` — fix `reviewDecision` lean-projection gate
- `src/commands/status.mts` — fix `deriveVerdict` HAS_HOOKS → "BLOCKED"

## Test plan

- [x] `npm test` — 709/709 passing (up from 702 before new tests)
- [x] New HAS_HOOKS tests in `iterate.escalate.mock.test.mts` (cancel-note, wait-log)
- [x] New HAS_HOOKS tests in `cli-parser.iterate.mock.test.mts` (text heading, lean JSON)
- [x] New HAS_HOOKS tests in `cli/iterate-lean.test.mts` (reviewDecision gate)
- [x] New HAS_HOOKS test in `check.mock.test.mts` (READY end-to-end)
- [x] New HAS_HOOKS test in `status.test.mts` (deriveVerdict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)