### PR TITLE
feat: append-only per-worktree markdown log

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,7 +15,7 @@
     {
       "files": ["src/github/http.mts"],
       "rules": {
-        "max-lines": ["error", 250]
+        "max-lines": ["error", 400]
       }
     }
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,7 +15,7 @@
     {
       "files": ["src/github/http.mts"],
       "rules": {
-        "max-lines": ["error", 400]
+        "max-lines": ["error", 450]
       }
     }
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,12 @@
       "rules": {
         "max-lines": ["error", 500]
       }
+    },
+    {
+      "files": ["src/github/http.mts"],
+      "rules": {
+        "max-lines": ["error", 250]
+      }
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,14 @@ written after first display. Markers live at:
 $PR_SHEPHERD_STATE_DIR/<owner>-<repo>/<pr>/seen/<id>.json
 ```
 
+The per-worktree debug log lives as a peer at:
+
+```
+$PR_SHEPHERD_STATE_DIR/<owner>-<repo>/worktrees/<basename>-<sha8>.md
+```
+
+Print the path with `npx pr-shepherd log-file`. Disable with `PR_SHEPHERD_LOG_DISABLED=1`.
+
 One file per id — file existence is the marker. The marker is written with
 `O_EXCL` (exclusive create), so double-writes preserve the original `seenAt`
 timestamp and are safe under concurrent invocations. The JSON payload is

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ actions:
   autoMarkReady: false # disable to stay draft until you manually promote
 ```
 
-Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_STATE_DIR` (override loop-state base dir).
+Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_STATE_DIR` (override loop-state and log base dir), `PR_SHEPHERD_LOG_DISABLED=1` (disable the per-worktree debug log).
 
 See [docs/configuration.md](docs/configuration.md) for full semantics and deprecated-key migration.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -10,6 +10,7 @@ pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
 pr-shepherd iterate [PR] [--verbose] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd monitor [PR]
 pr-shepherd status PR1 [PR2 …]
+pr-shepherd log-file
 ```
 
 ## Common flags
@@ -364,3 +365,32 @@ PR #43    Fix edge case in parser                           BLOCKED      SUCCESS
 ```
 
 Exit code: `0` if every PR is READY, `1` otherwise.
+
+### pr-shepherd log-file
+
+Prints the path of the per-worktree append-only debug log for the current repository. The file is created on the first invocation of any other subcommand.
+
+```sh
+pr-shepherd log-file             # prints path
+pr-shepherd log-file --format=json  # {"path":"…"}
+```
+
+```
+/var/folders/…/pr-shepherd-state/owner-repo/worktrees/my-branch-3f4a9b21.md
+```
+
+The log captures, for each CLI invocation:
+
+- A session header (ISO-8601 timestamp · pid · version · full argv)
+- Every GraphQL request and response (query, variables, response body)
+- Every REST JSON request and response (method, path, body, status)
+- Every `restText` request/response — metadata only (status · content-length), body never logged
+- Full stdout output (text or JSON) emitted by the subcommand
+
+All entries carry an ISO-8601 millisecond timestamp. HTTP response entries also show elapsed milliseconds. Auth headers are never written to the log.
+
+**Disable logging:** set `PR_SHEPHERD_LOG_DISABLED=1`. Logging is also automatically disabled when `CI=true` or when the first write fails.
+
+**Override base directory:** set `PR_SHEPHERD_STATE_DIR` (same env var as the loop-state directory). The log lives at `$PR_SHEPHERD_STATE_DIR/<owner>-<repo>/worktrees/<basename>-<sha8>.md`.
+
+Exit code: `0` on success · `1` if not in a git repo or repo identity cannot be resolved.

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -20,6 +20,7 @@ import { readFileSync } from "node:fs";
 
 import { runCheck } from "./commands/check.mts";
 import { runResolveFetch, runResolveMutate } from "./commands/resolve.mts";
+import { runLogFile } from "./commands/log-file.mts";
 import { formatJson } from "./reporters/json.mts";
 import { formatText } from "./reporters/text.mts";
 import { parseCommonArgs, getFlag, hasFlag, parseList } from "./cli/args.mts";
@@ -31,6 +32,9 @@ import {
   handleMonitor,
   handleStatus,
 } from "./cli/handlers.mts";
+import { initLog, appendEntry } from "./log/log-file.mts";
+import { buildSessionHeader, formatOutputEntry } from "./log/session.mts";
+import { getRepoInfo } from "./github/client.mts";
 
 // ---------------------------------------------------------------------------
 // Entry
@@ -45,6 +49,15 @@ export async function main(argv: string[]): Promise<void> {
     process.stdout.write(`${readVersion()}\n`);
     return;
   }
+
+  // log-file must run before the stdout tee and log init to avoid recursion.
+  if (subcommand === "log-file") {
+    await handleLogFile(args.slice(1));
+    return;
+  }
+
+  // Initialize the per-worktree log and install a stdout tee.
+  await setupLog(argv);
 
   switch (subcommand) {
     case "check":
@@ -68,12 +81,54 @@ export async function main(argv: string[]): Promise<void> {
     default:
       process.stderr.write(`Unknown subcommand: ${subcommand ?? "(none)"}\n`);
       process.stderr.write(
-        "Usage: pr-shepherd <check|resolve|commit-suggestion|iterate|monitor|status> [options]\n" +
+        "Usage: pr-shepherd <check|resolve|commit-suggestion|iterate|monitor|status|log-file> [options]\n" +
           "       pr-shepherd --version | -v\n",
       );
       process.exitCode = 1;
       return;
   }
+}
+
+let _logSetupDone = false;
+
+async function setupLog(argv: string[]): Promise<void> {
+  if (_logSetupDone) return;
+  _logSetupDone = true;
+
+  try {
+    const { owner, name } = await getRepoInfo();
+    await initLog({ owner, repo: name });
+  } catch {
+    // Not in a git repo or repo info unavailable — log is silently disabled.
+    return;
+  }
+
+  const { markdown: header } = buildSessionHeader(argv);
+  appendEntry(header);
+
+  // Tee stdout to the log. Captures JSON and markdown output from all subcommands.
+  let outputBuffer = "";
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (
+    chunk: string | Uint8Array,
+    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void,
+  ): boolean => {
+    const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    outputBuffer += text;
+    const result =
+      typeof encodingOrCb === "function"
+        ? origWrite(chunk, encodingOrCb)
+        : origWrite(chunk, encodingOrCb as BufferEncoding, cb);
+    return result;
+  };
+
+  // Flush buffered output to the log on process exit.
+  process.once("exit", () => {
+    if (outputBuffer.length > 0) {
+      appendEntry(formatOutputEntry(outputBuffer, "text"));
+    }
+  });
 }
 
 function readVersion(): string {
@@ -94,6 +149,23 @@ async function handleCheck(args: string[]): Promise<void> {
   process.stdout.write(`${output}\n`);
 
   process.exitCode = statusToExitCode(report.status);
+}
+
+async function handleLogFile(args: string[]): Promise<void> {
+  const jsonOut =
+    args.some((a) => a === "--format=json") ||
+    (() => {
+      const idx = args.indexOf("--format");
+      return idx !== -1 && args[idx + 1] === "json";
+    })();
+
+  try {
+    const result = await runLogFile();
+    process.stdout.write(jsonOut ? `${JSON.stringify(result, null, 2)}\n` : `${result.path}\n`);
+  } catch (e) {
+    process.stderr.write(`pr-shepherd: log-file: ${String(e)}\n`);
+    process.exitCode = 1;
+  }
 }
 
 async function handleResolve(args: string[]): Promise<void> {

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -32,9 +32,7 @@ import {
   handleMonitor,
   handleStatus,
 } from "./cli/handlers.mts";
-import { initLog, appendEntry } from "./log/log-file.mts";
-import { buildSessionHeader, formatOutputEntry } from "./log/session.mts";
-import { getRepoInfo } from "./github/client.mts";
+import { setupLog } from "./log/setup.mts";
 
 // ---------------------------------------------------------------------------
 // Entry
@@ -87,48 +85,6 @@ export async function main(argv: string[]): Promise<void> {
       process.exitCode = 1;
       return;
   }
-}
-
-let _logSetupDone = false;
-
-async function setupLog(argv: string[]): Promise<void> {
-  if (_logSetupDone) return;
-  _logSetupDone = true;
-
-  try {
-    const { owner, name } = await getRepoInfo();
-    await initLog({ owner, repo: name });
-  } catch {
-    // Not in a git repo or repo info unavailable — log is silently disabled.
-    return;
-  }
-
-  const { markdown: header } = buildSessionHeader(argv);
-  appendEntry(header);
-
-  // Tee stdout to the log. Captures JSON and markdown output from all subcommands.
-  let outputBuffer = "";
-  const origWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = (
-    chunk: string | Uint8Array,
-    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
-    cb?: (err?: Error | null) => void,
-  ): boolean => {
-    const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
-    outputBuffer += text;
-    const result =
-      typeof encodingOrCb === "function"
-        ? origWrite(chunk, encodingOrCb)
-        : origWrite(chunk, encodingOrCb as BufferEncoding, cb);
-    return result;
-  };
-
-  // Flush buffered output to the log on process exit.
-  process.once("exit", () => {
-    if (outputBuffer.length > 0) {
-      appendEntry(formatOutputEntry(outputBuffer, "text"));
-    }
-  });
 }
 
 function readVersion(): string {

--- a/src/commands/log-file.mts
+++ b/src/commands/log-file.mts
@@ -1,0 +1,12 @@
+import { getRepoInfo } from "../github/client.mts";
+import { resolveLogPath } from "../log/log-file.mts";
+
+export interface LogFileResult {
+  path: string;
+}
+
+export async function runLogFile(): Promise<LogFileResult> {
+  const { owner, name } = await getRepoInfo();
+  const path = await resolveLogPath({ owner, repo: name });
+  return { path };
+}

--- a/src/commands/log-file.test.mts
+++ b/src/commands/log-file.test.mts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    optsOrCb:
+      | Record<string, unknown>
+      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
+    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
+    mockExecFile(cmd, args)
+      .then((result: { stdout: string; stderr: string }) => cb(null, result))
+      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+  },
+}));
+
+import { runLogFile } from "./log-file.mts";
+
+function gitRemote(url: string) {
+  mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "git" && args[0] === "remote")
+      return Promise.resolve({ stdout: `${url}\n`, stderr: "" });
+    if (cmd === "git" && args[0] === "rev-parse")
+      return Promise.resolve({ stdout: "/fake/worktree\n", stderr: "" });
+    return Promise.reject(new Error(`unexpected: ${cmd} ${args.join(" ")}`));
+  });
+}
+
+describe("runLogFile", () => {
+  it("returns an object with a path property", async () => {
+    gitRemote("https://github.com/acme/widgets.git");
+    const result = await runLogFile();
+    expect(result).toHaveProperty("path");
+    expect(typeof result.path).toBe("string");
+  });
+
+  it("path contains the owner-repo segment", async () => {
+    gitRemote("https://github.com/acme/widgets.git");
+    const result = await runLogFile();
+    expect(result.path).toContain("acme-widgets");
+  });
+
+  it("path contains the worktrees directory", async () => {
+    gitRemote("https://github.com/acme/widgets.git");
+    const result = await runLogFile();
+    expect(result.path).toContain("worktrees");
+  });
+
+  it("path ends with .md", async () => {
+    gitRemote("https://github.com/acme/widgets.git");
+    const result = await runLogFile();
+    expect(result.path).toMatch(/\.md$/);
+  });
+
+  it("throws when not in a git repo", async () => {
+    mockExecFile.mockRejectedValue(new Error("not a git repo"));
+    await expect(runLogFile()).rejects.toThrow();
+  });
+});

--- a/src/commands/ready-delay.mts
+++ b/src/commands/ready-delay.mts
@@ -8,8 +8,8 @@
 
 import { readFile, writeFile, mkdir, unlink } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
 import { SAFE_SEGMENT } from "../util/path-segment.mts";
+import { resolveStateBase } from "../state/base.mts";
 
 // ---------------------------------------------------------------------------
 // Ready-delay state machine
@@ -94,7 +94,7 @@ function readySincePath(pr: number, owner: string, repo: string): string {
       throw new Error(`Invalid path segment "${field}": ${value}`);
     }
   }
-  const base = process.env["PR_SHEPHERD_STATE_DIR"] ?? join(tmpdir(), "pr-shepherd-state");
+  const base = resolveStateBase();
   return join(base, `${owner}-${repo}`, String(pr), "ready-since.txt");
 }
 

--- a/src/github/http.mock.test.mts
+++ b/src/github/http.mock.test.mts
@@ -209,6 +209,22 @@ describe("graphqlWithRateLimit — header parsing", () => {
     const result = await graphqlWithRateLimit("{ q }");
     expect(result.rateLimit).toBeUndefined();
   });
+
+  it("returns rateLimit: undefined when rate-limit headers contain non-numeric values", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        "content-type": "application/json",
+        "x-ratelimit-remaining": "not-a-number",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-reset": "1700000000",
+      }),
+      json: () => Promise.resolve({ data: {} }),
+    });
+    const result = await graphqlWithRateLimit("{ q }");
+    expect(result.rateLimit).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -331,5 +347,25 @@ describe("restText — redirect handling", () => {
     await expect(restText("/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
       /GitHub REST GET.*failed: 404/,
     );
+  });
+
+  it("retries on 401 and returns text after token refresh", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        text: () => Promise.resolve("Unauthorized"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve("log content"),
+      });
+    const text = await restText("/repos/o/r/actions/jobs/1/logs");
+    expect(text).toBe("log content");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -69,6 +69,15 @@ function redactToken(body: string): string {
   return body.replace(/Bearer\s+\S+/gi, "[REDACTED]");
 }
 
+function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
 type RetryLogFn = (status: number, durationMs: number) => void;
 
 async function requestWithTokenRetry(
@@ -316,7 +325,8 @@ export async function restText(path: string): Promise<string> {
     const location = res.headers.get("location");
     if (location) {
       const n2 = nextEntry();
-      appendEntry(formatRequestEntry({ n: n2, kind: "restText", method: "GET", url: location }));
+      const logUrl = redactUrl(location);
+      appendEntry(formatRequestEntry({ n: n2, kind: "restText", method: "GET", url: logUrl }));
       const t1 = performance.now();
       const redirectRes = await fetch(location);
       const duration2 = Math.round(performance.now() - t1);
@@ -328,7 +338,7 @@ export async function restText(path: string): Promise<string> {
           n: n2,
           kind: "restText",
           method: "GET",
-          url: location,
+          url: logUrl,
           status: redirectRes.status,
           durationMs: duration2,
           contentLength,

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -1,5 +1,7 @@
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
+import { appendEntry, nextEntry } from "../log/log-file.mts";
+import { formatRequestEntry, formatResponseEntry } from "../log/session.mts";
 
 const execFile = promisify(execFileCb);
 
@@ -83,22 +85,30 @@ async function graphqlInner<T>(
   query: string,
   vars: Record<string, unknown>,
 ): Promise<{ data: T; rateLimit: RateLimitInfo | null }> {
+  const url = `${BASE_URL}/graphql`;
+  const n = nextEntry();
+  appendEntry(formatRequestEntry({ n, kind: "GraphQL", method: "POST", url, body: { query, variables: vars } }));
+  const t0 = performance.now();
+
   const res = await requestWithTokenRetry(async () =>
-    fetch(`${BASE_URL}/graphql`, {
+    fetch(url, {
       method: "POST",
       headers: await makeHeaders(),
       body: JSON.stringify({ query, variables: vars }),
     }),
   );
 
+  const durationMs = Math.round(performance.now() - t0);
   const rateLimit = parseRateLimit(res.headers);
 
   if (!res.ok) {
     const body = await res.text();
+    appendEntry(formatResponseEntry({ n, kind: "GraphQL", method: "POST", url, status: res.status, durationMs, textBody: sanitizeBody(body) }));
     throw new Error(`GitHub GraphQL request failed: ${res.status} ${sanitizeBody(body)}`);
   }
 
   const parsed = (await res.json()) as { data: T | null; errors?: Array<{ message: string }> };
+  appendEntry(formatResponseEntry({ n, kind: "GraphQL", method: "POST", url, status: res.status, durationMs, body: parsed }));
 
   if (parsed.data == null) {
     const messages = (parsed.errors ?? []).map((e: { message: string }) => e.message).join("; ");
@@ -133,39 +143,65 @@ export async function graphqlWithRateLimit<T = unknown>(
 // ---------------------------------------------------------------------------
 
 export async function rest<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+  const url = `${BASE_URL}${path}`;
+  const n = nextEntry();
+  appendEntry(formatRequestEntry({ n, kind: "REST", method, url, body }));
+  const t0 = performance.now();
+
   const res = await requestWithTokenRetry(async () =>
-    fetch(`${BASE_URL}${path}`, {
+    fetch(url, {
       method,
       headers: await makeHeaders(),
       body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
   );
 
+  const durationMs = Math.round(performance.now() - t0);
+  const ct = res.headers.get("content-type") ?? "";
+
   if (!res.ok) {
     const text = await res.text();
+    appendEntry(formatResponseEntry({ n, kind: "REST", method, url, status: res.status, durationMs, textBody: sanitizeBody(text) }));
     throw new Error(`GitHub REST ${method} ${path} failed: ${res.status} ${sanitizeBody(text)}`);
   }
 
-  const ct = res.headers.get("content-type") ?? "";
   if (ct.includes("application/json")) {
-    return res.json() as Promise<T>;
+    const json = (await res.json()) as T;
+    appendEntry(formatResponseEntry({ n, kind: "REST", method, url, status: res.status, durationMs, contentType: ct }));
+    return json;
   }
+  appendEntry(formatResponseEntry({ n, kind: "REST", method, url, status: res.status, durationMs, contentType: ct || undefined }));
   return undefined as T;
 }
 
 export async function restText(path: string): Promise<string> {
+  const url = `${BASE_URL}${path}`;
+  const n = nextEntry();
+  appendEntry(formatRequestEntry({ n, kind: "restText", method: "GET", url }));
+  const t0 = performance.now();
+
   const res = await requestWithTokenRetry(async () =>
-    fetch(`${BASE_URL}${path}`, {
+    fetch(url, {
       method: "GET",
       headers: await makeHeaders(),
       redirect: "manual",
     }),
   );
 
+  const durationMs = Math.round(performance.now() - t0);
+
   if (res.status === 301 || res.status === 302 || res.status === 307 || res.status === 308) {
+    appendEntry(formatResponseEntry({ n, kind: "restText", method: "GET", url, status: res.status, durationMs }));
     const location = res.headers.get("location");
     if (location) {
+      const n2 = nextEntry();
+      appendEntry(formatRequestEntry({ n: n2, kind: "restText", method: "GET", url: location }));
+      const t1 = performance.now();
       const redirectRes = await fetch(location);
+      const duration2 = Math.round(performance.now() - t1);
+      const clRaw = redirectRes.headers.get("content-length");
+      const contentLength = clRaw !== null && Number.isFinite(Number(clRaw)) ? Number(clRaw) : undefined;
+      appendEntry(formatResponseEntry({ n: n2, kind: "restText", method: "GET", url: location, status: redirectRes.status, durationMs: duration2, contentLength }));
       if (!redirectRes.ok) {
         throw new Error(`redirect target ${location} failed: ${redirectRes.status}`);
       }
@@ -175,9 +211,13 @@ export async function restText(path: string): Promise<string> {
 
   if (!res.ok) {
     const text = await res.text();
+    appendEntry(formatResponseEntry({ n, kind: "restText", method: "GET", url, status: res.status, durationMs }));
     throw new Error(`GitHub REST GET ${path} failed: ${res.status} ${sanitizeBody(text)}`);
   }
 
+  const clRaw = res.headers.get("content-length");
+  const contentLength = clRaw !== null && Number.isFinite(Number(clRaw)) ? Number(clRaw) : undefined;
+  appendEntry(formatResponseEntry({ n, kind: "restText", method: "GET", url, status: res.status, durationMs, contentLength }));
   return res.text();
 }
 

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -69,16 +69,24 @@ function redactToken(body: string): string {
   return body.replace(/Bearer\s+\S+/gi, "[REDACTED]");
 }
 
-async function requestWithTokenRetry(fn: () => Promise<Response>): Promise<Response> {
+type RetryLogFn = (status: number, durationMs: number) => void;
+
+async function requestWithTokenRetry(
+  fn: () => Promise<Response>,
+  t0: number,
+  onIntermediate?: RetryLogFn,
+): Promise<{ res: Response; attempt: number; retryT0: number }> {
   const res = await fn();
   if (res.status === 401 && _token !== undefined) {
+    onIntermediate?.(401, Math.round(performance.now() - t0));
     try {
       await res.arrayBuffer();
     } catch {}
     _token = undefined;
-    return fn();
+    const retryT0 = performance.now();
+    return { res: await fn(), attempt: 2, retryT0 };
   }
-  return res;
+  return { res, attempt: 1, retryT0: t0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -102,15 +110,29 @@ async function graphqlInner<T>(
   );
   const t0 = performance.now();
 
-  const res = await requestWithTokenRetry(async () =>
-    fetch(url, {
-      method: "POST",
-      headers: await makeHeaders(),
-      body: JSON.stringify({ query, variables: vars }),
-    }),
+  const { res, attempt, retryT0 } = await requestWithTokenRetry(
+    async () =>
+      fetch(url, {
+        method: "POST",
+        headers: await makeHeaders(),
+        body: JSON.stringify({ query, variables: vars }),
+      }),
+    t0,
+    (status, firstDurationMs) => {
+      appendEntry(
+        formatResponseEntry({
+          n,
+          kind: "GraphQL",
+          method: "POST",
+          url,
+          status,
+          durationMs: firstDurationMs,
+        }),
+      );
+    },
   );
 
-  const durationMs = Math.round(performance.now() - t0);
+  const durationMs = Math.round(performance.now() - retryT0);
   const rateLimit = parseRateLimit(res.headers);
 
   if (!res.ok) {
@@ -124,6 +146,7 @@ async function graphqlInner<T>(
         status: res.status,
         durationMs,
         textBody: redactToken(body),
+        attempt: attempt > 1 ? attempt : undefined,
       }),
     );
     throw new Error(`GitHub GraphQL request failed: ${res.status} ${sanitizeBody(body)}`);
@@ -139,6 +162,7 @@ async function graphqlInner<T>(
       status: res.status,
       durationMs,
       body: parsed,
+      attempt: attempt > 1 ? attempt : undefined,
     }),
   );
 
@@ -180,15 +204,22 @@ export async function rest<T = unknown>(method: string, path: string, body?: unk
   appendEntry(formatRequestEntry({ n, kind: "REST", method, url, body }));
   const t0 = performance.now();
 
-  const res = await requestWithTokenRetry(async () =>
-    fetch(url, {
-      method,
-      headers: await makeHeaders(),
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    }),
+  const { res, attempt, retryT0 } = await requestWithTokenRetry(
+    async () =>
+      fetch(url, {
+        method,
+        headers: await makeHeaders(),
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      }),
+    t0,
+    (status, firstDurationMs) => {
+      appendEntry(
+        formatResponseEntry({ n, kind: "REST", method, url, status, durationMs: firstDurationMs }),
+      );
+    },
   );
 
-  const durationMs = Math.round(performance.now() - t0);
+  const durationMs = Math.round(performance.now() - retryT0);
   const ct = res.headers.get("content-type") ?? "";
 
   if (!res.ok) {
@@ -202,6 +233,7 @@ export async function rest<T = unknown>(method: string, path: string, body?: unk
         status: res.status,
         durationMs,
         textBody: redactToken(text),
+        attempt: attempt > 1 ? attempt : undefined,
       }),
     );
     throw new Error(`GitHub REST ${method} ${path} failed: ${res.status} ${sanitizeBody(text)}`);
@@ -219,6 +251,7 @@ export async function rest<T = unknown>(method: string, path: string, body?: unk
         durationMs,
         contentType: ct,
         body: json,
+        attempt: attempt > 1 ? attempt : undefined,
       }),
     );
     return json;
@@ -232,6 +265,7 @@ export async function rest<T = unknown>(method: string, path: string, body?: unk
       status: res.status,
       durationMs,
       contentType: ct || undefined,
+      attempt: attempt > 1 ? attempt : undefined,
     }),
   );
   return undefined as T;
@@ -243,15 +277,29 @@ export async function restText(path: string): Promise<string> {
   appendEntry(formatRequestEntry({ n, kind: "restText", method: "GET", url }));
   const t0 = performance.now();
 
-  const res = await requestWithTokenRetry(async () =>
-    fetch(url, {
-      method: "GET",
-      headers: await makeHeaders(),
-      redirect: "manual",
-    }),
+  const { res, attempt, retryT0 } = await requestWithTokenRetry(
+    async () =>
+      fetch(url, {
+        method: "GET",
+        headers: await makeHeaders(),
+        redirect: "manual",
+      }),
+    t0,
+    (status, firstDurationMs) => {
+      appendEntry(
+        formatResponseEntry({
+          n,
+          kind: "restText",
+          method: "GET",
+          url,
+          status,
+          durationMs: firstDurationMs,
+        }),
+      );
+    },
   );
 
-  const durationMs = Math.round(performance.now() - t0);
+  const durationMs = Math.round(performance.now() - retryT0);
 
   if (res.status === 301 || res.status === 302 || res.status === 307 || res.status === 308) {
     appendEntry(
@@ -262,6 +310,7 @@ export async function restText(path: string): Promise<string> {
         url,
         status: res.status,
         durationMs,
+        attempt: attempt > 1 ? attempt : undefined,
       }),
     );
     const location = res.headers.get("location");
@@ -302,6 +351,7 @@ export async function restText(path: string): Promise<string> {
         url,
         status: res.status,
         durationMs,
+        attempt: attempt > 1 ? attempt : undefined,
       }),
     );
     throw new Error(`GitHub REST GET ${path} failed: ${res.status} ${sanitizeBody(text)}`);
@@ -319,6 +369,7 @@ export async function restText(path: string): Promise<string> {
       status: res.status,
       durationMs,
       contentLength,
+      attempt: attempt > 1 ? attempt : undefined,
     }),
   );
   return res.text();

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -65,6 +65,10 @@ function sanitizeBody(body: string): string {
   return body.replace(/Bearer\s+\S+/gi, "[REDACTED]").slice(0, 200);
 }
 
+function redactToken(body: string): string {
+  return body.replace(/Bearer\s+\S+/gi, "[REDACTED]");
+}
+
 async function requestWithTokenRetry(fn: () => Promise<Response>): Promise<Response> {
   const res = await fn();
   if (res.status === 401 && _token !== undefined) {
@@ -87,7 +91,15 @@ async function graphqlInner<T>(
 ): Promise<{ data: T; rateLimit: RateLimitInfo | null }> {
   const url = `${BASE_URL}/graphql`;
   const n = nextEntry();
-  appendEntry(formatRequestEntry({ n, kind: "GraphQL", method: "POST", url, body: { query, variables: vars } }));
+  appendEntry(
+    formatRequestEntry({
+      n,
+      kind: "GraphQL",
+      method: "POST",
+      url,
+      body: { query, variables: vars },
+    }),
+  );
   const t0 = performance.now();
 
   const res = await requestWithTokenRetry(async () =>
@@ -103,12 +115,32 @@ async function graphqlInner<T>(
 
   if (!res.ok) {
     const body = await res.text();
-    appendEntry(formatResponseEntry({ n, kind: "GraphQL", method: "POST", url, status: res.status, durationMs, textBody: sanitizeBody(body) }));
+    appendEntry(
+      formatResponseEntry({
+        n,
+        kind: "GraphQL",
+        method: "POST",
+        url,
+        status: res.status,
+        durationMs,
+        textBody: redactToken(body),
+      }),
+    );
     throw new Error(`GitHub GraphQL request failed: ${res.status} ${sanitizeBody(body)}`);
   }
 
   const parsed = (await res.json()) as { data: T | null; errors?: Array<{ message: string }> };
-  appendEntry(formatResponseEntry({ n, kind: "GraphQL", method: "POST", url, status: res.status, durationMs, body: parsed }));
+  appendEntry(
+    formatResponseEntry({
+      n,
+      kind: "GraphQL",
+      method: "POST",
+      url,
+      status: res.status,
+      durationMs,
+      body: parsed,
+    }),
+  );
 
   if (parsed.data == null) {
     const messages = (parsed.errors ?? []).map((e: { message: string }) => e.message).join("; ");
@@ -161,16 +193,47 @@ export async function rest<T = unknown>(method: string, path: string, body?: unk
 
   if (!res.ok) {
     const text = await res.text();
-    appendEntry(formatResponseEntry({ n, kind: "REST", method, url, status: res.status, durationMs, textBody: sanitizeBody(text) }));
+    appendEntry(
+      formatResponseEntry({
+        n,
+        kind: "REST",
+        method,
+        url,
+        status: res.status,
+        durationMs,
+        textBody: redactToken(text),
+      }),
+    );
     throw new Error(`GitHub REST ${method} ${path} failed: ${res.status} ${sanitizeBody(text)}`);
   }
 
   if (ct.includes("application/json")) {
     const json = (await res.json()) as T;
-    appendEntry(formatResponseEntry({ n, kind: "REST", method, url, status: res.status, durationMs, contentType: ct }));
+    appendEntry(
+      formatResponseEntry({
+        n,
+        kind: "REST",
+        method,
+        url,
+        status: res.status,
+        durationMs,
+        contentType: ct,
+        body: json,
+      }),
+    );
     return json;
   }
-  appendEntry(formatResponseEntry({ n, kind: "REST", method, url, status: res.status, durationMs, contentType: ct || undefined }));
+  appendEntry(
+    formatResponseEntry({
+      n,
+      kind: "REST",
+      method,
+      url,
+      status: res.status,
+      durationMs,
+      contentType: ct || undefined,
+    }),
+  );
   return undefined as T;
 }
 
@@ -191,7 +254,16 @@ export async function restText(path: string): Promise<string> {
   const durationMs = Math.round(performance.now() - t0);
 
   if (res.status === 301 || res.status === 302 || res.status === 307 || res.status === 308) {
-    appendEntry(formatResponseEntry({ n, kind: "restText", method: "GET", url, status: res.status, durationMs }));
+    appendEntry(
+      formatResponseEntry({
+        n,
+        kind: "restText",
+        method: "GET",
+        url,
+        status: res.status,
+        durationMs,
+      }),
+    );
     const location = res.headers.get("location");
     if (location) {
       const n2 = nextEntry();
@@ -200,8 +272,19 @@ export async function restText(path: string): Promise<string> {
       const redirectRes = await fetch(location);
       const duration2 = Math.round(performance.now() - t1);
       const clRaw = redirectRes.headers.get("content-length");
-      const contentLength = clRaw !== null && Number.isFinite(Number(clRaw)) ? Number(clRaw) : undefined;
-      appendEntry(formatResponseEntry({ n: n2, kind: "restText", method: "GET", url: location, status: redirectRes.status, durationMs: duration2, contentLength }));
+      const contentLength =
+        clRaw !== null && Number.isFinite(Number(clRaw)) ? Number(clRaw) : undefined;
+      appendEntry(
+        formatResponseEntry({
+          n: n2,
+          kind: "restText",
+          method: "GET",
+          url: location,
+          status: redirectRes.status,
+          durationMs: duration2,
+          contentLength,
+        }),
+      );
       if (!redirectRes.ok) {
         throw new Error(`redirect target ${location} failed: ${redirectRes.status}`);
       }
@@ -211,13 +294,33 @@ export async function restText(path: string): Promise<string> {
 
   if (!res.ok) {
     const text = await res.text();
-    appendEntry(formatResponseEntry({ n, kind: "restText", method: "GET", url, status: res.status, durationMs }));
+    appendEntry(
+      formatResponseEntry({
+        n,
+        kind: "restText",
+        method: "GET",
+        url,
+        status: res.status,
+        durationMs,
+      }),
+    );
     throw new Error(`GitHub REST GET ${path} failed: ${res.status} ${sanitizeBody(text)}`);
   }
 
   const clRaw = res.headers.get("content-length");
-  const contentLength = clRaw !== null && Number.isFinite(Number(clRaw)) ? Number(clRaw) : undefined;
-  appendEntry(formatResponseEntry({ n, kind: "restText", method: "GET", url, status: res.status, durationMs, contentLength }));
+  const contentLength =
+    clRaw !== null && Number.isFinite(Number(clRaw)) ? Number(clRaw) : undefined;
+  appendEntry(
+    formatResponseEntry({
+      n,
+      kind: "restText",
+      method: "GET",
+      url,
+      status: res.status,
+      durationMs,
+      contentLength,
+    }),
+  );
   return res.text();
 }
 

--- a/src/log/log-file.mts
+++ b/src/log/log-file.mts
@@ -14,8 +14,7 @@ import { resolveStateBase } from "../state/base.mts";
 import { SAFE_SEGMENT } from "../util/path-segment.mts";
 import { getWorktreeKey } from "../util/worktree.mts";
 
-let _disabled =
-  process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
+let _disabled = process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
 
 let _logPath: string | null = null;
 let _entryCounter = 0;
@@ -86,8 +85,7 @@ export async function resolveLogPath(repoKey: RepoKey): Promise<string> {
 
 /** Exposed for tests to reset module state. */
 export function _resetLogState(): void {
-  _disabled =
-    process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
+  _disabled = process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
   _logPath = null;
   _worktreeKey = null;
   _entryCounter = 0;

--- a/src/log/log-file.mts
+++ b/src/log/log-file.mts
@@ -14,7 +14,13 @@ import { resolveStateBase } from "../state/base.mts";
 import { SAFE_SEGMENT } from "../util/path-segment.mts";
 import { getWorktreeKey } from "../util/worktree.mts";
 
-let _disabled = process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
+function computeDisabled(): boolean {
+  if (process.env["PR_SHEPHERD_LOG_DISABLED"] === "1") return true;
+  const ci = process.env["CI"];
+  return ci !== undefined && ci !== "" && ci !== "0" && ci !== "false";
+}
+
+let _disabled = computeDisabled();
 
 let _logPath: string | null = null;
 let _entryCounter = 0;
@@ -85,7 +91,7 @@ export async function resolveLogPath(repoKey: RepoKey): Promise<string> {
 
 /** Exposed for tests to reset module state. */
 export function _resetLogState(): void {
-  _disabled = process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
+  _disabled = computeDisabled();
   _logPath = null;
   _worktreeKey = null;
   _entryCounter = 0;

--- a/src/log/log-file.mts
+++ b/src/log/log-file.mts
@@ -1,0 +1,94 @@
+/**
+ * Append-only per-worktree markdown log.
+ *
+ * Log path: $PR_SHEPHERD_STATE_DIR/<owner>-<repo>/worktrees/<basename>-<sha8>.md
+ *
+ * Always-on by default. Set PR_SHEPHERD_LOG_DISABLED=1 or CI=true to disable.
+ * Write failures flip an internal disabled flag so the CLI never crashes because
+ * logging failed.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { resolveStateBase } from "../state/base.mts";
+import { SAFE_SEGMENT } from "../util/path-segment.mts";
+import { getWorktreeKey } from "../util/worktree.mts";
+
+let _disabled =
+  process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
+
+let _logPath: string | null = null;
+let _entryCounter = 0;
+
+/** Returns the next monotonically-increasing entry number for the current session. */
+export function nextEntry(): number {
+  return ++_entryCounter;
+}
+
+export interface RepoKey {
+  owner: string;
+  repo: string;
+}
+
+export function getLogFilePath(key: RepoKey): string {
+  const { owner, repo } = key;
+  if (!SAFE_SEGMENT.test(owner) || !SAFE_SEGMENT.test(repo)) {
+    throw new Error(`Invalid repo key segments: ${owner}/${repo}`);
+  }
+  const base = resolveStateBase();
+  // Worktree key injected at init time; fall back to "unknown" if not yet set.
+  const wkey = _worktreeKey ?? "unknown";
+  return join(base, `${owner}-${repo}`, "worktrees", `${wkey}.md`);
+}
+
+let _worktreeKey: string | null = null;
+
+/**
+ * Initialize the log for this process. Must be called before appendEntry().
+ * Silently disables logging on any error (no git repo, bad repo name, etc.).
+ */
+export async function initLog(repoKey: RepoKey): Promise<string | null> {
+  if (_disabled) return null;
+  try {
+    const { owner, repo } = repoKey;
+    if (!SAFE_SEGMENT.test(owner) || !SAFE_SEGMENT.test(repo)) return null;
+    _worktreeKey = await getWorktreeKey();
+    const path = getLogFilePath(repoKey);
+    mkdirSync(dirname(path), { recursive: true });
+    _logPath = path;
+    return path;
+  } catch {
+    _disabled = true;
+    return null;
+  }
+}
+
+/** Append a pre-formatted markdown chunk to the log. No-op if disabled. */
+export function appendEntry(markdown: string): void {
+  if (_disabled || _logPath === null) return;
+  try {
+    appendFileSync(_logPath, markdown);
+  } catch (e) {
+    process.stderr.write(`pr-shepherd: log write failed (disabling log): ${String(e)}\n`);
+    _disabled = true;
+  }
+}
+
+/** Resolve the log path without initializing (for the log-file subcommand). */
+export async function resolveLogPath(repoKey: RepoKey): Promise<string> {
+  if (!SAFE_SEGMENT.test(repoKey.owner) || !SAFE_SEGMENT.test(repoKey.repo)) {
+    throw new Error(`Invalid repo key segments: ${repoKey.owner}/${repoKey.repo}`);
+  }
+  const wkey = await getWorktreeKey();
+  const base = resolveStateBase();
+  return join(base, `${repoKey.owner}-${repoKey.repo}`, "worktrees", `${wkey}.md`);
+}
+
+/** Exposed for tests to reset module state. */
+export function _resetLogState(): void {
+  _disabled =
+    process.env["PR_SHEPHERD_LOG_DISABLED"] === "1" || process.env["CI"] === "true";
+  _logPath = null;
+  _worktreeKey = null;
+  _entryCounter = 0;
+}

--- a/src/log/log-file.test.mts
+++ b/src/log/log-file.test.mts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// Mock getWorktreeKey so tests don't need a git repo.
+vi.mock("../util/worktree.mts", () => ({
+  getWorktreeKey: vi.fn().mockResolvedValue("test-worktree-abc12345"),
+}));
+
+let testStateDir: string;
+
+beforeEach(() => {
+  testStateDir = `${process.env["TMPDIR"] ?? "/tmp"}/shepherd-log-test-${randomBytes(4).toString("hex")}`;
+  process.env["PR_SHEPHERD_STATE_DIR"] = testStateDir;
+  delete process.env["PR_SHEPHERD_LOG_DISABLED"];
+  delete process.env["CI"];
+});
+
+afterEach(async () => {
+  delete process.env["PR_SHEPHERD_STATE_DIR"];
+  await rm(testStateDir, { recursive: true, force: true });
+});
+
+async function freshModule() {
+  vi.resetModules();
+  const mod = await import("./log-file.mts");
+  return mod;
+}
+
+describe("initLog + appendEntry", () => {
+  it("creates the log file and appends content", async () => {
+    const { initLog, appendEntry } = await freshModule();
+    const path = await initLog({ owner: "acme", repo: "widgets" });
+    expect(path).not.toBeNull();
+    appendEntry("## Session\nhello\n");
+    const content = await readFile(path!, "utf8");
+    expect(content).toContain("## Session\nhello\n");
+  });
+
+  it("appends (does not truncate) on second call", async () => {
+    const { initLog, appendEntry } = await freshModule();
+    const path = await initLog({ owner: "acme", repo: "widgets" });
+    appendEntry("first\n");
+    appendEntry("second\n");
+    const content = await readFile(path!, "utf8");
+    expect(content).toContain("first\n");
+    expect(content).toContain("second\n");
+  });
+
+  it("is a no-op when PR_SHEPHERD_LOG_DISABLED=1", async () => {
+    process.env["PR_SHEPHERD_LOG_DISABLED"] = "1";
+    const { initLog, appendEntry } = await freshModule();
+    const path = await initLog({ owner: "acme", repo: "widgets" });
+    expect(path).toBeNull();
+    appendEntry("should not be written");
+    // File should not exist
+    try {
+      await readFile(join(testStateDir, "acme-widgets", "worktrees", "test-worktree-abc12345.md"), "utf8");
+      expect.fail("file should not exist");
+    } catch (e: unknown) {
+      expect((e as NodeJS.ErrnoException).code).toBe("ENOENT");
+    }
+  });
+
+  it("is a no-op when CI=true", async () => {
+    process.env["CI"] = "true";
+    const { initLog, appendEntry } = await freshModule();
+    const path = await initLog({ owner: "acme", repo: "widgets" });
+    expect(path).toBeNull();
+    appendEntry("should not be written");
+  });
+
+  it("swallows write errors and disables further writes", async () => {
+    const { initLog, appendEntry } = await freshModule();
+    await initLog({ owner: "acme", repo: "widgets" });
+    // Make it fail by removing the directory after init
+    await rm(testStateDir, { recursive: true, force: true });
+    // Should not throw
+    expect(() => appendEntry("after removal\n")).not.toThrow();
+    // Subsequent appends are no-ops (disabled flag is set)
+    expect(() => appendEntry("another append\n")).not.toThrow();
+  });
+});
+
+describe("resolveLogPath", () => {
+  it("returns the expected path structure", async () => {
+    const { resolveLogPath } = await freshModule();
+    const path = await resolveLogPath({ owner: "acme", repo: "widgets" });
+    expect(path).toContain("acme-widgets");
+    expect(path).toContain("worktrees");
+    expect(path).toContain("test-worktree-abc12345.md");
+  });
+
+  it("throws for invalid owner/repo segments", async () => {
+    const { resolveLogPath } = await freshModule();
+    await expect(resolveLogPath({ owner: "acme/evil", repo: "widgets" })).rejects.toThrow();
+  });
+});

--- a/src/log/log-file.test.mts
+++ b/src/log/log-file.test.mts
@@ -56,7 +56,10 @@ describe("initLog + appendEntry", () => {
     appendEntry("should not be written");
     // File should not exist
     try {
-      await readFile(join(testStateDir, "acme-widgets", "worktrees", "test-worktree-abc12345.md"), "utf8");
+      await readFile(
+        join(testStateDir, "acme-widgets", "worktrees", "test-worktree-abc12345.md"),
+        "utf8",
+      );
       expect.fail("file should not exist");
     } catch (e: unknown) {
       expect((e as NodeJS.ErrnoException).code).toBe("ENOENT");

--- a/src/log/log-file.test.mts
+++ b/src/log/log-file.test.mts
@@ -100,3 +100,49 @@ describe("resolveLogPath", () => {
     await expect(resolveLogPath({ owner: "acme/evil", repo: "widgets" })).rejects.toThrow();
   });
 });
+
+describe("getLogFilePath", () => {
+  it("throws for invalid owner segment", async () => {
+    const { getLogFilePath } = await freshModule();
+    expect(() => getLogFilePath({ owner: "bad/owner", repo: "widgets" })).toThrow(
+      /Invalid repo key segments/,
+    );
+  });
+
+  it("uses 'unknown' worktree key before initLog is called", async () => {
+    const { getLogFilePath } = await freshModule();
+    const path = getLogFilePath({ owner: "acme", repo: "widgets" });
+    expect(path).toContain("unknown.md");
+  });
+});
+
+describe("initLog validation", () => {
+  it("returns null for invalid owner segment without throwing", async () => {
+    const { initLog } = await freshModule();
+    const path = await initLog({ owner: "bad/owner", repo: "widgets" });
+    expect(path).toBeNull();
+  });
+});
+
+describe("initLog error handling", () => {
+  it("disables log when getWorktreeKey throws", async () => {
+    vi.resetModules();
+    const { getWorktreeKey } = await import("../util/worktree.mts");
+    vi.mocked(getWorktreeKey).mockRejectedValueOnce(new Error("not a git repo"));
+    const { initLog, appendEntry } = await import("./log-file.mts");
+    const path = await initLog({ owner: "acme", repo: "widgets" });
+    expect(path).toBeNull();
+    expect(() => appendEntry("test")).not.toThrow();
+  });
+});
+
+describe("_resetLogState", () => {
+  it("resets entry counter and clears log path", async () => {
+    const { initLog, nextEntry, _resetLogState } = await freshModule();
+    await initLog({ owner: "acme", repo: "widgets" });
+    nextEntry();
+    nextEntry(); // counter = 2
+    _resetLogState();
+    expect(nextEntry()).toBe(1); // reset to 0, incremented to 1
+  });
+});

--- a/src/log/session.mts
+++ b/src/log/session.mts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function readVersion(): string {
+  const pkgUrl = new URL("../../package.json", import.meta.url);
+  const pkg = JSON.parse(readFileSync(fileURLToPath(pkgUrl), "utf8")) as { version: string };
+  return pkg.version;
+}
+
+export interface SessionContext {
+  /** Monotonically-incrementing counter for entries within this session. */
+  nextEntry: () => number;
+}
+
+/** Builds the session header markdown block and returns a counter for entry numbering. */
+export function buildSessionHeader(argv: string[]): { markdown: string; ctx: SessionContext } {
+  const ts = new Date().toISOString();
+  const cmd = argv.slice(2).join(" ") || "(no args)";
+  let n = 0;
+  const markdown =
+    `## ${ts} — pr-shepherd ${cmd}\n` +
+    `pid: ${process.pid} · version: ${readVersion()}\n\n`;
+  return { markdown, ctx: { nextEntry: () => ++n } };
+}
+
+export interface HttpRequestEntry {
+  n: number;
+  kind: "GraphQL" | "REST" | "restText";
+  method: string;
+  url: string;
+  body?: unknown;
+}
+
+export interface HttpResponseEntry {
+  n: number;
+  kind: "GraphQL" | "REST" | "restText";
+  method: string;
+  url: string;
+  status: number;
+  durationMs: number;
+  /** Parsed response body. Omit for restText. */
+  body?: unknown;
+  /** Raw text response body. Omit for restText. */
+  textBody?: string;
+  contentType?: string;
+  contentLength?: number;
+  /** Set on 401-retry invocations. */
+  attempt?: number;
+}
+
+const MAX_BODY = Number(process.env["PR_SHEPHERD_LOG_MAX_BODY"] ?? 256 * 1024);
+
+function truncate(s: string): string {
+  if (s.length <= MAX_BODY) return s;
+  return `${s.slice(0, MAX_BODY)}\n...[truncated ${s.length - MAX_BODY} bytes]`;
+}
+
+function fenceBody(body: unknown, lang: string): string {
+  const raw = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+  return `\`\`\`${lang}\n${truncate(raw)}\n\`\`\`\n`;
+}
+
+export function formatRequestEntry(entry: HttpRequestEntry): string {
+  const ts = new Date().toISOString();
+  const label =
+    entry.kind === "GraphQL"
+      ? `GraphQL request — POST ${entry.url}`
+      : entry.kind === "restText"
+        ? `restText request — GET ${entry.url}`
+        : `REST request — ${entry.method} ${entry.url}`;
+
+  let out = `### #${entry.n} ${label}\n${ts}\n`;
+
+  if (entry.kind === "restText") {
+    out += `(body omitted: log artifact)\n\n`;
+    return out;
+  }
+
+  if (entry.body !== undefined && entry.kind === "GraphQL") {
+    const { query, variables } = entry.body as { query: string; variables?: unknown };
+    out += fenceBody(query, "graphql");
+    if (variables && Object.keys(variables as object).length > 0) {
+      out += `variables:\n${fenceBody(variables, "json")}`;
+    }
+  } else if (entry.body !== undefined) {
+    out += fenceBody(entry.body, "json");
+  } else {
+    out += `(no body)\n`;
+  }
+
+  return out + "\n";
+}
+
+export function formatResponseEntry(entry: HttpResponseEntry): string {
+  const ts = new Date().toISOString();
+  const attempt = entry.attempt !== undefined ? ` (attempt ${entry.attempt}/2 after 401)` : "";
+  const label =
+    entry.kind === "GraphQL"
+      ? `GraphQL response — ${entry.status}${attempt} · ${entry.durationMs}ms`
+      : entry.kind === "restText"
+        ? `restText response — ${entry.status} · ${entry.durationMs}ms`
+        : `REST response — ${entry.status} · ${entry.durationMs}ms`;
+
+  let out = `### #${entry.n} ${label}\n${ts}\n`;
+
+  if (entry.kind === "restText") {
+    if (entry.contentLength !== undefined) {
+      out += `content-length: ${entry.contentLength} bytes (body not logged)\n\n`;
+    } else {
+      out += `(body not logged)\n\n`;
+    }
+    return out;
+  }
+
+  if (entry.contentType !== undefined) {
+    out += `content-type: ${entry.contentType}`;
+    if (entry.contentLength !== undefined) out += ` · ${entry.contentLength} bytes`;
+    out += "\n";
+  }
+
+  if (entry.body !== undefined) {
+    out += fenceBody(entry.body, "json");
+  } else if (entry.textBody !== undefined) {
+    out += fenceBody(entry.textBody, "");
+  }
+
+  return out + "\n";
+}
+
+export function formatOutputEntry(text: string, format: "text" | "json"): string {
+  const ts = new Date().toISOString();
+  const lang = format === "json" ? "json" : "";
+  return `### Output (${format})\n${ts}\n${fenceBody(text.trimEnd(), lang)}\n`;
+}

--- a/src/log/session.mts
+++ b/src/log/session.mts
@@ -18,8 +18,7 @@ export function buildSessionHeader(argv: string[]): { markdown: string; ctx: Ses
   const cmd = argv.slice(2).join(" ") || "(no args)";
   let n = 0;
   const markdown =
-    `## ${ts} — pr-shepherd ${cmd}\n` +
-    `pid: ${process.pid} · version: ${readVersion()}\n\n`;
+    `## ${ts} — pr-shepherd ${cmd}\n` + `pid: ${process.pid} · version: ${readVersion()}\n\n`;
   return { markdown, ctx: { nextEntry: () => ++n } };
 }
 
@@ -48,11 +47,12 @@ export interface HttpResponseEntry {
   attempt?: number;
 }
 
-const MAX_BODY = Number(process.env["PR_SHEPHERD_LOG_MAX_BODY"] ?? 256 * 1024);
+const _maxBodyRaw = Number(process.env["PR_SHEPHERD_LOG_MAX_BODY"]);
+const MAX_BODY = Number.isFinite(_maxBodyRaw) && _maxBodyRaw > 0 ? _maxBodyRaw : 256 * 1024;
 
 function truncate(s: string): string {
   if (s.length <= MAX_BODY) return s;
-  return `${s.slice(0, MAX_BODY)}\n...[truncated ${s.length - MAX_BODY} bytes]`;
+  return `${s.slice(0, MAX_BODY)}\n...[truncated ${s.length - MAX_BODY} characters]`;
 }
 
 function fenceBody(body: unknown, lang: string): string {

--- a/src/log/session.mts
+++ b/src/log/session.mts
@@ -7,19 +7,13 @@ function readVersion(): string {
   return pkg.version;
 }
 
-export interface SessionContext {
-  /** Monotonically-incrementing counter for entries within this session. */
-  nextEntry: () => number;
-}
-
-/** Builds the session header markdown block and returns a counter for entry numbering. */
-export function buildSessionHeader(argv: string[]): { markdown: string; ctx: SessionContext } {
+/** Builds the session header markdown block. */
+export function buildSessionHeader(argv: string[]): { markdown: string } {
   const ts = new Date().toISOString();
   const cmd = argv.slice(2).join(" ") || "(no args)";
-  let n = 0;
   const markdown =
     `## ${ts} — pr-shepherd ${cmd}\n` + `pid: ${process.pid} · version: ${readVersion()}\n\n`;
-  return { markdown, ctx: { nextEntry: () => ++n } };
+  return { markdown };
 }
 
 export interface HttpRequestEntry {
@@ -98,8 +92,8 @@ export function formatResponseEntry(entry: HttpResponseEntry): string {
     entry.kind === "GraphQL"
       ? `GraphQL response — ${entry.status}${attempt} · ${entry.durationMs}ms`
       : entry.kind === "restText"
-        ? `restText response — ${entry.status} · ${entry.durationMs}ms`
-        : `REST response — ${entry.status} · ${entry.durationMs}ms`;
+        ? `restText response — ${entry.status}${attempt} · ${entry.durationMs}ms`
+        : `REST response — ${entry.status}${attempt} · ${entry.durationMs}ms`;
 
   let out = `### #${entry.n} ${label}\n${ts}\n`;
 

--- a/src/log/session.test.mts
+++ b/src/log/session.test.mts
@@ -19,13 +19,6 @@ describe("buildSessionHeader", () => {
     const { markdown } = buildSessionHeader(["node", "bin/index.mjs"]);
     expect(markdown).toContain("(no args)");
   });
-
-  it("returns a context whose nextEntry() increments", () => {
-    const { ctx } = buildSessionHeader(["node", "bin/index.mjs", "check"]);
-    expect(ctx.nextEntry()).toBe(1);
-    expect(ctx.nextEntry()).toBe(2);
-    expect(ctx.nextEntry()).toBe(3);
-  });
 });
 
 describe("formatRequestEntry", () => {

--- a/src/log/session.test.mts
+++ b/src/log/session.test.mts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   buildSessionHeader,
   formatRequestEntry,
@@ -138,6 +138,20 @@ describe("formatResponseEntry", () => {
     expect(out).toContain('"id": 1');
   });
 
+  it("includes content-length in header when both contentType and contentLength are set", () => {
+    const out = formatResponseEntry({
+      n: 4,
+      kind: "REST",
+      method: "GET",
+      url: "https://api.github.com/repos/acme/foo",
+      status: 200,
+      durationMs: 88,
+      contentType: "application/json",
+      contentLength: 512,
+    });
+    expect(out).toContain("application/json · 512 bytes");
+  });
+
   it("formats a restText response with content-length, no body", () => {
     const out = formatResponseEntry({
       n: 5,
@@ -205,6 +219,30 @@ describe("truncation", () => {
     } finally {
       if (env === undefined) delete process.env["PR_SHEPHERD_LOG_MAX_BODY"];
       else process.env["PR_SHEPHERD_LOG_MAX_BODY"] = env;
+    }
+  });
+
+  it("actually truncates when MAX_BODY env is set before module load", async () => {
+    const saved = process.env["PR_SHEPHERD_LOG_MAX_BODY"];
+    try {
+      process.env["PR_SHEPHERD_LOG_MAX_BODY"] = "5";
+      vi.resetModules();
+      const { formatResponseEntry: freshFmt } = await import("./session.mts");
+      const out = freshFmt({
+        n: 1,
+        kind: "GraphQL",
+        method: "POST",
+        url: "https://api.github.com/graphql",
+        status: 200,
+        durationMs: 10,
+        textBody: "a".repeat(20),
+      });
+      expect(out).toContain("truncated");
+      expect(out).toContain("characters");
+    } finally {
+      vi.resetModules();
+      if (saved === undefined) delete process.env["PR_SHEPHERD_LOG_MAX_BODY"];
+      else process.env["PR_SHEPHERD_LOG_MAX_BODY"] = saved;
     }
   });
 });

--- a/src/log/session.test.mts
+++ b/src/log/session.test.mts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSessionHeader,
+  formatRequestEntry,
+  formatResponseEntry,
+  formatOutputEntry,
+} from "./session.mts";
+
+describe("buildSessionHeader", () => {
+  it("includes the ISO timestamp and command args", () => {
+    const { markdown } = buildSessionHeader(["node", "bin/index.mjs", "check", "42"]);
+    expect(markdown).toMatch(/^## \d{4}-\d{2}-\d{2}T/);
+    expect(markdown).toContain("check 42");
+    expect(markdown).toContain("pid:");
+    expect(markdown).toContain("version:");
+  });
+
+  it("uses (no args) when no subcommand is given", () => {
+    const { markdown } = buildSessionHeader(["node", "bin/index.mjs"]);
+    expect(markdown).toContain("(no args)");
+  });
+
+  it("returns a context whose nextEntry() increments", () => {
+    const { ctx } = buildSessionHeader(["node", "bin/index.mjs", "check"]);
+    expect(ctx.nextEntry()).toBe(1);
+    expect(ctx.nextEntry()).toBe(2);
+    expect(ctx.nextEntry()).toBe(3);
+  });
+});
+
+describe("formatRequestEntry", () => {
+  it("formats a GraphQL request with query and variables", () => {
+    const out = formatRequestEntry({
+      n: 1,
+      kind: "GraphQL",
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      body: { query: "query { viewer { login } }", variables: { owner: "acme" } },
+    });
+    expect(out).toContain("### #1 GraphQL request");
+    expect(out).toContain("query { viewer { login } }");
+    expect(out).toContain('"owner": "acme"');
+  });
+
+  it("omits empty variables block for GraphQL", () => {
+    const out = formatRequestEntry({
+      n: 2,
+      kind: "GraphQL",
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      body: { query: "query { viewer { login } }", variables: {} },
+    });
+    expect(out).not.toContain("variables:");
+  });
+
+  it("formats a REST request with body", () => {
+    const out = formatRequestEntry({
+      n: 3,
+      kind: "REST",
+      method: "POST",
+      url: "https://api.github.com/repos/acme/foo/issues",
+      body: { title: "Bug" },
+    });
+    expect(out).toContain("### #3 REST request — POST");
+    expect(out).toContain('"title": "Bug"');
+  });
+
+  it("formats a REST request without body as (no body)", () => {
+    const out = formatRequestEntry({
+      n: 4,
+      kind: "REST",
+      method: "GET",
+      url: "https://api.github.com/repos/acme/foo",
+    });
+    expect(out).toContain("(no body)");
+  });
+
+  it("formats a restText request with no body logged", () => {
+    const out = formatRequestEntry({
+      n: 5,
+      kind: "restText",
+      method: "GET",
+      url: "https://api.github.com/logs/123",
+    });
+    expect(out).toContain("### #5 restText request");
+    expect(out).toContain("(body omitted: log artifact)");
+  });
+});
+
+describe("formatResponseEntry", () => {
+  it("formats a successful GraphQL response", () => {
+    const out = formatResponseEntry({
+      n: 1,
+      kind: "GraphQL",
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      status: 200,
+      durationMs: 312,
+      body: { data: { viewer: { login: "alice" } } },
+    });
+    expect(out).toContain("### #1 GraphQL response — 200 · 312ms");
+    expect(out).toContain('"login": "alice"');
+  });
+
+  it("formats a failed GraphQL response with textBody", () => {
+    const out = formatResponseEntry({
+      n: 2,
+      kind: "GraphQL",
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      status: 401,
+      durationMs: 55,
+      textBody: "Unauthorized",
+    });
+    expect(out).toContain("401 · 55ms");
+    expect(out).toContain("Unauthorized");
+  });
+
+  it("includes attempt marker when attempt is set", () => {
+    const out = formatResponseEntry({
+      n: 3,
+      kind: "GraphQL",
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      status: 200,
+      durationMs: 100,
+      attempt: 2,
+      body: { data: null },
+    });
+    expect(out).toContain("attempt 2/2 after 401");
+  });
+
+  it("formats a REST response with content-type and body", () => {
+    const out = formatResponseEntry({
+      n: 4,
+      kind: "REST",
+      method: "GET",
+      url: "https://api.github.com/repos/acme/foo",
+      status: 200,
+      durationMs: 88,
+      contentType: "application/json",
+      body: { id: 1 },
+    });
+    expect(out).toContain("content-type: application/json");
+    expect(out).toContain('"id": 1');
+  });
+
+  it("formats a restText response with content-length, no body", () => {
+    const out = formatResponseEntry({
+      n: 5,
+      kind: "restText",
+      method: "GET",
+      url: "https://storage.example.com/logs/job.txt",
+      status: 200,
+      durationMs: 720,
+      contentLength: 1248912,
+    });
+    expect(out).toContain("1248912 bytes (body not logged)");
+    expect(out).not.toContain("```");
+  });
+
+  it("formats a restText response with no content-length", () => {
+    const out = formatResponseEntry({
+      n: 6,
+      kind: "restText",
+      method: "GET",
+      url: "https://storage.example.com/logs/job.txt",
+      status: 200,
+      durationMs: 100,
+    });
+    expect(out).toContain("(body not logged)");
+  });
+});
+
+describe("formatOutputEntry", () => {
+  it("wraps text output in a fenced block", () => {
+    const out = formatOutputEntry("hello world\n", "text");
+    expect(out).toContain("### Output (text)");
+    expect(out).toContain("hello world");
+    expect(out).toContain("```");
+  });
+
+  it("wraps json output with json lang tag", () => {
+    const out = formatOutputEntry('{"status":"ok"}', "json");
+    expect(out).toContain("### Output (json)");
+    expect(out).toContain("```json");
+  });
+});
+
+describe("truncation", () => {
+  it("truncates large bodies and reports characters", () => {
+    const env = process.env["PR_SHEPHERD_LOG_MAX_BODY"];
+    try {
+      process.env["PR_SHEPHERD_LOG_MAX_BODY"] = "10";
+      // Re-import after env change would be needed for module-level const,
+      // but we can test via formatRequestEntry with a long body
+      // Instead test through formatResponseEntry with a body string >10 chars
+      const longBody = "a".repeat(20);
+      const out = formatResponseEntry({
+        n: 1,
+        kind: "GraphQL",
+        method: "POST",
+        url: "https://api.github.com/graphql",
+        status: 200,
+        durationMs: 10,
+        textBody: longBody,
+      });
+      // MAX_BODY is module-level const — can't change after import, but we can
+      // verify the truncation message format says "characters"
+      // (the actual truncation only fires if we set it before module load)
+      expect(out).toSatisfy((s: string) => s.includes("characters") || !s.includes("truncated"));
+    } finally {
+      if (env === undefined) delete process.env["PR_SHEPHERD_LOG_MAX_BODY"];
+      else process.env["PR_SHEPHERD_LOG_MAX_BODY"] = env;
+    }
+  });
+});

--- a/src/log/session.test.mts
+++ b/src/log/session.test.mts
@@ -195,34 +195,7 @@ describe("formatOutputEntry", () => {
 });
 
 describe("truncation", () => {
-  it("truncates large bodies and reports characters", () => {
-    const env = process.env["PR_SHEPHERD_LOG_MAX_BODY"];
-    try {
-      process.env["PR_SHEPHERD_LOG_MAX_BODY"] = "10";
-      // Re-import after env change would be needed for module-level const,
-      // but we can test via formatRequestEntry with a long body
-      // Instead test through formatResponseEntry with a body string >10 chars
-      const longBody = "a".repeat(20);
-      const out = formatResponseEntry({
-        n: 1,
-        kind: "GraphQL",
-        method: "POST",
-        url: "https://api.github.com/graphql",
-        status: 200,
-        durationMs: 10,
-        textBody: longBody,
-      });
-      // MAX_BODY is module-level const — can't change after import, but we can
-      // verify the truncation message format says "characters"
-      // (the actual truncation only fires if we set it before module load)
-      expect(out).toSatisfy((s: string) => s.includes("characters") || !s.includes("truncated"));
-    } finally {
-      if (env === undefined) delete process.env["PR_SHEPHERD_LOG_MAX_BODY"];
-      else process.env["PR_SHEPHERD_LOG_MAX_BODY"] = env;
-    }
-  });
-
-  it("actually truncates when MAX_BODY env is set before module load", async () => {
+  it("truncates when MAX_BODY env is set before module load", async () => {
     const saved = process.env["PR_SHEPHERD_LOG_MAX_BODY"];
     try {
       process.env["PR_SHEPHERD_LOG_MAX_BODY"] = "5";

--- a/src/log/setup.mts
+++ b/src/log/setup.mts
@@ -4,6 +4,14 @@ import { getRepoInfo } from "../github/client.mts";
 
 let _done = false;
 
+function detectFormat(argv: string[]): "text" | "json" {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--format=json") return "json";
+    if (argv[i] === "--format" && argv[i + 1] === "json") return "json";
+  }
+  return "text";
+}
+
 /**
  * Initialize the per-worktree log, write the session header, and install a
  * stdout tee that routes all CLI output to the log. No-op after the first call.
@@ -23,20 +31,17 @@ export async function setupLog(argv: string[]): Promise<void> {
   const { markdown: header } = buildSessionHeader(argv);
   appendEntry(header);
 
-  let outputBuffer = "";
+  const format = detectFormat(argv);
   const origWrite = process.stdout.write.bind(process.stdout);
   process.stdout.write = (
     chunk: string | Uint8Array,
     encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
     cb?: (err?: Error | null) => void,
   ): boolean => {
-    outputBuffer += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    if (text.length > 0) appendEntry(formatOutputEntry(text, format));
     return typeof encodingOrCb === "function"
       ? origWrite(chunk, encodingOrCb)
       : origWrite(chunk, encodingOrCb as BufferEncoding, cb);
   };
-
-  process.once("exit", () => {
-    if (outputBuffer.length > 0) appendEntry(formatOutputEntry(outputBuffer, "text"));
-  });
 }

--- a/src/log/setup.mts
+++ b/src/log/setup.mts
@@ -1,0 +1,42 @@
+import { initLog, appendEntry } from "./log-file.mts";
+import { buildSessionHeader, formatOutputEntry } from "./session.mts";
+import { getRepoInfo } from "../github/client.mts";
+
+let _done = false;
+
+/**
+ * Initialize the per-worktree log, write the session header, and install a
+ * stdout tee that routes all CLI output to the log. No-op after the first call.
+ * Silently skips logging when not in a git repo or on any other error.
+ */
+export async function setupLog(argv: string[]): Promise<void> {
+  if (_done) return;
+  _done = true;
+
+  try {
+    const { owner, name } = await getRepoInfo();
+    await initLog({ owner, repo: name });
+  } catch {
+    return;
+  }
+
+  const { markdown: header } = buildSessionHeader(argv);
+  appendEntry(header);
+
+  let outputBuffer = "";
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (
+    chunk: string | Uint8Array,
+    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void,
+  ): boolean => {
+    outputBuffer += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return typeof encodingOrCb === "function"
+      ? origWrite(chunk, encodingOrCb)
+      : origWrite(chunk, encodingOrCb as BufferEncoding, cb);
+  };
+
+  process.once("exit", () => {
+    if (outputBuffer.length > 0) appendEntry(formatOutputEntry(outputBuffer, "text"));
+  });
+}

--- a/src/log/setup.mts
+++ b/src/log/setup.mts
@@ -23,25 +23,34 @@ export async function setupLog(argv: string[]): Promise<void> {
 
   try {
     const { owner, name } = await getRepoInfo();
-    await initLog({ owner, repo: name });
+    const log = await initLog({ owner, repo: name });
+    if (!log) return;
   } catch {
     return;
   }
 
-  const { markdown: header } = buildSessionHeader(argv);
-  appendEntry(header);
+  try {
+    const { markdown: header } = buildSessionHeader(argv);
+    appendEntry(header);
 
-  const format = detectFormat(argv);
-  const origWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = (
-    chunk: string | Uint8Array,
-    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
-    cb?: (err?: Error | null) => void,
-  ): boolean => {
-    const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
-    if (text.length > 0) appendEntry(formatOutputEntry(text, format));
-    return typeof encodingOrCb === "function"
-      ? origWrite(chunk, encodingOrCb)
-      : origWrite(chunk, encodingOrCb as BufferEncoding, cb);
-  };
+    const format = detectFormat(argv);
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (
+      chunk: string | Uint8Array,
+      encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+      cb?: (err?: Error | null) => void,
+    ): boolean => {
+      try {
+        const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+        if (text.length > 0) appendEntry(formatOutputEntry(text, format));
+      } catch {
+        // Best-effort: logging must never interfere with CLI output.
+      }
+      return typeof encodingOrCb === "function"
+        ? origWrite(chunk, encodingOrCb)
+        : origWrite(chunk, encodingOrCb as BufferEncoding, cb);
+    };
+  } catch {
+    // Best-effort: logging setup must never prevent the CLI from running.
+  }
 }

--- a/src/log/setup.test.mts
+++ b/src/log/setup.test.mts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockRejectedValue(new Error("not in a git repo")),
+}));
+
+vi.mock("./log-file.mts", () => ({
+  initLog: vi.fn().mockResolvedValue(null),
+  appendEntry: vi.fn(),
+}));
+
+vi.mock("./session.mts", () => ({
+  buildSessionHeader: vi.fn().mockReturnValue({ markdown: "## header\n" }),
+  formatOutputEntry: vi.fn().mockReturnValue("### Output\n"),
+}));
+
+describe("setupLog", () => {
+  it("returns without throwing when getRepoInfo fails", async () => {
+    vi.resetModules();
+    const { setupLog } = await import("./setup.mts");
+    await expect(setupLog(["node", "bin/index.mjs", "check"])).resolves.toBeUndefined();
+  });
+});

--- a/src/state/base.mts
+++ b/src/state/base.mts
@@ -1,0 +1,6 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+export function resolveStateBase(): string {
+  return process.env["PR_SHEPHERD_STATE_DIR"] ?? join(tmpdir(), "pr-shepherd-state");
+}

--- a/src/state/base.test.mts
+++ b/src/state/base.test.mts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveStateBase } from "./base.mts";
+
+describe("resolveStateBase", () => {
+  const saved = process.env["PR_SHEPHERD_STATE_DIR"];
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env["PR_SHEPHERD_STATE_DIR"];
+    } else {
+      process.env["PR_SHEPHERD_STATE_DIR"] = saved;
+    }
+  });
+
+  it("returns default when env var not set", () => {
+    delete process.env["PR_SHEPHERD_STATE_DIR"];
+    expect(resolveStateBase()).toBe(join(tmpdir(), "pr-shepherd-state"));
+  });
+
+  it("returns env var value when set", () => {
+    process.env["PR_SHEPHERD_STATE_DIR"] = "/custom/state";
+    expect(resolveStateBase()).toBe("/custom/state");
+  });
+
+  it("is idempotent for the same env", () => {
+    process.env["PR_SHEPHERD_STATE_DIR"] = "/custom/state";
+    expect(resolveStateBase()).toBe(resolveStateBase());
+  });
+});

--- a/src/state/fix-attempts.mts
+++ b/src/state/fix-attempts.mts
@@ -11,8 +11,8 @@
 import { readFile, writeFile, rename, unlink, mkdir } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
 import { SAFE_SEGMENT } from "../util/path-segment.mts";
+import { resolveStateBase } from "./base.mts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,6 +81,6 @@ function resolvePath(key: StateKey): string {
       throw new Error(`Invalid state key segment "${field}": ${value}`);
     }
   }
-  const base = process.env["PR_SHEPHERD_STATE_DIR"] ?? join(tmpdir(), "pr-shepherd-state");
+  const base = resolveStateBase();
   return join(base, `${key.owner}-${key.repo}`, String(key.pr), "fix-attempts.json");
 }

--- a/src/state/iterate-stall.mts
+++ b/src/state/iterate-stall.mts
@@ -11,8 +11,8 @@
 import { readFile, writeFile, rename, unlink, mkdir } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
 import { SAFE_SEGMENT } from "../util/path-segment.mts";
+import { resolveStateBase } from "./base.mts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -90,6 +90,6 @@ function resolvePath(key: StateKey): string {
       throw new Error(`Invalid state key segment "${field}": ${value}`);
     }
   }
-  const base = process.env["PR_SHEPHERD_STATE_DIR"] ?? join(tmpdir(), "pr-shepherd-state");
+  const base = resolveStateBase();
   return join(base, `${key.owner}-${key.repo}`, String(key.pr), "iterate-stall.json");
 }

--- a/src/state/seen-comments.mts
+++ b/src/state/seen-comments.mts
@@ -1,7 +1,8 @@
 import { readFile, writeFile, mkdir, access, readdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
 import { SAFE_SEGMENT } from "../util/path-segment.mts";
+
+import { resolveStateBase } from "./base.mts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -84,7 +85,7 @@ function resolveDir(key: StateKey): string {
       throw new Error(`Invalid state key segment "${field}": ${value}`);
     }
   }
-  const base = process.env["PR_SHEPHERD_STATE_DIR"] ?? join(tmpdir(), "pr-shepherd-state");
+  const base = resolveStateBase();
   return join(base, `${key.owner}-${key.repo}`, String(key.pr), "seen");
 }
 

--- a/src/util/worktree.mts
+++ b/src/util/worktree.mts
@@ -1,0 +1,26 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
+import { SAFE_SEGMENT } from "./path-segment.mts";
+
+const execFile = promisify(execFileCb);
+
+/** Returns the absolute path to the current git worktree root. Throws outside a git repo. */
+export async function getWorktreeRoot(): Promise<string> {
+  const { stdout } = await execFile("git", ["rev-parse", "--show-toplevel"]);
+  return stdout.trim();
+}
+
+/**
+ * Returns a filesystem-safe key for the current worktree, unique across
+ * worktrees of the same repo. Format: `<basename>-<sha8>` where sha8 is
+ * the first 8 hex chars of sha256(toplevel). Falls back to sha8-only if
+ * the basename contains characters outside SAFE_SEGMENT.
+ */
+export async function getWorktreeKey(): Promise<string> {
+  const root = await getWorktreeRoot();
+  const sha8 = createHash("sha256").update(root).digest("hex").slice(0, 8);
+  const base = basename(root);
+  return SAFE_SEGMENT.test(base) ? `${base}-${sha8}` : sha8;
+}

--- a/src/util/worktree.test.mts
+++ b/src/util/worktree.test.mts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "node:crypto";
+
+const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    optsOrCb:
+      | Record<string, unknown>
+      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
+    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
+    mockExecFile(cmd, args)
+      .then((result: { stdout: string; stderr: string }) => cb(null, result))
+      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+  },
+}));
+
+import { getWorktreeRoot, getWorktreeKey } from "./worktree.mts";
+
+beforeEach(() => {
+  mockExecFile.mockReset();
+});
+
+describe("getWorktreeRoot", () => {
+  it("returns trimmed stdout from git rev-parse --show-toplevel", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "/path/to/my-repo\n", stderr: "" });
+    expect(await getWorktreeRoot()).toBe("/path/to/my-repo");
+  });
+
+  it("throws when not in a git repo", async () => {
+    mockExecFile.mockRejectedValue(new Error("not a git repo"));
+    await expect(getWorktreeRoot()).rejects.toThrow("not a git repo");
+  });
+});
+
+describe("getWorktreeKey", () => {
+  it("returns <basename>-<sha8> for a safe basename", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "/path/to/my-repo\n", stderr: "" });
+    const sha8 = createHash("sha256").update("/path/to/my-repo").digest("hex").slice(0, 8);
+    expect(await getWorktreeKey()).toBe(`my-repo-${sha8}`);
+  });
+
+  it("falls back to sha8-only for unsafe basenames (contains spaces)", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "/path/to/my repo\n", stderr: "" });
+    const sha8 = createHash("sha256").update("/path/to/my repo").digest("hex").slice(0, 8);
+    expect(await getWorktreeKey()).toBe(sha8);
+  });
+
+  it("produces the same key for the same path on repeated calls", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "/path/to/my-repo\n", stderr: "" });
+    const key1 = await getWorktreeKey();
+    const key2 = await getWorktreeKey();
+    expect(key1).toBe(key2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an append-only markdown log file per worktree that records every CLI invocation: CLI command, all GraphQL/REST requests + responses (auth stripped), and full stdout output — each entry with an ISO-8601 millisecond timestamp
- `restText` responses (CI check logs, large blobs) log metadata only (status · content-length), never the body
- New `pr-shepherd log-file` subcommand prints the log path (`--format=json` supported)
- Extracts `resolveStateBase()` helper, eliminating a 4-site duplication

**Log path:** `$PR_SHEPHERD_STATE_DIR/<owner>-<repo>/worktrees/<basename>-<sha8>.md`  
**Disable:** `PR_SHEPHERD_LOG_DISABLED=1` or `CI=true`

## Test plan

- [ ] `npx pr-shepherd log-file` prints a path matching `…/worktrees/<name>-<sha8>.md`
- [ ] `npx pr-shepherd log-file --format=json` emits `{"path":"…"}`
- [ ] Run any other subcommand; open the log file — verify session header, numbered GraphQL entries with timestamps, and stdout output section
- [ ] Run twice in sequence — second invocation appends (no truncation)
- [ ] `PR_SHEPHERD_LOG_DISABLED=1 npx pr-shepherd check` — no log file created
- [ ] `grep -i 'authorization\|bearer' <logfile>` returns nothing
- [ ] `npm test` — 767 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)