### PR TITLE
perf: eliminate REST calls for read paths, batch status queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,16 @@ Running `npm install` also updates the `~/.claude/plugins/marketplaces/local/plu
 
 `--format=json` and `--format=text` (default) must surface equivalent information. Every field exposed in JSON output should have a corresponding representation in text output, and vice versa. Do not add data to one format without updating the other.
 
+## GitHub API
+
+All GitHub I/O uses GraphQL by default. The only permitted REST call sites are:
+
+- **Actions jobs/logs** (`src/checks/triage.mts`) — GitHub's GraphQL schema does not expose job-level data or log downloads.
+- **Cancel workflow run** (`src/commands/iterate/helpers.mts`) — no `cancelWorkflowRun` GraphQL mutation exists.
+- **`getMergeableState` fallback** (`src/github/client.mts`) — REST `GET /pulls/{n}` triggers GitHub's lazy mergeability computation when GraphQL returns `UNKNOWN`.
+
+Any new `rest()` call outside these three cases must be justified against this list. GraphQL is preferred for all read paths; mutations that GitHub exposes via GraphQL must use GraphQL.
+
 ## Dogfooding
 
 During development, run the CLI from this repository root with `npx pr-shepherd` (after `npm install && npm run build`).

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -58,6 +58,8 @@ function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "abc123",
+    headRefName: "feature",
+    headRepoWithOwner: "owner/repo",
     baseRefName: "main",
     reviewRequests: [],
     latestReviews: [],

--- a/src/commands/commit-suggestion.apply.mock.test.mts
+++ b/src/commands/commit-suggestion.apply.mock.test.mts
@@ -149,7 +149,7 @@ function setupHappyPath(): void {
 describe("runCommitSuggestion — successful apply", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     setupHappyPath();
   });
 
@@ -273,7 +273,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — dry-run", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockReadFile as any).mockResolvedValue(FILE_CONTENT);
@@ -371,7 +371,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — git apply rollback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockReadFile as any).mockResolvedValue(FILE_CONTENT);

--- a/src/commands/commit-suggestion.apply.mock.test.mts
+++ b/src/commands/commit-suggestion.apply.mock.test.mts
@@ -33,9 +33,6 @@ vi.mock("node:fs/promises", () => ({
 vi.mock("../github/client.mts", () => ({
   getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
   getCurrentPrNumber: vi.fn().mockResolvedValue(42 as number | null),
-  getPrHead: vi
-    .fn()
-    .mockResolvedValue({ sha: "headsha", ref: "feature/foo", repoWithOwner: "owner/repo" }),
   getCurrentBranch: vi.fn().mockResolvedValue("feature/foo"),
 }));
 
@@ -53,13 +50,12 @@ vi.mock("../comments/resolve.mts", () => ({
 }));
 
 import { runCommitSuggestion } from "./commit-suggestion.mts";
-import { getPrHead, getCurrentBranch } from "../github/client.mts";
+import { getCurrentBranch } from "../github/client.mts";
 import { fetchPrBatch } from "../github/batch.mts";
 import { applyResolveOptions } from "../comments/resolve.mts";
 import { readFile, unlink } from "node:fs/promises";
 import type { ReviewThread, BatchPrData } from "../types.mts";
 
-const mockGetPrHead = vi.mocked(getPrHead);
 const mockGetCurrentBranch = vi.mocked(getCurrentBranch);
 const mockFetchBatch = vi.mocked(fetchPrBatch);
 const mockApplyResolveOptions = vi.mocked(applyResolveOptions);
@@ -97,6 +93,8 @@ function makeBatch(threads: ReviewThread[]): BatchPrData {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "headsha",
+    headRefName: "feature/foo",
+    headRepoWithOwner: "owner/repo",
     baseRefName: "main",
     reviewRequests: [],
     latestReviews: [],
@@ -151,12 +149,7 @@ function setupHappyPath(): void {
 describe("runCommitSuggestion — successful apply", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     setupHappyPath();
   });
 
@@ -280,12 +273,7 @@ describe("runCommitSuggestion — successful apply", () => {
 describe("runCommitSuggestion — dry-run", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockReadFile as any).mockResolvedValue(FILE_CONTENT);
@@ -383,12 +371,7 @@ describe("runCommitSuggestion — dry-run", () => {
 describe("runCommitSuggestion — git apply rollback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockReadFile as any).mockResolvedValue(FILE_CONTENT);

--- a/src/commands/commit-suggestion.mock.test.mts
+++ b/src/commands/commit-suggestion.mock.test.mts
@@ -149,7 +149,7 @@ function setupHappyPath(): void {
 describe("runCommitSuggestion — validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     mockExecFile.mockImplementation(() => makeGitSuccess(""));
   });
@@ -180,7 +180,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — preflight", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
   });
 
@@ -229,7 +229,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — thread classification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockExecFile.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "rev-parse") return makeGitSuccess("headsha\n");
       return makeGitSuccess("");
@@ -308,7 +308,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — file read failure", () => {
   it("propagates the underlying readFile error when file cannot be read", async () => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     mockExecFile.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "rev-parse") return makeGitSuccess("headsha\n");
@@ -326,7 +326,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 
   it("propagates a non-Error rejection from readFile", async () => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     mockExecFile.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "rev-parse") return makeGitSuccess("headsha\n");
@@ -344,7 +344,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — patch failure", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockReadFile as any).mockResolvedValue(FILE_CONTENT);
@@ -438,7 +438,7 @@ mockGetCurrentBranch.mockResolvedValue("feature/foo");
 describe("runCommitSuggestion — resolve failure", () => {
   it("returns applied:true with error in postActionInstruction when resolve fails after commit", async () => {
     vi.clearAllMocks();
-mockGetCurrentBranch.mockResolvedValue("feature/foo");
+    mockGetCurrentBranch.mockResolvedValue("feature/foo");
     setupHappyPath();
     mockApplyResolveOptions.mockResolvedValue({
       resolvedThreads: [],

--- a/src/commands/commit-suggestion.mock.test.mts
+++ b/src/commands/commit-suggestion.mock.test.mts
@@ -33,9 +33,6 @@ vi.mock("node:fs/promises", () => ({
 vi.mock("../github/client.mts", () => ({
   getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
   getCurrentPrNumber: vi.fn().mockResolvedValue(42 as number | null),
-  getPrHead: vi
-    .fn()
-    .mockResolvedValue({ sha: "headsha", ref: "feature/foo", repoWithOwner: "owner/repo" }),
   getCurrentBranch: vi.fn().mockResolvedValue("feature/foo"),
 }));
 
@@ -53,13 +50,12 @@ vi.mock("../comments/resolve.mts", () => ({
 }));
 
 import { runCommitSuggestion } from "./commit-suggestion.mts";
-import { getPrHead, getCurrentBranch, getCurrentPrNumber } from "../github/client.mts";
+import { getCurrentBranch, getCurrentPrNumber } from "../github/client.mts";
 import { fetchPrBatch } from "../github/batch.mts";
 import { applyResolveOptions } from "../comments/resolve.mts";
 import { readFile } from "node:fs/promises";
 import type { ReviewThread, BatchPrData } from "../types.mts";
 
-const mockGetPrHead = vi.mocked(getPrHead);
 const mockGetCurrentBranch = vi.mocked(getCurrentBranch);
 const mockGetCurrentPrNumber = vi.mocked(getCurrentPrNumber);
 const mockFetchBatch = vi.mocked(fetchPrBatch);
@@ -97,6 +93,8 @@ function makeBatch(threads: ReviewThread[]): BatchPrData {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "headsha",
+    headRefName: "feature/foo",
+    headRepoWithOwner: "owner/repo",
     baseRefName: "main",
     reviewRequests: [],
     latestReviews: [],
@@ -151,12 +149,7 @@ function setupHappyPath(): void {
 describe("runCommitSuggestion — validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     mockExecFile.mockImplementation(() => makeGitSuccess(""));
   });
@@ -187,12 +180,7 @@ describe("runCommitSuggestion — validation", () => {
 describe("runCommitSuggestion — preflight", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
   });
 
@@ -241,12 +229,7 @@ describe("runCommitSuggestion — preflight", () => {
 describe("runCommitSuggestion — thread classification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockExecFile.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "rev-parse") return makeGitSuccess("headsha\n");
       return makeGitSuccess("");
@@ -325,12 +308,7 @@ describe("runCommitSuggestion — thread classification", () => {
 describe("runCommitSuggestion — file read failure", () => {
   it("propagates the underlying readFile error when file cannot be read", async () => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     mockExecFile.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "rev-parse") return makeGitSuccess("headsha\n");
@@ -348,12 +326,7 @@ describe("runCommitSuggestion — file read failure", () => {
 
   it("propagates a non-Error rejection from readFile", async () => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     mockExecFile.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "rev-parse") return makeGitSuccess("headsha\n");
@@ -371,12 +344,7 @@ describe("runCommitSuggestion — file read failure", () => {
 describe("runCommitSuggestion — patch failure", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     mockFetchBatch.mockResolvedValue({ data: makeBatch([makeThread()]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockReadFile as any).mockResolvedValue(FILE_CONTENT);
@@ -470,12 +438,7 @@ describe("runCommitSuggestion — patch failure", () => {
 describe("runCommitSuggestion — resolve failure", () => {
   it("returns applied:true with error in postActionInstruction when resolve fails after commit", async () => {
     vi.clearAllMocks();
-    mockGetPrHead.mockResolvedValue({
-      sha: "headsha",
-      ref: "feature/foo",
-      repoWithOwner: "owner/repo",
-    });
-    mockGetCurrentBranch.mockResolvedValue("feature/foo");
+mockGetCurrentBranch.mockResolvedValue("feature/foo");
     setupHappyPath();
     mockApplyResolveOptions.mockResolvedValue({
       resolvedThreads: [],

--- a/src/commands/commit-suggestion.mock.test.mts
+++ b/src/commands/commit-suggestion.mock.test.mts
@@ -83,7 +83,10 @@ function makeThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
   };
 }
 
-function makeBatch(threads: ReviewThread[]): BatchPrData {
+function makeBatch(
+  threads: ReviewThread[],
+  headRepoWithOwner: string | null = "owner/repo",
+): BatchPrData {
   return {
     nodeId: "PR_kgDOAAA",
     number: 42,
@@ -94,7 +97,7 @@ function makeBatch(threads: ReviewThread[]): BatchPrData {
     reviewDecision: "APPROVED",
     headRefOid: "headsha",
     headRefName: "feature/foo",
-    headRepoWithOwner: "owner/repo",
+    headRepoWithOwner,
     baseRefName: "main",
     reviewRequests: [],
     latestReviews: [],
@@ -219,6 +222,16 @@ describe("runCommitSuggestion — preflight", () => {
     await expect(
       runCommitSuggestion({ ...GLOBAL_OPTS, threadId: "PRRT_x", message: "fix" }),
     ).rejects.toThrow("does not match PR head headsha");
+  });
+
+  it("throws when head repository is unavailable (deleted fork)", async () => {
+    mockFetchBatch.mockResolvedValue({
+      data: makeBatch([makeThread()], null),
+    });
+    mockExecFile.mockImplementation(() => makeGitSuccess(""));
+    await expect(
+      runCommitSuggestion({ ...GLOBAL_OPTS, threadId: "PRRT_x", message: "fix" }),
+    ).rejects.toThrow("head repository is unavailable");
   });
 });
 

--- a/src/commands/commit-suggestion.mts
+++ b/src/commands/commit-suggestion.mts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
-import { getRepoInfo, getCurrentPrNumber, getPrHead, getCurrentBranch } from "../github/client.mts";
+import { getRepoInfo, getCurrentPrNumber, getCurrentBranch } from "../github/client.mts";
 import { fetchPrBatch } from "../github/batch.mts";
 import { applyResolveOptions } from "../comments/resolve.mts";
 import { parseSuggestion, isCommittableSuggestion } from "../suggestions/parse.mts";
@@ -43,24 +43,26 @@ export async function runCommitSuggestion(
     throw new Error("No open PR found for current branch. Pass a PR number explicitly.");
   }
 
-  const head = await getPrHead(prNumber, repo.owner, repo.name);
   const currentBranch = await getCurrentBranch();
-  if (currentBranch !== head.ref) {
-    throw new Error(
-      `Current branch "${currentBranch}" does not match PR head branch "${head.ref}". ` +
-        `Check out "${head.ref}" before applying suggestions.`,
-    );
-  }
-
   const { stdout: localHeadOut } = await execFile("git", ["rev-parse", "HEAD"]);
   const localHeadSha = localHeadOut.trim();
-  if (localHeadSha !== head.sha) {
+
+  const { data } = await fetchPrBatch(prNumber, repo);
+  if (!data.headRepoWithOwner) {
+    throw new Error(`PR #${prNumber} head repository is unavailable (fork may have been deleted).`);
+  }
+  if (currentBranch !== data.headRefName) {
     throw new Error(
-      `Local HEAD ${localHeadSha} does not match PR head ${head.sha}. ` +
-        `Pull/rebase "${head.ref}" to the latest PR head and try again.`,
+      `Current branch "${currentBranch}" does not match PR head branch "${data.headRefName}". ` +
+        `Check out "${data.headRefName}" before applying suggestions.`,
     );
   }
-  const { data } = await fetchPrBatch(prNumber, repo);
+  if (localHeadSha !== data.headRefOid) {
+    throw new Error(
+      `Local HEAD ${localHeadSha} does not match PR head ${data.headRefOid}. ` +
+        `Pull/rebase "${data.headRefName}" to the latest PR head and try again.`,
+    );
+  }
   const thread = data.reviewThreads.find((t) => t.id === opts.threadId);
   if (!thread) {
     throw new Error(`Thread ${opts.threadId} not found on PR #${prNumber}.`);
@@ -92,9 +94,7 @@ export async function runCommitSuggestion(
   const startLine = thread.startLine ?? thread.line;
   const endLine = thread.line;
   const filePath = thread.path;
-
   const originalContent = await readFile(filePath, "utf8");
-
   const patch = buildUnifiedDiff({
     path: filePath,
     originalContent,

--- a/src/commands/resolve.mock.test.mts
+++ b/src/commands/resolve.mock.test.mts
@@ -61,6 +61,8 @@ function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "abc123",
+    headRefName: "feature",
+    headRepoWithOwner: "owner/repo",
     baseRefName: "main",
     reviewRequests: [],
     latestReviews: [],

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -64,7 +64,7 @@ export async function runStatus(opts: StatusCommandOptions): Promise<PrSummary[]
 // ---------------------------------------------------------------------------
 
 function buildBatchStatusQuery(prNumbers: number[]): string {
-  const uniquePrs = [...new Set(prNumbers)];
+  const uniquePrs = [...new Set(prNumbers.filter((n) => n > 0))];
   const f =
     "number title state isDraft mergeStateStatus reviewDecision " +
     "reviewThreads(last:100){totalCount pageInfo{hasPreviousPage startCursor} nodes{isResolved}} " +

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -64,11 +64,12 @@ export async function runStatus(opts: StatusCommandOptions): Promise<PrSummary[]
 // ---------------------------------------------------------------------------
 
 function buildBatchStatusQuery(prNumbers: number[]): string {
+  const uniquePrs = [...new Set(prNumbers)];
   const f =
     "number title state isDraft mergeStateStatus reviewDecision " +
     "reviewThreads(last:100){totalCount pageInfo{hasPreviousPage startCursor} nodes{isResolved}} " +
     "commits(last:1){nodes{commit{statusCheckRollup{state}}}}";
-  const aliases = prNumbers.map((n) => `pr_${n}:pullRequest(number:${n}){${f}}`).join(" ");
+  const aliases = uniquePrs.map((n) => `pr_${n}:pullRequest(number:${n}){${f}}`).join(" ");
   return `query MultiPrStatusBatch($owner:String!,$repo:String!){repository(owner:$owner,name:$repo){${aliases}}}`;
 }
 

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -2,14 +2,15 @@
  * `shepherd status PR1 [PR2 PR3 …]`
  *
  * Fetches readiness status for one or more PRs and prints a table.
- * Uses a separate lightweight GraphQL query (MULTI_PR_STATUS_QUERY) per PR
- * rather than the heavy batch query, since we only need summary data.
+ * Issues a single GraphQL request with one alias per PR number rather than
+ * N separate requests, so the round-trip count is always 1 (plus optional
+ * per-PR pagination calls when a PR has > 100 review threads).
  *
  * Exit code: 0 if all PRs are READY, non-zero otherwise.
  */
 
 import { graphql, getRepoInfo } from "../github/client.mts";
-import { MULTI_PR_STATUS_QUERY, MULTI_PR_STATUS_QUERY_WITH_CURSOR } from "../github/queries.mts";
+import { MULTI_PR_STATUS_QUERY_WITH_CURSOR } from "../github/queries.mts";
 import type { GlobalOptions } from "../types.mts";
 
 // ---------------------------------------------------------------------------
@@ -37,9 +38,23 @@ export interface StatusCommandOptions extends GlobalOptions {
 }
 
 export async function runStatus(opts: StatusCommandOptions): Promise<PrSummary[]> {
+  if (opts.prNumbers.length === 0) return [];
+
   const repo = await getRepoInfo();
+  const doc = buildBatchStatusQuery(opts.prNumbers);
+  const result = await graphql<{ repository: Record<string, RawPrStatus | null> }>(doc, {
+    owner: repo.owner,
+    repo: repo.name,
+  });
+
   const summaries = await Promise.all(
-    opts.prNumbers.map((pr) => fetchSummary(pr, repo.owner, repo.name)),
+    opts.prNumbers.map((pr) => {
+      const rawPr = result.data.repository[`pr_${pr}`];
+      if (!rawPr) {
+        throw new Error(`PR #${pr} not found in ${repo.owner}/${repo.name}`);
+      }
+      return paginateAndBuild(pr, rawPr, repo.owner, repo.name);
+    }),
   );
   return summaries;
 }
@@ -48,23 +63,24 @@ export async function runStatus(opts: StatusCommandOptions): Promise<PrSummary[]
 // Internal
 // ---------------------------------------------------------------------------
 
-async function fetchSummary(pr: number, owner: string, repo: string): Promise<PrSummary> {
-  const result = await graphql<RawStatusResponse>(MULTI_PR_STATUS_QUERY, {
-    owner,
-    repo,
-    pr,
-  });
+function buildBatchStatusQuery(prNumbers: number[]): string {
+  const f =
+    "number title state isDraft mergeStateStatus reviewDecision " +
+    "reviewThreads(last:100){totalCount pageInfo{hasPreviousPage startCursor} nodes{isResolved}} " +
+    "commits(last:1){nodes{commit{statusCheckRollup{state}}}}";
+  const aliases = prNumbers.map((n) => `pr_${n}:pullRequest(number:${n}){${f}}`).join(" ");
+  return `query MultiPrStatusBatch($owner:String!,$repo:String!){repository(owner:$owner,name:$repo){${aliases}}}`;
+}
 
-  const p = result.data.repository.pullRequest;
-  if (!p) {
-    throw new Error(`PR #${pr} not found in ${owner}/${repo}`);
-  }
-
+async function paginateAndBuild(
+  pr: number,
+  p: RawPrStatus,
+  owner: string,
+  repo: string,
+): Promise<PrSummary> {
   let allNodes = p.reviewThreads.nodes;
 
-  // If the response was truncated, fetch additional pages to get the full count.
   if (p.reviewThreads.totalCount > p.reviewThreads.nodes.length) {
-    // Fetch additional pages backward until we have all threads.
     const MAX_THREAD_PAGES = 10;
     let pagesFetched = 0;
     const totalCount = p.reviewThreads.totalCount;
@@ -77,7 +93,7 @@ async function fetchSummary(pr: number, owner: string, repo: string): Promise<Pr
         break;
       }
       // eslint-disable-next-line no-await-in-loop
-      const extra = await graphql<RawStatusResponse>(MULTI_PR_STATUS_QUERY_WITH_CURSOR, {
+      const extra = await graphql<RawPagedResponse>(MULTI_PR_STATUS_QUERY_WITH_CURSOR, {
         owner,
         repo,
         pr,
@@ -95,7 +111,6 @@ async function fetchSummary(pr: number, owner: string, repo: string): Promise<Pr
 
   const unresolvedThreads = allNodes.filter((n) => !n.isResolved).length;
   const ciState = p.commits.nodes[0]?.commit.statusCheckRollup?.state ?? null;
-  // If we still have fewer nodes than totalCount, report truncation.
   const threadsTruncated = p.reviewThreads.totalCount > allNodes.length;
 
   return {
@@ -156,27 +171,29 @@ export function deriveVerdict(s: PrSummary): string {
 // Raw GraphQL types
 // ---------------------------------------------------------------------------
 
-interface RawStatusResponse {
+interface RawPrStatus {
+  number: number;
+  title: string;
+  state: string;
+  isDraft: boolean;
+  mergeStateStatus: string;
+  reviewDecision: string | null;
+  reviewThreads: {
+    totalCount: number;
+    pageInfo?: { hasPreviousPage: boolean; startCursor: string | null };
+    nodes: Array<{ isResolved: boolean }>;
+  };
+  commits: {
+    nodes: Array<{
+      commit: {
+        statusCheckRollup: { state: string } | null;
+      };
+    }>;
+  };
+}
+
+interface RawPagedResponse {
   repository: {
-    pullRequest: {
-      number: number;
-      title: string;
-      state: string;
-      isDraft: boolean;
-      mergeStateStatus: string;
-      reviewDecision: string | null;
-      reviewThreads: {
-        totalCount: number;
-        pageInfo?: { hasPreviousPage: boolean; startCursor: string | null };
-        nodes: Array<{ isResolved: boolean }>;
-      };
-      commits: {
-        nodes: Array<{
-          commit: {
-            statusCheckRollup: { state: string } | null;
-          };
-        }>;
-      };
-    } | null;
+    pullRequest: RawPrStatus | null;
   };
 }

--- a/src/commands/status.test.mts
+++ b/src/commands/status.test.mts
@@ -33,40 +33,56 @@ function makeSummary(overrides: Partial<PrSummary> = {}): PrSummary {
   };
 }
 
-function makeRawResponse(
-  pr: Partial<{
-    number: number;
-    title: string;
-    state: string;
-    isDraft: boolean;
-    mergeStateStatus: string;
-    reviewDecision: string | null;
+type RawPrOverrides = Partial<{
+  number: number;
+  title: string;
+  state: string;
+  isDraft: boolean;
+  mergeStateStatus: string;
+  reviewDecision: string | null;
+  reviewThreads: {
+    totalCount: number;
+    pageInfo?: { hasPreviousPage: boolean; startCursor: string | null };
+    nodes: Array<{ isResolved: boolean }>;
+  };
+  commits: { nodes: Array<{ commit: { statusCheckRollup: { state: string } | null } }> };
+}>;
+
+function makeRawPr(overrides: RawPrOverrides = {}) {
+  return {
+    number: 42,
+    title: "Fix bug",
+    state: "OPEN",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    reviewDecision: "APPROVED",
     reviewThreads: {
-      totalCount: number;
-      pageInfo?: { hasPreviousPage: boolean; startCursor: string | null };
-      nodes: Array<{ isResolved: boolean }>;
-    };
-    commits: { nodes: Array<{ commit: { statusCheckRollup: { state: string } | null } }> };
-  }> = {},
-) {
+      totalCount: 0,
+      pageInfo: { hasPreviousPage: false, startCursor: null },
+      nodes: [],
+    },
+    commits: { nodes: [{ commit: { statusCheckRollup: { state: "SUCCESS" } } }] },
+    ...overrides,
+  };
+}
+
+/** Wraps a single PR in the batched alias format used by runStatus. */
+function makeBatchResponse(prNumber: number, overrides: RawPrOverrides = {}) {
   return {
     data: {
       repository: {
-        pullRequest: {
-          number: 42,
-          title: "Fix bug",
-          state: "OPEN",
-          isDraft: false,
-          mergeStateStatus: "CLEAN",
-          reviewDecision: "APPROVED",
-          reviewThreads: {
-            totalCount: 0,
-            pageInfo: { hasPreviousPage: false, startCursor: null },
-            nodes: [],
-          },
-          commits: { nodes: [{ commit: { statusCheckRollup: { state: "SUCCESS" } } }] },
-          ...pr,
-        },
+        [`pr_${prNumber}`]: makeRawPr({ number: prNumber, ...overrides }),
+      },
+    },
+  };
+}
+
+/** Wraps a single PR in the pullRequest format used by the paged follow-up query. */
+function makePagedResponse(overrides: RawPrOverrides = {}) {
+  return {
+    data: {
+      repository: {
+        pullRequest: makeRawPr(overrides),
       },
     },
   };
@@ -151,8 +167,8 @@ describe("formatStatusTable — formatting", () => {
 // ---------------------------------------------------------------------------
 
 describe("runStatus — PR not found", () => {
-  it("throws when pullRequest is null", async () => {
-    mockGraphql.mockResolvedValue({ data: { repository: { pullRequest: null } } });
+  it("throws when PR alias is null", async () => {
+    mockGraphql.mockResolvedValue({ data: { repository: { pr_99: null } } });
     await expect(runStatus({ prNumbers: [99], format: "text" })).rejects.toThrow(
       "PR #99 not found",
     );
@@ -161,10 +177,10 @@ describe("runStatus — PR not found", () => {
 
 describe("runStatus — pagination", () => {
   it("fetches additional pages when totalCount > nodes.length", async () => {
-    // First call: 1 node but totalCount=2
+    // First call: batched query, 1 node but totalCount=2
     mockGraphql
       .mockResolvedValueOnce(
-        makeRawResponse({
+        makeBatchResponse(42, {
           reviewThreads: {
             totalCount: 2,
             pageInfo: { hasPreviousPage: true, startCursor: "cursor-abc" },
@@ -172,9 +188,9 @@ describe("runStatus — pagination", () => {
           },
         }),
       )
-      // Second call (pagination): 1 more unresolved node
+      // Second call (per-PR pagination using MULTI_PR_STATUS_QUERY_WITH_CURSOR)
       .mockResolvedValueOnce(
-        makeRawResponse({
+        makePagedResponse({
           reviewThreads: {
             totalCount: 2,
             pageInfo: { hasPreviousPage: false, startCursor: null },
@@ -194,7 +210,7 @@ describe("runStatus — pagination", () => {
   it("sets threadsTruncated when totalCount still exceeds collected nodes", async () => {
     // First page: 1 node, totalCount=5, no more pages
     mockGraphql.mockResolvedValueOnce(
-      makeRawResponse({
+      makeBatchResponse(42, {
         reviewThreads: {
           totalCount: 5,
           pageInfo: { hasPreviousPage: false, startCursor: null },

--- a/src/commands/status.test.mts
+++ b/src/commands/status.test.mts
@@ -166,6 +166,34 @@ describe("formatStatusTable — formatting", () => {
 // runStatus
 // ---------------------------------------------------------------------------
 
+describe("runStatus — empty input", () => {
+  it("returns empty array when prNumbers is empty", async () => {
+    const result = await runStatus({ prNumbers: [], format: "text" });
+    expect(result).toEqual([]);
+    expect(mockGraphql).not.toHaveBeenCalled();
+  });
+});
+
+describe("runStatus — multi-PR batch", () => {
+  it("fetches multiple PRs in a single request", async () => {
+    mockGraphql.mockResolvedValueOnce({
+      data: {
+        repository: {
+          pr_10: makeRawPr({ number: 10, title: "PR ten", state: "OPEN" }),
+          pr_20: makeRawPr({ number: 20, title: "PR twenty", state: "MERGED" }),
+        },
+      },
+    });
+
+    const summaries = await runStatus({ prNumbers: [10, 20], format: "text" });
+    expect(mockGraphql).toHaveBeenCalledTimes(1);
+    expect(summaries).toHaveLength(2);
+    expect(summaries[0]!.number).toBe(10);
+    expect(summaries[1]!.number).toBe(20);
+    expect(summaries[1]!.state).toBe("MERGED");
+  });
+});
+
 describe("runStatus — PR not found", () => {
   it("throws when PR alias is null", async () => {
     mockGraphql.mockResolvedValue({ data: { repository: { pr_99: null } } });

--- a/src/github/batch-parsers.mock.test.mts
+++ b/src/github/batch-parsers.mock.test.mts
@@ -27,6 +27,8 @@ function makeRawPr(overrides: Record<string, unknown> = {}) {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "abc123",
+    headRefName: "feature",
+    headRepository: { nameWithOwner: "owner/repo" },
     baseRefName: "main",
     reviewRequests: { nodes: [] },
     latestReviews: { nodes: [] },

--- a/src/github/batch-parsers.mock.test.mts
+++ b/src/github/batch-parsers.mock.test.mts
@@ -479,4 +479,18 @@ describe("fetchPrBatch — null author fallbacks", () => {
     const { data } = await fetchPrBatch(42, REPO);
     expect(data.reviewDecision).toBeNull();
   });
+
+  it("maps headRepository: null to headRepoWithOwner: null (deleted fork)", async () => {
+    const pr = makeRawPr({ headRepository: null });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.headRepoWithOwner).toBeNull();
+  });
+
+  it("maps headRepository.nameWithOwner to headRepoWithOwner", async () => {
+    const pr = makeRawPr({ headRepository: { nameWithOwner: "contributor/fork" } });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.headRepoWithOwner).toBe("contributor/fork");
+  });
 });

--- a/src/github/batch-parsers.mts
+++ b/src/github/batch-parsers.mts
@@ -130,6 +130,8 @@ export function parseRawPr(
     mergeStateStatus: raw.mergeStateStatus as BatchPrData["mergeStateStatus"],
     reviewDecision: (raw.reviewDecision ?? null) as BatchPrData["reviewDecision"],
     headRefOid: raw.headRefOid,
+    headRefName: raw.headRefName,
+    headRepoWithOwner: raw.headRepository?.nameWithOwner ?? null,
     baseRefName: raw.baseRefName,
     reviewRequests,
     latestReviews,

--- a/src/github/batch-parsers.summary.mock.test.mts
+++ b/src/github/batch-parsers.summary.mock.test.mts
@@ -23,6 +23,8 @@ function makeRawPr(overrides: Record<string, unknown> = {}) {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "abc123",
+    headRefName: "feature",
+    headRepository: { nameWithOwner: "owner/repo" },
     baseRefName: "main",
     reviewRequests: { nodes: [] },
     latestReviews: { nodes: [] },

--- a/src/github/batch-raw-types.mts
+++ b/src/github/batch-raw-types.mts
@@ -15,6 +15,8 @@ export interface RawPr {
   mergeStateStatus: string;
   reviewDecision: string | null;
   headRefOid: string;
+  headRefName: string;
+  headRepository: { nameWithOwner: string } | null;
   baseRefName: string;
   reviewRequests: {
     nodes: Array<{

--- a/src/github/batch.mock.test.mts
+++ b/src/github/batch.mock.test.mts
@@ -27,6 +27,8 @@ function makeRawPr(overrides: Record<string, unknown> = {}) {
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
     headRefOid: "abc123",
+    headRefName: "feature",
+    headRepository: { nameWithOwner: "owner/repo" },
     baseRefName: "main",
     reviewRequests: { nodes: [] },
     latestReviews: { nodes: [] },

--- a/src/github/client.mock.test.mts
+++ b/src/github/client.mock.test.mts
@@ -290,4 +290,3 @@ describe("getPrHeadSha", () => {
     await expect(getPrHeadSha(42, "owner", "repo")).rejects.toThrow("headRefOid missing");
   });
 });
-

--- a/src/github/client.mock.test.mts
+++ b/src/github/client.mock.test.mts
@@ -31,8 +31,6 @@ import {
   graphqlWithRateLimit,
   getCurrentPrNumber,
   getMergeableState,
-  getPrHead,
-  getFileContents,
   getPrHeadSha,
   getRepoInfo,
 } from "./client.mts";
@@ -293,92 +291,3 @@ describe("getPrHeadSha", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// getPrHead
-// ---------------------------------------------------------------------------
-
-describe("getPrHead", () => {
-  it("returns sha, ref, and repoWithOwner from REST response", async () => {
-    mockFetch.mockResolvedValue(
-      restOk({
-        head: {
-          sha: "abc123",
-          ref: "feature-branch",
-          repo: { full_name: "owner/repo" },
-        },
-      }),
-    );
-    const result = await getPrHead(42, "owner", "repo");
-    expect(result).toEqual({
-      sha: "abc123",
-      ref: "feature-branch",
-      repoWithOwner: "owner/repo",
-    });
-  });
-
-  it("returns the fork's full_name for cross-fork PRs", async () => {
-    mockFetch.mockResolvedValue(
-      restOk({
-        head: {
-          sha: "abc123",
-          ref: "contributor-branch",
-          repo: { full_name: "contributor/fork" },
-        },
-      }),
-    );
-    const result = await getPrHead(42, "owner", "repo");
-    expect(result.repoWithOwner).toBe("contributor/fork");
-  });
-
-  it("throws when head.repo is null (deleted fork)", async () => {
-    mockFetch.mockResolvedValue(restOk({ head: { sha: "abc123", ref: "whatever", repo: null } }));
-    await expect(getPrHead(42, "owner", "repo")).rejects.toThrow(/head repository is unavailable/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// getFileContents
-// ---------------------------------------------------------------------------
-
-describe("getFileContents", () => {
-  it("decodes base64-encoded file content", async () => {
-    const content = "line one\nline two\n";
-    const encoded = Buffer.from(content, "utf8").toString("base64");
-    mockFetch.mockResolvedValue(restOk({ content: encoded, encoding: "base64" }));
-    const result = await getFileContents("owner/repo", "src/foo.ts", "abc123");
-    expect(result).toBe(content);
-  });
-
-  it("percent-encodes path segments but preserves slashes", async () => {
-    const content = "ok";
-    mockFetch.mockResolvedValue(
-      restOk({ content: Buffer.from(content).toString("base64"), encoding: "base64" }),
-    );
-    await getFileContents("owner/repo", "src/needs encoding/foo.ts", "main");
-    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/contents/src/needs%20encoding/foo.ts?ref=main");
-  });
-
-  it("percent-encodes the ref (branch names with slashes, hash characters)", async () => {
-    mockFetch.mockResolvedValue(
-      restOk({ content: Buffer.from("x").toString("base64"), encoding: "base64" }),
-    );
-    await getFileContents("owner/repo", "a.ts", "refs/heads/feature");
-    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("?ref=refs%2Fheads%2Ffeature");
-  });
-
-  it("throws when the response is missing base64 content", async () => {
-    mockFetch.mockResolvedValue(restOk({ encoding: "none" }));
-    await expect(getFileContents("owner/repo", "a.ts", "main")).rejects.toThrow(
-      /could not be read as text/,
-    );
-  });
-
-  it("throws when encoding is not base64", async () => {
-    mockFetch.mockResolvedValue(restOk({ content: "raw text", encoding: "utf8" }));
-    await expect(getFileContents("owner/repo", "a.ts", "main")).rejects.toThrow(
-      /could not be read as text/,
-    );
-  });
-});

--- a/src/github/client.mts
+++ b/src/github/client.mts
@@ -76,56 +76,6 @@ export async function getPrHeadSha(pr: number, owner: string, name: string): Pro
   return sha;
 }
 
-export interface PrHeadInfo {
-  sha: string;
-  /** Branch name on the head repository. */
-  ref: string;
-  /** `"owner/name"` of the head repository — equals the base repo for same-repo PRs, differs for fork PRs. */
-  repoWithOwner: string;
-}
-
-/**
- * Full head info for a PR — sha, branch name, and the head repository's full name.
- * Needed by commit-suggestions to target the correct branch via `createCommitOnBranch`.
- */
-export async function getPrHead(pr: number, owner: string, name: string): Promise<PrHeadInfo> {
-  const data = await rest<{
-    head: { sha: string; ref: string; repo: { full_name: string } | null };
-  }>("GET", `/repos/${owner}/${name}/pulls/${pr}`);
-  if (!data.head.repo) {
-    throw new Error(`PR #${pr} head repository is unavailable (fork may have been deleted).`);
-  }
-  return {
-    sha: data.head.sha,
-    ref: data.head.ref,
-    repoWithOwner: data.head.repo.full_name,
-  };
-}
-
-/**
- * Fetch a file's raw text content at a given ref. Uses the REST contents endpoint,
- * which returns base64 for files under 1MB. Throws for binary / oversize files.
- */
-export async function getFileContents(
-  repoWithOwner: string,
-  path: string,
-  ref: string,
-): Promise<string> {
-  const data = await rest<{ content?: string; encoding?: string; size?: number }>(
-    "GET",
-    `/repos/${repoWithOwner}/contents/${encodePathForApi(path)}?ref=${encodeURIComponent(ref)}`,
-  );
-  if (!data.content || data.encoding !== "base64") {
-    throw new Error(`File ${path} could not be read as text (encoding=${data.encoding ?? "n/a"}).`);
-  }
-  return Buffer.from(data.content, "base64").toString("utf8");
-}
-
-// Encode every path segment but preserve the slashes between them.
-function encodePathForApi(path: string): string {
-  return path.split("/").map(encodeURIComponent).join("/");
-}
-
 /**
  * Fetches `mergeable` and `mergeStateStatus` via the REST API.
  *

--- a/src/github/gql/batch-pr.gql
+++ b/src/github/gql/batch-pr.gql
@@ -19,6 +19,10 @@ query BatchPr(
       mergeStateStatus
       reviewDecision
       headRefOid
+      headRefName
+      headRepository {
+        nameWithOwner
+      }
       baseRefName
       # Not paginated — capped at 50; PRs with more pending reviewers truncate silently.
       reviewRequests(last: 50) {

--- a/src/github/queries.mts
+++ b/src/github/queries.mts
@@ -19,10 +19,7 @@ export const BATCH_PR_QUERY = gql("batch-pr.gql");
 /** Returns the current head commit SHA for a PR. Used by waitForSha polling. */
 export const GET_PR_HEAD_SHA_QUERY = gql("get-pr-head-sha.gql");
 
-/** Multi-PR status query for `shepherd status PR1 PR2 …`. */
-export const MULTI_PR_STATUS_QUERY = gql("multi-pr-status.gql");
-
-/** Paginated version — used when reviewThreads is truncated (totalCount > 100). */
+/** Paginated follow-up for `shepherd status` — used when reviewThreads is truncated (totalCount > 100). */
 export const MULTI_PR_STATUS_QUERY_WITH_CURSOR = gql("multi-pr-status-paged.gql");
 
 /** Look up PR number by branch name (for getCurrentPrNumber). */

--- a/src/github/queries.test.mts
+++ b/src/github/queries.test.mts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   BATCH_PR_QUERY,
   GET_PR_HEAD_SHA_QUERY,
-  MULTI_PR_STATUS_QUERY,
   MULTI_PR_STATUS_QUERY_WITH_CURSOR,
 } from "./queries.mts";
 
@@ -18,12 +17,6 @@ describe("queries — GQL constants load at import time", () => {
     expect(GET_PR_HEAD_SHA_QUERY.length).toBeGreaterThan(0);
     expect(GET_PR_HEAD_SHA_QUERY).toContain("query");
     expect(GET_PR_HEAD_SHA_QUERY).toContain("headRefOid");
-  });
-
-  it("MULTI_PR_STATUS_QUERY is a non-empty query string", () => {
-    expect(typeof MULTI_PR_STATUS_QUERY).toBe("string");
-    expect(MULTI_PR_STATUS_QUERY.length).toBeGreaterThan(0);
-    expect(MULTI_PR_STATUS_QUERY).toContain("query");
   });
 
   it("MULTI_PR_STATUS_QUERY_WITH_CURSOR is a non-empty query string", () => {

--- a/src/merge-status/derive.test.mts
+++ b/src/merge-status/derive.test.mts
@@ -12,6 +12,8 @@ function makePr(overrides: Partial<BatchPrData>): BatchPrData {
     mergeStateStatus: "CLEAN",
     reviewDecision: null,
     headRefOid: "abc123",
+    headRefName: "feature",
+    headRepoWithOwner: "owner/repo",
     baseRefName: "main",
     reviewRequests: [],
     latestReviews: [],

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -165,6 +165,9 @@ export interface BatchPrData {
   mergeStateStatus: MergeStateStatus;
   reviewDecision: ReviewDecision;
   headRefOid: string;
+  headRefName: string;
+  /** `"owner/name"` of the head repository; null when the fork has been deleted. */
+  headRepoWithOwner: string | null;
   baseRefName: string;
   reviewRequests: Array<{ login: string }>;
   latestReviews: Array<{ login: string; state: string }>;


### PR DESCRIPTION
## Summary

- **`getPrHead` → GraphQL**: Adds `headRefName` and `headRepository.nameWithOwner` to `BATCH_PR_QUERY`; `commit-suggestion` reads head info from the existing batch fetch instead of a separate REST `GET /pulls/{n}`. Removes one round trip per invocation.
- **Delete `getFileContents`**: No production callers existed — dead REST endpoint removed.
- **`shepherd status` → single aliased GraphQL query**: Replaces N parallel `MULTI_PR_STATUS_QUERY` calls with one document using GraphQL aliases (`pr_1: pullRequest(number: 1) {...}`). N PRs now cost 1 round trip instead of N.

After these changes, REST is confined to three inherently-REST endpoints that have no GraphQL equivalent: Actions jobs/logs, cancel workflow run, and the `getMergeableState` fallback (REST poke needed when GraphQL returns UNKNOWN). Adds a `## GitHub API` section to CLAUDE.md documenting this allowlist.

## Test plan

- [ ] All 797 existing tests pass (`npm test`)
- [ ] `npm run lint` and `npm run typecheck` clean
- [ ] Dogfood `npx pr-shepherd status <pr1> <pr2> <pr3>` — verify output matches per-PR run; debug log shows exactly **one** GraphQL POST
- [ ] Dogfood `npx pr-shepherd commit-suggestion --thread-id <id> --dry-run` — verify debug log shows **zero** REST calls (only the batch GraphQL)
- [ ] Dogfood `npx pr-shepherd check` on a PR with a failing check — Actions REST calls (jobs + logs) still present, triage output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)