### PR TITLE
docs: align docs/ with current CLI

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -33,6 +33,8 @@ Lean-mode rules for the summary line:
 
 `--verbose` restores the full summary line: all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, and `shouldCancel` always present.
 
+**Note on `mergeStatus` in JSON lean mode.** The lean JSON projection (`--format=json`, default) emits `mergeStateStatus` (the raw GitHub value) but **omits the derived `mergeStatus` discriminator** (`CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN`). Scripts that branch on `mergeStatus` must use `--verbose` to get the full `IterateResult`. `mergeStateStatus` is always present in both modes.
+
 Load-bearing conventions (the monitor SKILL depends on these):
 
 1. Line 1 is always an H1 heading of the form `# PR #<N> [<ACTION>]`. The action tag identifies the output for logging and validation — behavior is driven by the `## Instructions` section, not by dispatching on the tag.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,7 @@ shepherd/
 │   ├── handlers.mts       # async handlers wired from cli-parser (iterate, monitor, status, commit-suggestion)
 │   ├── formatters.mts     # barrel for per-output formatters
 │   ├── iterate-formatter.mts  # Markdown formatter for IterateResult
+│   ├── iterate-lean.mts   # lean JSON projection for default --format=json output
 │   └── fix-formatter.mts  # Markdown formatter for fix_code variant
 │
 ├── commands/              # one file (or dir) per subcommand
@@ -61,10 +62,10 @@ shepherd/
 │       ├── minimize-comment.gql
 │       └── dismiss-review.gql
 │
-├── cache/
-│   ├── file-cache.mts     # TTL-aware file cache with atomic writes (tmp + rename)
-│   ├── fix-attempts.mts   # per-thread fix-attempt counter (JSON file in cache dir)
-│   └── iterate-stall.mts  # stall-state persistence
+├── state/
+│   ├── fix-attempts.mts   # per-thread fix-attempt counter (JSON file in state dir)
+│   ├── iterate-stall.mts  # stall-state persistence
+│   └── seen-comments.mts  # seen-marker gate for first-look threads/comments
 │
 ├── checks/
 │   ├── classify.mts       # event filter + CI verdict

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -243,7 +243,7 @@ pr-shepherd iterate 42 --ready-delay 15m  # override ready-delay for this run
 | `--verbose`                   | false                                   | Full JSON output (all fields); restores full summary line in Markdown. See [actions.md](actions.md). |
 | `--ready-delay Nm`            | `watch.readyDelayMinutes` in config     | Settle window before the loop cancels after READY                                                    |
 | `--cooldown-seconds N`        | `iterate.cooldownSeconds` in config     | Wait after a push before reading CI                                                                  |
-| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`)                                     |
+| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`)                                      |
 | `--no-auto-mark-ready`        | false                                   | Skip converting draft → ready-for-review                                                             |
 | `--no-auto-cancel-actionable` | false                                   | Skip cancelling actionable failing runs                                                              |
 
@@ -282,10 +282,12 @@ Example for `[FIX_CODE]` (richest action):
 
 - `24697658766` — `CI / lint / typecheck / test (22.x)`
   > Run tests
-  ```
-  Error: expected 'foo' to equal 'bar'
-    at Object.<anonymous> (src/commands/iterate.test.mts:58:22)
-  ```
+```
+
+Error: expected 'foo' to equal 'bar'
+at Object.<anonymous> (src/commands/iterate.test.mts:58:22)
+
+```
 
 ## Post-fix push
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -7,7 +7,7 @@ pr-shepherd -v|--version
 pr-shepherd check [PR]
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
-pr-shepherd iterate [PR] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
+pr-shepherd iterate [PR] [--verbose] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd monitor [PR]
 pr-shepherd status PR1 [PR2 …]
 ```
@@ -16,9 +16,10 @@ pr-shepherd status PR1 [PR2 …]
 
 All subcommands accept:
 
-| Flag                  | Default | Description   |
-| --------------------- | ------- | ------------- |
-| `--format text\|json` | `text`  | Output format |
+| Flag                  | Default | Description                                                                                       |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `--format text\|json` | `text`  | Output format                                                                                     |
+| `--verbose`           | false   | (`iterate` only) emit full `IterateResult` JSON / show all base/summary fields in Markdown output |
 
 ### pr-shepherd check [PR]
 
@@ -237,21 +238,22 @@ pr-shepherd iterate 42 --ready-delay 15m  # override ready-delay for this run
 
 **Flags:**
 
-| Flag                          | Default                                 | Description                                                     |
-| ----------------------------- | --------------------------------------- | --------------------------------------------------------------- |
-| `--ready-delay Nm`            | `watch.readyDelayMinutes` in config     | Settle window before the loop cancels after READY               |
-| `--cooldown-seconds N`        | `iterate.cooldownSeconds` in config     | Wait after a push before reading CI                             |
-| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`) |
-| `--no-auto-mark-ready`        | false                                   | Skip converting draft → ready-for-review                        |
-| `--no-auto-cancel-actionable` | false                                   | Skip cancelling actionable failing runs                         |
+| Flag                          | Default                                 | Description                                                                                          |
+| ----------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--verbose`                   | false                                   | Full JSON output (all fields); restores full summary line in Markdown. See [actions.md](actions.md). |
+| `--ready-delay Nm`            | `watch.readyDelayMinutes` in config     | Settle window before the loop cancels after READY                                                    |
+| `--cooldown-seconds N`        | `iterate.cooldownSeconds` in config     | Wait after a push before reading CI                                                                  |
+| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`)                                     |
+| `--no-auto-mark-ready`        | false                                   | Skip converting draft → ready-for-review                                                             |
+| `--no-auto-cancel-actionable` | false                                   | Skip cancelling actionable failing runs                                                              |
 
-**Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Example for `[WAIT]`:
+**Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Zero counts (`skipped`, `filtered`, `inProgress`) are omitted in lean mode; `copilotReviewInProgress` and `isDraft` are only shown when `true`; `shouldCancel` is never shown. Example for `[WAIT]`:
 
 ```markdown
 # PR #42 [WAIT]
 
 **status** `READY` · **merge** `CLEAN` · **state** `OPEN` · **repo** `owner/repo`
-**summary** 3 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 540 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
+**summary** 3 passing · **remainingSeconds** 540
 
 WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
 
@@ -266,13 +268,7 @@ Example for `[FIX_CODE]` (richest action):
 # PR #42 [FIX_CODE]
 
 **status** `UNRESOLVED_COMMENTS` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
-**summary** 3 passing, 0 skipped, 0 filtered, 0 inProgress · **remainingSeconds** 600 · **copilotReviewInProgress** false · **isDraft** false · **shouldCancel** false
-
-## Checks
-
-- ✓ `build` — SUCCESS
-- ✗ `lint / typecheck / test (22.x)` (actionable) — FAILURE · `24697658766`
-  > Error: expected 'foo' to equal 'bar'
+**summary** 3 passing
 
 ## Review threads
 
@@ -284,7 +280,12 @@ Example for `[FIX_CODE]` (richest action):
 
 ## Failing checks
 
-- `24697658766` — `lint / typecheck / test (22.x)` (actionable)
+- `24697658766` — `CI / lint / typecheck / test (22.x)`
+  > Run tests
+  ```
+  Error: expected 'foo' to equal 'bar'
+    at Object.<anonymous> (src/commands/iterate.test.mts:58:22)
+  ```
 
 ## Post-fix push
 
@@ -294,19 +295,20 @@ Example for `[FIX_CODE]` (richest action):
 ## Instructions
 
 1. Apply code fixes: read and edit each file referenced under `## Review threads` and `## Actionable comments` above.
-2. For each bullet in `## Failing checks` whose backticked locator is a numeric runId (GitHub Actions): run `gh run view <runId> --log-failed`, identify the failure, and apply the fix.
+2. For each bullet in `## Failing checks`: examine the log tail shown — if the failure looks transient (network error, flaky test), run `gh run rerun <runId> --failed`; otherwise apply a code fix.
 3. Commit changed files: `git add <files> && git commit -m "<descriptive message>"`
 4. Keep the PR title and description current: if the changes alter the PR's scope or intent, run `gh pr edit 42 --title "<new title>" --body "<new body>"` to reflect them. Skip if the existing title/body still accurately describe the PR.
 5. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`
 6. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
-7. Stop this iteration — CI needs time to run on the new push before the next tick.
+7. Add a `## Shepherd Journal` entry to the PR description for any large decisions made: `gh pr edit 42 --body "$(gh pr view 42 --json body -q .body)\n\n## Shepherd Journal\n- <decision>"`
+8. Stop this iteration — CI needs time to run on the new push before the next tick.
 ```
 
-See [actions.md](actions.md) for all eight actions and their complete output shapes.
+See [actions.md](actions.md) for all six actions and their complete output shapes.
 
 Both `--format=text` (default Markdown) and `--format=json` carry equivalent information — every field exposed in JSON has a corresponding Markdown representation, and vice versa.
 
-Exit codes: `0` wait/cooldown/mark_ready · `1` fix_code/rebase · `2` cancel · `3` escalate
+Exit codes: `0` wait/cooldown/mark_ready · `1` fix_code · `2` cancel · `3` escalate
 
 ### pr-shepherd monitor [PR]
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -280,7 +280,7 @@ Example for `[FIX_CODE]` (richest action):
 
 ## Failing checks
 
-- `24697658766` — `CI / lint / typecheck / test (22.x)`
+- `24697658766` — `CI › lint / typecheck / test (22.x)`
   > Run tests
 ```
 
@@ -297,12 +297,12 @@ at Object.<anonymous> (src/commands/iterate.test.mts:58:22)
 ## Instructions
 
 1. Apply code fixes: read and edit each file referenced under `## Review threads` and `## Actionable comments` above.
-2. For each bullet in `## Failing checks`: examine the log tail shown — if the failure looks transient (network error, flaky test), run `gh run rerun <runId> --failed`; otherwise apply a code fix.
+2. For each bullet in `## Failing checks`: the backticked locator at the start of each line is the runId. If a log tail is shown, examine it — if the failure looks transient (network error, flaky test), run `gh run rerun <runId> --failed`; otherwise apply a code fix. If no log tail appears, run `gh run view <runId> --log-failed` to diagnose first.
 3. Commit changed files: `git add <files> && git commit -m "<descriptive message>"`
 4. Keep the PR title and description current: if the changes alter the PR's scope or intent, run `gh pr edit 42 --title "<new title>" --body "<new body>"` to reflect them. Skip if the existing title/body still accurately describe the PR.
 5. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`
 6. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
-7. Add a `## Shepherd Journal` entry to the PR description for any large decisions made: `gh pr edit 42 --body "$(gh pr view 42 --json body -q .body)\n\n## Shepherd Journal\n- <decision>"`
+7. For any large decisions made, add or update a `## Shepherd Journal` section in the PR description: `gh pr edit 42 --body …`
 8. Stop this iteration — CI needs time to run on the new push before the next tick.
 ```
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -66,7 +66,7 @@ rm $TMPDIR/pr-shepherd-state/acme-myrepo/42/ready-since.txt
 
 **Fix options:**
 
-1. Increase the cron interval: `--interval 8m`
+1. Increase `watch.interval` in `.pr-shepherdrc.yml` (e.g. `8m`). The next monitor run will pick it up.
 2. Check `x-ratelimit-remaining` in the reporter JSON output to monitor consumption
 
 ---

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -66,7 +66,7 @@ rm $TMPDIR/pr-shepherd-state/acme-myrepo/42/ready-since.txt
 
 **Fix options:**
 
-1. Increase `watch.interval` in `.pr-shepherdrc.yml` (e.g. `8m`). The next monitor run will pick it up.
+1. Increase `watch.interval` in `.pr-shepherdrc.yml` (e.g. `8m`). Then cancel and recreate the monitor loop (re-run `/pr-shepherd:monitor`) — the interval is baked into the cron job at creation time and won't change automatically.
 2. Check `x-ratelimit-remaining` in the reporter JSON output to monitor consumption
 
 ---

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -8,13 +8,13 @@ Four recipes for common extension patterns.
 
 ## Recipe 1: Add a new action
 
-1. **Add the type** — in `types.mts`, add to the `ShepherdAction` union:
+1. **Add the type** — in `types/iterate.mts`, add to the `ShepherdAction` union:
 
    ```ts
    export type ShepherdAction = 'cooldown' | 'wait' | ... | 'my_action'
    ```
 
-2. **Add the result interface** — in `types.mts`, add:
+2. **Add the result interface** — in `types/iterate.mts`, add:
 
    ```ts
    export interface IterateResultMyAction extends IterateResultBase {
@@ -27,11 +27,7 @@ Four recipes for common extension patterns.
 
 3. **Add the dispatch step** — in `commands/iterate.mts`, insert a new numbered step in the decision chain. Return the new result shape.
 
-4. **Add the cron prompt handler** — in `skills/monitor/SKILL.md`, add a new bullet inside the CronCreate prompt for the new `action` value:
-
-   ```
-   - `my_action` → log: `MY_ACTION: <relevant info>`
-   ```
+4. **Add the formatter** — in `cli/iterate-formatter.mts`, add a `case "my_action":` branch that emits the action-specific body and a numbered `## Instructions` section. The monitor skill follows those steps verbatim — no changes to `skills/monitor/SKILL.md` are required.
 
 5. **Add tests** — in `commands/iterate.mock.test.mts`, add a `describe('runIterate — my_action')` block.
 
@@ -69,7 +65,7 @@ Four recipes for common extension patterns.
 
 3. **Add the function** — in `comments/resolve.mts`, add a new exported function that calls the mutation via `graphqlWithRateLimit`.
 
-4. **Add to `ResolveOptions`** — if the mutation is triggered by `resolve` command options, add the relevant field to `ResolveOptions` in `types.mts`.
+4. **Add to `ResolveOptions`** — if the mutation is triggered by `resolve` command options, add the relevant field to `ResolveOptions` in `types/report.mts`.
 
 5. **Add tests** — in `comments/resolve.mock.test.mts`, add test cases.
 


### PR DESCRIPTION
## Summary

- **`docs/cli-usage.md`**: add `--verbose` to global and iterate flag tables; fix lean-mode summary line examples (drop zero counts / false flags); replace fabricated `## Checks` section with accurate `## Failing checks` + `logTail` example; update failing-check instruction to log-tail + rerun/fix approach; add Shepherd Journal step; fix exit-codes line (drop `rebase`); fix "all eight actions" → "all six".
- **`docs/actions.md`**: add note clarifying that lean JSON projection omits derived `mergeStatus` while emitting `mergeStateStatus`.
- **`docs/architecture.md`**: rename `cache/` block → `state/` (matches actual filesystem); add `cli/iterate-lean.mts`; add `state/seen-comments.mts`.
- **`docs/debugging.md`**: replace non-existent `--interval 8m` flag with correct config-file approach.
- **`docs/extending.md`**: rewrite Recipe 1 step 4 (no per-action bullet in monitor SKILL needed — `## Instructions` block drives behavior); fix type-file paths (`types/iterate.mts`, `types/report.mts`).

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] All removed claims verified absent via `grep`
- [x] `docs/actions.md` (canonical reference) cross-checked as still current

🤖 Generated with [Claude Code](https://claude.com/claude-code)