### PR TITLE
feat: surface suggestion content and line ranges to agents

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -295,7 +295,7 @@ The JSON payload exposes the same data under `fix.{threads, actionableComments, 
 GitHub reviewers can leave ` ```suggestion ` fenced blocks in review thread bodies. The CLI parses these and surfaces them to the agent in two forms:
 
 - A `[suggestion]` marker on the thread heading.
-- Immediately after the blockquoted body, either a `Replaces line(s) …` block showing the parsed replacement text, or for an empty suggestion (deletion), a `Deletes line(s) …` line with no replacement fenced block.
+- Immediately after the blockquoted body, a `Replaces line(s) …` block showing the parsed replacement text. For an empty suggestion (deletion), the label is `Replaces line(s) … with nothing:` followed by an empty fenced block.
 
 The numbered `## Instructions` section tells the agent how to apply each `[suggestion]` thread.
 
@@ -310,10 +310,11 @@ The numbered `## Instructions` section tells the agent how to apply each `[sugge
 > const remainingSeconds = computeRemaining();
 > ```
 
-  Replaces line 42:
-  ```
-  const remainingSeconds = computeRemaining();
-  ```
+Replaces line 42:
+
+```
+const remainingSeconds = computeRemaining();
+```
 ````
 
 Steps: open `src/foo.ts`, replace line 42 with `const remainingSeconds = computeRemaining();`, then proceed to the commit step in `## Instructions`.
@@ -329,10 +330,11 @@ Steps: open `src/foo.ts`, replace line 42 with `const remainingSeconds = compute
 > const result = computeAll();
 > ```
 
-  Replaces lines 40–42:
-  ```
-  const result = computeAll();
-  ```
+Replaces lines 40–42:
+
+```
+const result = computeAll();
+```
 ````
 
 Replace lines 40–42 in `src/foo.ts` with the single replacement line shown in the block.
@@ -350,10 +352,11 @@ Example with two threads:
 > const remainingSeconds = computeRemaining();
 > ```
 
-  Replaces line 42:
-  ```
-  const remainingSeconds = computeRemaining();
-  ```
+Replaces line 42:
+
+```
+const remainingSeconds = computeRemaining();
+```
 
 ### `PRRT_kwDOSGizTs58XC2M` — `src/bar.ts:17` (@alice) [suggestion]
 
@@ -361,10 +364,11 @@ Example with two threads:
 > return value ?? defaultValue;
 > ```
 
-  Replaces line 17:
-  ```
-  return value ?? defaultValue;
-  ```
+Replaces line 17:
+
+```
+return value ?? defaultValue;
+```
 ````
 
 Apply both edits, then commit and push together. The `resolve:` command at the bottom of `## Post-fix push` already includes both IDs:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -249,7 +249,7 @@ AssertionError: expected true to be false
 **Section order:**
 
 1. Heading + base fields (always present).
-2. `## Review threads` — each thread under `### <id> — <loc> (@author)` with the full body as a `>` blockquote. Multi-paragraph bodies preserve empty lines as `>` lines, so code blocks and ` ```suggestion ` blocks survive intact.
+2. `## Review threads` — each thread under `### <id> — <loc> (@author) [suggestion]?` where `<loc>` is `` `path:line` `` for single-line threads or `` `path:startLine-endLine` `` for multi-line threads. The full body follows as a `>` blockquote. Multi-paragraph bodies preserve empty lines as `>` lines. Threads with a ` ```suggestion ` fence carry a `[suggestion]` tag in the heading and a `Replaces lines …` block after the body showing the parsed replacement.
 3. `## Actionable comments` — same shape as threads minus the `<loc>`.
 4. `## Failing checks` — one bullet per failing check. Shape varies by locator:
    - ``- `<runId>` — `<workflowName> › <jobName>` `` for GitHub Actions checks (`workflowName ›` prefix omitted when unavailable; `jobName` falls back to the check name when absent).
@@ -292,35 +292,50 @@ The JSON payload exposes the same data under `fix.{threads, actionableComments, 
 
 ### Applying ` ```suggestion ` blocks
 
-GitHub reviewers can leave ` ```suggestion ` fenced blocks in review thread bodies. In `iterate`'s `fix_code` output these ride verbatim inside the blockquoted thread body — there is no separate structured field. The numbered `## Instructions` explicitly say to treat any ` ```suggestion ` block as a literal line replacement at the file and line range shown in the thread heading.
+GitHub reviewers can leave ` ```suggestion ` fenced blocks in review thread bodies. The CLI parses these and surfaces them to the agent in two forms:
 
-**Single-line suggestion.** Thread locators in `[FIX_CODE]` use the end line only (e.g. `src/foo.ts:42`). When the body contains a suggestion block, replace exactly that line with the suggestion's content:
+- A `[suggestion]` marker on the thread heading.
+- A `Replaces lines …` block immediately after the blockquoted body showing the parsed replacement text.
+
+The numbered `## Instructions` section tells the agent how to apply each `[suggestion]` thread.
+
+**Single-line suggestion.** Thread headings include the end line (e.g. `src/foo.ts:42`). The `Replaces line 42:` block shows the replacement verbatim:
 
 ````markdown
-### `PRRT_kwDOSGizTs58XB1L` — `src/foo.ts:42` (@alice)
+### `PRRT_kwDOSGizTs58XB1L` — `src/foo.ts:42` (@alice) [suggestion]
 
 > Rename `x` to `remainingSeconds` so readers don't have to trace back to the declaration.
 >
 > ```suggestion
 > const remainingSeconds = computeRemaining();
 > ```
+
+  Replaces line 42:
+  ```
+  const remainingSeconds = computeRemaining();
+  ```
 ````
 
 Steps: open `src/foo.ts`, replace line 42 with `const remainingSeconds = computeRemaining();`, then proceed to the commit step in `## Instructions`.
 
-**Multi-line suggestion.** When the thread spans a range the locator shows only the end line (e.g. `src/foo.ts:42`), but the suggestion body replaces all lines from `startLine` to `line` inclusive. An empty suggestion body deletes those lines; a body of one blank line replaces the range with a single blank line.
+**Multi-line suggestion.** When the thread spans a range, the heading shows `path:startLine-endLine` (e.g. `src/foo.ts:40-42`). The `Replaces lines 40–42:` block contains the replacement that is spliced in for that entire range. An empty block means "delete those lines"; a block containing a single blank line means "replace with one blank line".
 
 ````markdown
-### `PRRT_kwDOSGizTs58XB2M` — `src/foo.ts:42` (@alice)
+### `PRRT_kwDOSGizTs58XB2M` — `src/foo.ts:40-42` (@alice) [suggestion]
 
 > Collapse these three assignments into one.
 >
 > ```suggestion
 > const result = computeAll();
 > ```
+
+  Replaces lines 40–42:
+  ```
+  const result = computeAll();
+  ```
 ````
 
-If the reviewer's thread was originally anchored to lines 40–42, you replace lines 40–42 with the single suggestion line. When the range isn't obvious from context, read the surrounding file to find which lines the comment is attached to.
+Replace lines 40–42 in `src/foo.ts` with the single replacement line shown in the block.
 
 **Multiple suggestions (two or more threads).** Apply each suggestion to its target file. The edits are independent — apply them in any order that avoids line-number drift (apply suggestions on later lines first when both touch the same file). Then make a single `git add && git commit` covering all the changed files before the rebase/push step in `## Instructions`. Both thread IDs go into the `resolve:` command's `--resolve-thread-ids` argument as a comma-separated list.
 
@@ -329,17 +344,27 @@ Example with two threads:
 ````markdown
 ## Review threads
 
-### `PRRT_kwDOSGizTs58XB1L` — `src/foo.ts:42` (@alice)
+### `PRRT_kwDOSGizTs58XB1L` — `src/foo.ts:42` (@alice) [suggestion]
 
 > ```suggestion
 > const remainingSeconds = computeRemaining();
 > ```
 
-### `PRRT_kwDOSGizTs58XC2M` — `src/bar.ts:17` (@alice)
+  Replaces line 42:
+  ```
+  const remainingSeconds = computeRemaining();
+  ```
+
+### `PRRT_kwDOSGizTs58XC2M` — `src/bar.ts:17` (@alice) [suggestion]
 
 > ```suggestion
 > return value ?? defaultValue;
 > ```
+
+  Replaces line 17:
+  ```
+  return value ?? defaultValue;
+  ```
 ````
 
 Apply both edits, then commit and push together. The `resolve:` command at the bottom of `## Post-fix push` already includes both IDs:
@@ -348,7 +373,7 @@ Apply both edits, then commit and push together. The `resolve:` command at the b
 - resolve: `npx pr-shepherd resolve 42 --resolve-thread-ids PRRT_kwDOSGizTs58XB1L,PRRT_kwDOSGizTs58XC2M --require-sha "$HEAD_SHA" --message "$DISMISS_MESSAGE"`
 ```
 
-**Alternative: structured path via `commit-suggestion`.** Instead of editing files manually, you can shell out to `npx pr-shepherd commit-suggestion <PR> --thread-id <id> --message "…"`. This builds a unified diff from the suggestion block, validates it with `git apply --check`, writes the file, commits with a `Co-authored-by: <reviewer>` trailer, and resolves the thread on GitHub — all in one command. Pass `--dry-run` (omitting `--message`) to preview the unified diff without mutating the working tree, index, or GitHub state — the CLI exits `0` when the patch would apply cleanly, `1` on drift. The command handles one thread at a time; invoke it in sequence for multi-suggestion PRs, then push all the resulting commits together. See the `commit-suggestion` section in the [CLI reference](cli-usage.md#pr-shepherd-commit-suggestion-pr---thread-id-id---message) for flags and output format.
+**Preferred: structured path via `commit-suggestion`.** The `## Instructions` section tells the agent to run `npx pr-shepherd commit-suggestion <PR> --thread-id <id> --message "…"` for each `[suggestion]` thread. This builds a unified diff from the suggestion block, validates it with `git apply --check`, writes the file, commits with a `Co-authored-by: <reviewer>` trailer, and resolves the thread on GitHub — all in one command. Pass `--dry-run` (omitting `--message`) to preview the unified diff without mutating the working tree, index, or GitHub state — the CLI exits `0` when the patch would apply cleanly, `1` on drift. The command handles one thread at a time; invoke it in sequence for multi-suggestion PRs, then push all the resulting commits together. On `applied: true` the thread is already resolved — remove its ID from `--resolve-thread-ids` in the `resolve:` command. On `applied: false` fall through to the manual-edit path above. See the `commit-suggestion` section in the [CLI reference](cli-usage.md#pr-shepherd-commit-suggestion-pr---thread-id-id---message) for flags and output format.
 
 **What the monitor does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed in the monitor. See `## Instructions` in the output for the exact steps.
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -295,7 +295,7 @@ The JSON payload exposes the same data under `fix.{threads, actionableComments, 
 GitHub reviewers can leave ` ```suggestion ` fenced blocks in review thread bodies. The CLI parses these and surfaces them to the agent in two forms:
 
 - A `[suggestion]` marker on the thread heading.
-- A `Replaces lines …` block immediately after the blockquoted body showing the parsed replacement text.
+- Immediately after the blockquoted body, either a `Replaces line(s) …` block showing the parsed replacement text, or for an empty suggestion (deletion), a `Deletes line(s) …` line with no replacement fenced block.
 
 The numbered `## Instructions` section tells the agent how to apply each `[suggestion]` thread.
 

--- a/src/cli-parser.commit-suggestion.mock.test.mts
+++ b/src/cli-parser.commit-suggestion.mock.test.mts
@@ -176,14 +176,15 @@ describe("main — commit-suggestion", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("text output shows applied result with commit sha and post-action", async () => {
+  it("text output shows applied result with commit sha and post-action in ## Instructions", async () => {
     mockRunCommitSuggestion.mockResolvedValue(APPLIED_RESULT);
     await main(["node", "shepherd", "commit-suggestion", "--thread-id", "t1", "--message", "fix"]);
     const out = getStdout();
     expect(out).toContain("Applied suggestion from @alice:");
     expect(out).toContain("a.ts (line 5)");
     expect(out).toContain("Commit: abc123");
-    expect(out).toContain("git push");
+    expect(out).toContain("## Instructions");
+    expect(out).toContain("1. Run `git push`");
   });
 
   it("text output shows patch diff block in success result", async () => {
@@ -250,14 +251,15 @@ describe("main — commit-suggestion --dry-run", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("text output shows dry-run valid header and diff", async () => {
+  it("text output shows dry-run valid header, diff, and ## Instructions", async () => {
     mockRunCommitSuggestion.mockResolvedValue(DRY_RUN_VALID_RESULT);
     await main(["node", "shepherd", "commit-suggestion", "--thread-id", "t1", "--dry-run"]);
     const out = getStdout();
     expect(out).toContain("Dry-run: would apply suggestion from @alice:");
     expect(out).toContain("a.ts (line 5)");
     expect(out).toContain("```diff");
-    expect(out).toContain("Re-run without --dry-run");
+    expect(out).toContain("## Instructions");
+    expect(out).toContain("1. Re-run without --dry-run");
   });
 
   it("text output shows dry-run invalid header and reason", async () => {

--- a/src/cli-parser.iterate-fix.mock.test.mts
+++ b/src/cli-parser.iterate-fix.mock.test.mts
@@ -277,6 +277,52 @@ describe("main — iterate text format (fix_code and checks)", () => {
     );
   });
 
+  it("fix_code: multi-line thread heading shows startLine-endLine range", async () => {
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.threads = [
+      {
+        id: "t-range",
+        path: "src/foo.ts",
+        line: 42,
+        startLine: 40,
+        author: "alice",
+        body: "Collapse these.",
+        url: "",
+        suggestion: { startLine: 40, endLine: 42, lines: ["const x = 1;"], author: "alice" },
+      },
+    ];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain("### `t-range` — `src/foo.ts:40-42` (@alice)");
+    expect(out).toContain("[suggestion]");
+    expect(out).toContain("Replaces lines 40–42:");
+    expect(out).toContain("const x = 1;");
+  });
+
+  it("fix_code: single-line thread heading shows only end line (no range)", async () => {
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.threads = [
+      {
+        id: "t-single",
+        path: "src/foo.ts",
+        line: 10,
+        author: "alice",
+        body: "Fix this.",
+        url: "",
+      },
+    ];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain("### `t-single` — `src/foo.ts:10` (@alice)");
+    expect(out).not.toContain("10-10");
+  });
+
   it("fix_code: CRLF line endings in thread body are normalized in blockquote", async () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -251,69 +251,6 @@ describe("main — resolve", () => {
     expect(out).toContain("commit-suggestion");
   });
 
-  it("formatFetchResult shows parsed suggestion content inline under each [suggestion] bullet", async () => {
-    mockRunResolveFetch.mockResolvedValue({
-      prNumber: 42,
-      actionableThreads: [
-        {
-          id: "PRT_1",
-          path: "src/foo.ts",
-          line: 5,
-          startLine: null,
-          isMinimized: false,
-          author: "alice",
-          body: "Use const",
-          url: "",
-          createdAtUnix: 0,
-          suggestion: { startLine: 5, endLine: 5, lines: ["const x = 1;"], author: "alice" },
-        },
-      ],
-      actionableComments: [],
-      firstLookThreads: [],
-      firstLookComments: [],
-      changesRequestedReviews: [],
-      reviewSummaries: [],
-      commitSuggestionsEnabled: true,
-      instructions: ["Classify every item."],
-    });
-    await main(["node", "shepherd", "resolve", "42"]);
-    const out = stdoutSpy.mock.calls.map((c: string[]) => c[0]).join("");
-    expect(out).toContain("[suggestion]");
-    expect(out).toContain("Replaces line 5:");
-    expect(out).toContain("const x = 1;");
-  });
-
-  it("formatFetchResult shows multi-line range in bullet when startLine differs from line", async () => {
-    mockRunResolveFetch.mockResolvedValue({
-      prNumber: 42,
-      actionableThreads: [
-        {
-          id: "PRT_1",
-          path: "src/foo.ts",
-          line: 42,
-          startLine: 40,
-          isMinimized: false,
-          author: "alice",
-          body: "Collapse these",
-          url: "",
-          createdAtUnix: 0,
-          suggestion: { startLine: 40, endLine: 42, lines: ["const x = 1;"], author: "alice" },
-        },
-      ],
-      actionableComments: [],
-      firstLookThreads: [],
-      firstLookComments: [],
-      changesRequestedReviews: [],
-      reviewSummaries: [],
-      commitSuggestionsEnabled: true,
-      instructions: ["Classify every item."],
-    });
-    await main(["node", "shepherd", "resolve", "42"]);
-    const out = stdoutSpy.mock.calls.map((c: string[]) => c[0]).join("");
-    expect(out).toContain("`src/foo.ts:40-42`");
-    expect(out).toContain("Replaces lines 40–42:");
-  });
-
   it("formatFetchResult -- zero items emits single-step instructions", async () => {
     mockRunResolveFetch.mockResolvedValue({
       prNumber: 42,

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -251,6 +251,69 @@ describe("main — resolve", () => {
     expect(out).toContain("commit-suggestion");
   });
 
+  it("formatFetchResult shows parsed suggestion content inline under each [suggestion] bullet", async () => {
+    mockRunResolveFetch.mockResolvedValue({
+      prNumber: 42,
+      actionableThreads: [
+        {
+          id: "PRT_1",
+          path: "src/foo.ts",
+          line: 5,
+          startLine: null,
+          isMinimized: false,
+          author: "alice",
+          body: "Use const",
+          url: "",
+          createdAtUnix: 0,
+          suggestion: { startLine: 5, endLine: 5, lines: ["const x = 1;"], author: "alice" },
+        },
+      ],
+      actionableComments: [],
+      firstLookThreads: [],
+      firstLookComments: [],
+      changesRequestedReviews: [],
+      reviewSummaries: [],
+      commitSuggestionsEnabled: true,
+      instructions: ["Classify every item."],
+    });
+    await main(["node", "shepherd", "resolve", "42"]);
+    const out = stdoutSpy.mock.calls.map((c: string[]) => c[0]).join("");
+    expect(out).toContain("[suggestion]");
+    expect(out).toContain("Replaces line 5:");
+    expect(out).toContain("const x = 1;");
+  });
+
+  it("formatFetchResult shows multi-line range in bullet when startLine differs from line", async () => {
+    mockRunResolveFetch.mockResolvedValue({
+      prNumber: 42,
+      actionableThreads: [
+        {
+          id: "PRT_1",
+          path: "src/foo.ts",
+          line: 42,
+          startLine: 40,
+          isMinimized: false,
+          author: "alice",
+          body: "Collapse these",
+          url: "",
+          createdAtUnix: 0,
+          suggestion: { startLine: 40, endLine: 42, lines: ["const x = 1;"], author: "alice" },
+        },
+      ],
+      actionableComments: [],
+      firstLookThreads: [],
+      firstLookComments: [],
+      changesRequestedReviews: [],
+      reviewSummaries: [],
+      commitSuggestionsEnabled: true,
+      instructions: ["Classify every item."],
+    });
+    await main(["node", "shepherd", "resolve", "42"]);
+    const out = stdoutSpy.mock.calls.map((c: string[]) => c[0]).join("");
+    expect(out).toContain("`src/foo.ts:40-42`");
+    expect(out).toContain("Replaces lines 40–42:");
+  });
+
   it("formatFetchResult -- zero items emits single-step instructions", async () => {
     mockRunResolveFetch.mockResolvedValue({
       prNumber: 42,

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -306,8 +306,8 @@ describe("main — resolve", () => {
     const out = stdoutSpy.mock.calls.map((c: string[]) => c[0]).join("");
     expect(out).toContain("## Pending CHANGES_REQUESTED reviews (1)");
     expect(out).toContain("`reviewId=PRR_r1` (@carol)");
-    // null path/line fallbacks rendered
-    expect(out).toContain("`:?`");
+    // null path renders as (no location)
+    expect(out).toContain("`(no location)`");
   });
 
   it("formatFetchResult: thread and comment with url render ↗ link after id", async () => {

--- a/src/cli-parser.resolve-fetch-suggestion.mock.test.mts
+++ b/src/cli-parser.resolve-fetch-suggestion.mock.test.mts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
+vi.mock("./commands/resolve.mts", () => ({
+  runResolveFetch: vi.fn(),
+  runResolveMutate: vi.fn(),
+}));
+vi.mock("./commands/commit-suggestion.mts", () => ({ runCommitSuggestion: vi.fn() }));
+vi.mock("./commands/iterate.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+  return { ...actual, runIterate: vi.fn() };
+});
+vi.mock("./commands/status.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/status.mts")>();
+  return { ...actual, runStatus: vi.fn(), formatStatusTable: vi.fn().mockReturnValue("") };
+});
+vi.mock("./github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
+}));
+
+import { main } from "./cli-parser.mts";
+import { runResolveFetch } from "./commands/resolve.mts";
+import { runStatus } from "./commands/status.mts";
+
+const mockRunResolveFetch = vi.mocked(runResolveFetch);
+const mockRunStatus = vi.mocked(runStatus);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stdoutSpy: any;
+let stderrSpy: any;
+
+function getStdout(): string {
+  return stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  mockRunStatus.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+describe("formatFetchResult — suggestion rendering", () => {
+  it("shows parsed suggestion content inline under each [suggestion] bullet", async () => {
+    mockRunResolveFetch.mockResolvedValue({
+      prNumber: 42,
+      actionableThreads: [
+        {
+          id: "PRT_1",
+          path: "src/foo.ts",
+          line: 5,
+          startLine: null,
+          isMinimized: false,
+          author: "alice",
+          body: "Use const",
+          url: "",
+          createdAtUnix: 0,
+          suggestion: { startLine: 5, endLine: 5, lines: ["const x = 1;"], author: "alice" },
+        },
+      ],
+      actionableComments: [],
+      firstLookThreads: [],
+      firstLookComments: [],
+      changesRequestedReviews: [],
+      reviewSummaries: [],
+      commitSuggestionsEnabled: true,
+      instructions: ["Classify every item."],
+    });
+    await main(["node", "shepherd", "resolve", "42"]);
+    const out = getStdout();
+    expect(out).toContain("[suggestion]");
+    expect(out).toContain("Replaces line 5:");
+    expect(out).toContain("const x = 1;");
+  });
+
+  it("shows multi-line range in bullet when startLine differs from line", async () => {
+    mockRunResolveFetch.mockResolvedValue({
+      prNumber: 42,
+      actionableThreads: [
+        {
+          id: "PRT_1",
+          path: "src/foo.ts",
+          line: 42,
+          startLine: 40,
+          isMinimized: false,
+          author: "alice",
+          body: "Collapse these",
+          url: "",
+          createdAtUnix: 0,
+          suggestion: { startLine: 40, endLine: 42, lines: ["const x = 1;"], author: "alice" },
+        },
+      ],
+      actionableComments: [],
+      firstLookThreads: [],
+      firstLookComments: [],
+      changesRequestedReviews: [],
+      reviewSummaries: [],
+      commitSuggestionsEnabled: true,
+      instructions: ["Classify every item."],
+    });
+    await main(["node", "shepherd", "resolve", "42"]);
+    const out = getStdout();
+    expect(out).toContain("`src/foo.ts:40-42`");
+    expect(out).toContain("Replaces lines 40–42:");
+  });
+});

--- a/src/cli/fence.mts
+++ b/src/cli/fence.mts
@@ -1,0 +1,4 @@
+export function safeFence(content: string): string {
+  const maxRun = Math.max(0, ...Array.from(content.matchAll(/`+/g), (m) => m[0].length));
+  return "`".repeat(Math.max(3, maxRun + 1));
+}

--- a/src/cli/fix-formatter.mts
+++ b/src/cli/fix-formatter.mts
@@ -1,10 +1,7 @@
 import { renderResolveCommand } from "../commands/iterate.mts";
+import { safeFence } from "./fence.mts";
+import { renderSuggestionBlock, renderLineRange } from "./suggestion-renderer.mts";
 import type { IterateResultFixCode } from "../types.mts";
-
-function safeFence(content: string): string {
-  const maxRun = Math.max(0, ...Array.from(content.matchAll(/`+/g), (m) => m[0].length));
-  return "`".repeat(Math.max(3, maxRun + 1));
-}
 
 export function formatFixCodeResult(header: string, result: IterateResultFixCode): string {
   const sections: string[] = [header];
@@ -12,10 +9,15 @@ export function formatFixCodeResult(header: string, result: IterateResultFixCode
   if (result.fix.threads.length > 0) {
     sections.push("## Review threads");
     for (const t of result.fix.threads) {
-      const loc = t.path ? `\`${t.path}:${t.line ?? "?"}\`` : "(no location)";
+      const lineLabel = renderLineRange(t.startLine, t.line);
+      const loc = t.path ? `\`${t.path}:${lineLabel}\`` : "(no location)";
       const heading = t.url ? `[${t.id}](${t.url})` : `\`${t.id}\``;
-      sections.push(`### ${heading} — ${loc} (@${t.author})`);
+      const suggestionMarker = t.suggestion ? " [suggestion]" : "";
+      sections.push(`### ${heading} — ${loc} (@${t.author})${suggestionMarker}`);
       sections.push(blockquote(t.body));
+      if (t.suggestion) {
+        sections.push(renderSuggestionBlock(t.suggestion));
+      }
     }
   }
 

--- a/src/cli/fix-formatter.mts
+++ b/src/cli/fix-formatter.mts
@@ -16,7 +16,7 @@ export function formatFixCodeResult(header: string, result: IterateResultFixCode
       sections.push(`### ${heading} — ${loc} (@${t.author})${suggestionMarker}`);
       sections.push(blockquote(t.body));
       if (t.suggestion) {
-        sections.push(renderSuggestionBlock(t.suggestion));
+        sections.push(renderSuggestionBlock(t.suggestion, ""));
       }
     }
   }

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -33,8 +33,9 @@ export function formatFetchResult(result: FetchResult): string {
     const threadBullets = result.actionableThreads.map((t) => {
       const suggestionMarker = t.suggestion ? " [suggestion]" : "";
       const link = t.url ? ` [↗](${t.url})` : "";
-      const lineLabel = renderLineRange(t.startLine ?? undefined, t.line);
-      const loc = `\`${t.path ?? ""}:${lineLabel}\``;
+      const loc = t.path
+        ? `\`${t.path}:${renderLineRange(t.startLine ?? undefined, t.line)}\``
+        : "`(no location)`";
       const bulletLine = `- \`threadId=${t.id}\`${link} ${loc} (@${t.author})${suggestionMarker}: ${t.body.split("\n")[0]?.slice(0, 100) ?? ""}`;
       if (!t.suggestion) return bulletLine;
       return `${bulletLine}\n${renderSuggestionBlock(t.suggestion)}`;

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -119,7 +119,7 @@ export function formatCommitSuggestionResult(result: CommitSuggestionResult): st
   const range =
     result.startLine === result.endLine
       ? `line ${result.startLine}`
-      : `lines ${result.startLine}-${result.endLine}`;
+      : `lines ${result.startLine}–${result.endLine}`;
 
   function pushPatch(patch: string) {
     const fence = safeFence(patch);
@@ -147,7 +147,7 @@ export function formatCommitSuggestionResult(result: CommitSuggestionResult): st
     if (result.patch) pushPatch(result.patch);
   } else {
     lines.push(`Failed to apply suggestion ${result.threadId}:`);
-    lines.push(`- path: ${result.path} (lines ${result.startLine}–${result.endLine})`);
+    lines.push(`- path: ${result.path} (${range})`);
     lines.push(`- author: @${result.author}`);
     lines.push(`- reason: ${result.reason ?? "unknown"}`);
     if (result.patch) pushPatch(result.patch);

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -1,6 +1,8 @@
 export { formatIterateResult } from "./iterate-formatter.mts";
 export { projectIterateLean } from "./iterate-lean.mts";
 
+import { safeFence } from "./fence.mts";
+import { renderSuggestionBlock, renderLineRange } from "./suggestion-renderer.mts";
 import type { FetchResult } from "../commands/resolve.mts";
 import type { CommitSuggestionResult } from "../types.mts";
 import type { ResolveResult } from "../comments/resolve.mts";
@@ -28,15 +30,16 @@ export function formatFetchResult(result: FetchResult): string {
       `## Actionable Review Threads (${result.actionableThreads.length})` +
         (result.commitSuggestionsEnabled ? " [commit-suggestions: enabled]" : ""),
     );
-    sections.push(
-      result.actionableThreads
-        .map((t) => {
-          const suggestionMarker = t.suggestion ? " [suggestion]" : "";
-          const link = t.url ? ` [↗](${t.url})` : "";
-          return `- \`threadId=${t.id}\`${link} \`${t.path ?? ""}:${t.line ?? "?"}\` (@${t.author})${suggestionMarker}: ${t.body.split("\n")[0]?.slice(0, 100) ?? ""}`;
-        })
-        .join("\n"),
-    );
+    const threadBullets = result.actionableThreads.map((t) => {
+      const suggestionMarker = t.suggestion ? " [suggestion]" : "";
+      const link = t.url ? ` [↗](${t.url})` : "";
+      const lineLabel = renderLineRange(t.startLine ?? undefined, t.line);
+      const loc = `\`${t.path ?? ""}:${lineLabel}\``;
+      const bulletLine = `- \`threadId=${t.id}\`${link} ${loc} (@${t.author})${suggestionMarker}: ${t.body.split("\n")[0]?.slice(0, 100) ?? ""}`;
+      if (!t.suggestion) return bulletLine;
+      return `${bulletLine}\n${renderSuggestionBlock(t.suggestion)}`;
+    });
+    sections.push(threadBullets.join("\n\n"));
   }
 
   if (result.actionableComments.length > 0) {
@@ -113,12 +116,20 @@ export function formatFetchResult(result: FetchResult): string {
 
 export function formatCommitSuggestionResult(result: CommitSuggestionResult): string {
   const lines: string[] = [];
+  const range =
+    result.startLine === result.endLine
+      ? `line ${result.startLine}`
+      : `lines ${result.startLine}-${result.endLine}`;
+
+  function pushPatch(patch: string) {
+    const fence = safeFence(patch);
+    lines.push("");
+    lines.push(`${fence}diff`);
+    lines.push(patch.trimEnd());
+    lines.push(fence);
+  }
 
   if (result.dryRun) {
-    const range =
-      result.startLine === result.endLine
-        ? `line ${result.startLine}`
-        : `lines ${result.startLine}-${result.endLine}`;
     if (result.valid) {
       lines.push(`Dry-run: would apply suggestion from @${result.author}:`);
       lines.push(`  ${result.path} (${range})`);
@@ -128,42 +139,25 @@ export function formatCommitSuggestionResult(result: CommitSuggestionResult): st
       lines.push(`- author: @${result.author}`);
       lines.push(`- reason: ${result.reason ?? "unknown"}`);
     }
-    if (result.patch) {
-      lines.push("");
-      lines.push("```diff");
-      lines.push(result.patch.trimEnd());
-      lines.push("```");
-    }
+    if (result.patch) pushPatch(result.patch);
   } else if (result.applied) {
     lines.push(`Applied suggestion from @${result.author}:`);
-    const range =
-      result.startLine === result.endLine
-        ? `line ${result.startLine}`
-        : `lines ${result.startLine}-${result.endLine}`;
     lines.push(`  ${result.path} (${range})`);
     if (result.commitSha) lines.push(`Commit: ${result.commitSha}`);
-    if (result.patch) {
-      lines.push("");
-      lines.push("```diff");
-      lines.push(result.patch.trimEnd());
-      lines.push("```");
-    }
+    if (result.patch) pushPatch(result.patch);
   } else {
     lines.push(`Failed to apply suggestion ${result.threadId}:`);
     lines.push(`- path: ${result.path} (lines ${result.startLine}–${result.endLine})`);
     lines.push(`- author: @${result.author}`);
     lines.push(`- reason: ${result.reason ?? "unknown"}`);
-    if (result.patch) {
-      lines.push("");
-      lines.push("```diff");
-      lines.push(result.patch.trimEnd());
-      lines.push("```");
-    }
+    if (result.patch) pushPatch(result.patch);
   }
 
   if (result.postActionInstruction) {
     lines.push("");
-    lines.push(result.postActionInstruction);
+    lines.push("## Instructions");
+    lines.push("");
+    lines.push(`1. ${result.postActionInstruction}`);
   }
   return `${lines.join("\n")}\n`;
 }

--- a/src/cli/suggestion-renderer.mts
+++ b/src/cli/suggestion-renderer.mts
@@ -1,0 +1,36 @@
+import { safeFence } from "./fence.mts";
+import type { SuggestionBlock } from "../types.mts";
+
+export function renderLineRange(startLine: number | undefined, endLine: number | null): string {
+  if (endLine === null) return "?";
+  if (startLine !== undefined && startLine !== endLine) return `${startLine}-${endLine}`;
+  return String(endLine);
+}
+
+export function renderSuggestionBlock(s: SuggestionBlock, indent = "  "): string {
+  const rangeLabel =
+    s.startLine !== s.endLine
+      ? `lines ${s.startLine}–${s.endLine}`
+      : `line ${s.startLine}`;
+
+  if (s.lines.length === 0) {
+    return `${indent}Deletes ${rangeLabel}`;
+  }
+
+  const content = s.lines.join("\n");
+  const fence = safeFence(content);
+  const label =
+    s.lines.length === 1 && s.lines[0] === ""
+      ? `Replaces ${rangeLabel} with a blank line:`
+      : `Replaces ${rangeLabel}:`;
+
+  return [
+    `${indent}${label}`,
+    `${indent}${fence}`,
+    content
+      .split("\n")
+      .map((l) => `${indent}${l}`)
+      .join("\n"),
+    `${indent}${fence}`,
+  ].join("\n");
+}

--- a/src/cli/suggestion-renderer.mts
+++ b/src/cli/suggestion-renderer.mts
@@ -9,9 +9,7 @@ export function renderLineRange(startLine: number | undefined, endLine: number |
 
 export function renderSuggestionBlock(s: SuggestionBlock, indent = "  "): string {
   const rangeLabel =
-    s.startLine !== s.endLine
-      ? `lines ${s.startLine}–${s.endLine}`
-      : `line ${s.startLine}`;
+    s.startLine !== s.endLine ? `lines ${s.startLine}–${s.endLine}` : `line ${s.startLine}`;
 
   const content = s.lines.join("\n");
   const fence = safeFence(content);

--- a/src/cli/suggestion-renderer.mts
+++ b/src/cli/suggestion-renderer.mts
@@ -13,24 +13,26 @@ export function renderSuggestionBlock(s: SuggestionBlock, indent = "  "): string
       ? `lines ${s.startLine}–${s.endLine}`
       : `line ${s.startLine}`;
 
-  if (s.lines.length === 0) {
-    return `${indent}Deletes ${rangeLabel}`;
-  }
-
   const content = s.lines.join("\n");
   const fence = safeFence(content);
   const label =
-    s.lines.length === 1 && s.lines[0] === ""
-      ? `Replaces ${rangeLabel} with a blank line:`
-      : `Replaces ${rangeLabel}:`;
+    s.lines.length === 0
+      ? `Replaces ${rangeLabel} with nothing:`
+      : s.lines.length === 1 && s.lines[0] === ""
+        ? `Replaces ${rangeLabel} with a blank line:`
+        : `Replaces ${rangeLabel}:`;
 
   return [
     `${indent}${label}`,
     `${indent}${fence}`,
-    content
-      .split("\n")
-      .map((l) => `${indent}${l}`)
-      .join("\n"),
+    ...(content === ""
+      ? []
+      : [
+          content
+            .split("\n")
+            .map((l) => `${indent}${l}`)
+            .join("\n"),
+        ]),
     `${indent}${fence}`,
   ].join("\n");
 }

--- a/src/commands/iterate/render.mts
+++ b/src/commands/iterate/render.mts
@@ -56,9 +56,20 @@ export function buildFixInstructions(
 ): string[] {
   const instructions: string[] = [];
 
-  if (threads.length > 0 || actionableComments.length > 0) {
+  const hasSuggestions = threads.some((t) => t.suggestion);
+
+  if (hasSuggestions) {
     instructions.push(
-      `Apply code fixes: read and edit each file referenced under \`## Review threads\` and \`## Actionable comments\` above. If a comment body opens with a triple-backtick suggestion fence, treat its contents as a literal line replacement at the file and line range shown in the thread heading and apply it verbatim unless you have a specific reason to deviate.`,
+      `For each thread marked \`[suggestion]\` under \`## Review threads\`: run \`npx pr-shepherd commit-suggestion ${prNumber} --thread-id <id> --message "<one-sentence headline>" --format=json\`, one thread at a time. On \`applied: true\` the CLI already resolved the thread — remove its ID from \`--resolve-thread-ids\` in the \`resolve:\` command below. On \`applied: false\` read \`reason\` and \`patch\`, fall through to the manual-edit step, and do not retry the same command. Optionally pass \`--dry-run\` (omitting \`--message\`) to preview the patch without mutating the working tree.`,
+    );
+  }
+
+  if (threads.length > 0 || actionableComments.length > 0) {
+    const suggestionFallback = hasSuggestions
+      ? ` When applying a \`[suggestion]\` thread manually (e.g. after a failed \`commit-suggestion\` run), replace the exact line range shown in the heading (\`path:startLine-endLine\`) with the replacement shown in its \`Replaces lines …\` block verbatim — an empty replacement deletes those lines, a single blank line replaces the range with one blank line.`
+      : "";
+    instructions.push(
+      `Apply code fixes: read and edit each file referenced under \`## Review threads\` and \`## Actionable comments\` above.${suggestionFallback}`,
     );
   }
   const checksWithRunId = checks.filter((c) => c.runId);

--- a/src/commands/resolve.mts
+++ b/src/commands/resolve.mts
@@ -141,7 +141,6 @@ export async function runResolveFetch(opts: ResolveCommandOptions): Promise<Fetc
   return { ...result, instructions: buildFetchInstructions(prNumber, result) };
 }
 
-
 /**
  * Mutation mode: resolve/minimize/dismiss by ID.
  */

--- a/src/commands/resolve.mts
+++ b/src/commands/resolve.mts
@@ -3,7 +3,7 @@ import { fetchPrBatch } from "../github/batch.mts";
 import { getOutdatedThreads } from "../comments/outdated.mts";
 import { autoResolveOutdated, applyResolveOptions } from "../comments/resolve.mts";
 import { loadConfig } from "../config/load.mts";
-import { parseSuggestion } from "../suggestions/parse.mts";
+import { extractSuggestion } from "../suggestions/extract.mts";
 import { buildFetchInstructions } from "./resolve-instructions.mts";
 import { loadSeenSet, markSeen } from "../state/seen-comments.mts";
 import type {
@@ -141,25 +141,6 @@ export async function runResolveFetch(opts: ResolveCommandOptions): Promise<Fetc
   return { ...result, instructions: buildFetchInstructions(prNumber, result) };
 }
 
-/**
- * Attach a parsed suggestion block to a thread if the comment body contains one
- * and the thread has a resolvable line anchor. Threads without `path`/`line`
- * (rare — usually file-level comments) can't accept a suggestion commit.
- */
-function extractSuggestion(
-  thread: Omit<ReviewThread, "isResolved" | "isOutdated">,
-): SuggestionBlock | null {
-  if (!thread.path || thread.line === null) return null;
-  const parsed = parseSuggestion(thread.body);
-  if (!parsed) return null;
-  const startLine = thread.startLine ?? thread.line;
-  return {
-    startLine,
-    endLine: thread.line,
-    lines: parsed.lines,
-    author: thread.author,
-  };
-}
 
 /**
  * Mutation mode: resolve/minimize/dismiss by ID.

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -24,7 +24,9 @@ export function toAgentThread(t: ReviewThread): AgentThread {
     id: t.id,
     path: t.path,
     line: t.line,
-    ...(t.line !== null && t.startLine !== null && t.startLine !== t.line && { startLine: t.startLine }),
+    ...(t.line !== null &&
+      t.startLine !== null &&
+      t.startLine !== t.line && { startLine: t.startLine }),
     author: t.author,
     body: t.body,
     url: t.url,

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -24,7 +24,7 @@ export function toAgentThread(t: ReviewThread): AgentThread {
     id: t.id,
     path: t.path,
     line: t.line,
-    ...(t.startLine !== null && t.startLine !== t.line && { startLine: t.startLine }),
+    ...(t.line !== null && t.startLine !== null && t.startLine !== t.line && { startLine: t.startLine }),
     author: t.author,
     body: t.body,
     url: t.url,

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -8,6 +8,7 @@
  * The original domain types are preserved for check command output.
  */
 
+import { extractSuggestion } from "../suggestions/extract.mts";
 import type {
   ReviewThread,
   PrComment,
@@ -18,7 +19,17 @@ import type {
 } from "../types.mts";
 
 export function toAgentThread(t: ReviewThread): AgentThread {
-  return { id: t.id, path: t.path, line: t.line, author: t.author, body: t.body, url: t.url };
+  const suggestion = extractSuggestion(t) ?? undefined;
+  return {
+    id: t.id,
+    path: t.path,
+    line: t.line,
+    ...(t.startLine !== null && t.startLine !== t.line && { startLine: t.startLine }),
+    author: t.author,
+    body: t.body,
+    url: t.url,
+    ...(suggestion !== undefined && { suggestion }),
+  };
 }
 
 export function toAgentComment(c: PrComment): AgentComment {

--- a/src/reporters/agent.test.mts
+++ b/src/reporters/agent.test.mts
@@ -70,7 +70,13 @@ describe("toAgentThread", () => {
 
   it("attaches parsed suggestion when body contains a ```suggestion fence", () => {
     const body = "```suggestion\nconst x = 1;\n```";
-    const result = toAgentThread({ ...thread, path: "src/foo.mts", line: 10, startLine: null, body });
+    const result = toAgentThread({
+      ...thread,
+      path: "src/foo.mts",
+      line: 10,
+      startLine: null,
+      body,
+    });
     expect(result.suggestion).toEqual({
       startLine: 10,
       endLine: 10,

--- a/src/reporters/agent.test.mts
+++ b/src/reporters/agent.test.mts
@@ -52,6 +52,43 @@ describe("toAgentThread", () => {
     expect(result).not.toHaveProperty("isOutdated");
     expect(result).not.toHaveProperty("createdAtUnix");
   });
+
+  it("omits startLine when null (single-line thread)", () => {
+    const result = toAgentThread(thread);
+    expect(result).not.toHaveProperty("startLine");
+  });
+
+  it("omits startLine when equal to line (same-line range)", () => {
+    const result = toAgentThread({ ...thread, startLine: 10, line: 10 });
+    expect(result).not.toHaveProperty("startLine");
+  });
+
+  it("includes startLine when it differs from line (multi-line range)", () => {
+    const result = toAgentThread({ ...thread, startLine: 8, line: 10 });
+    expect(result.startLine).toBe(8);
+  });
+
+  it("attaches parsed suggestion when body contains a ```suggestion fence", () => {
+    const body = "```suggestion\nconst x = 1;\n```";
+    const result = toAgentThread({ ...thread, path: "src/foo.mts", line: 10, startLine: null, body });
+    expect(result.suggestion).toEqual({
+      startLine: 10,
+      endLine: 10,
+      lines: ["const x = 1;"],
+      author: "alice",
+    });
+  });
+
+  it("omits suggestion when body has no suggestion fence", () => {
+    const result = toAgentThread(thread);
+    expect(result).not.toHaveProperty("suggestion");
+  });
+
+  it("omits suggestion when path is null (file-level comment)", () => {
+    const body = "```suggestion\nconst x = 1;\n```";
+    const result = toAgentThread({ ...thread, path: null, body });
+    expect(result).not.toHaveProperty("suggestion");
+  });
 });
 
 describe("toAgentComment", () => {

--- a/src/suggestions/extract.mts
+++ b/src/suggestions/extract.mts
@@ -1,0 +1,21 @@
+import { parseSuggestion } from "./parse.mts";
+import type { SuggestionBlock } from "../types.mts";
+
+export function extractSuggestion(thread: {
+  path: string | null;
+  line: number | null;
+  startLine: number | null;
+  body: string;
+  author: string;
+}): SuggestionBlock | null {
+  if (!thread.path || thread.line === null) return null;
+  const parsed = parseSuggestion(thread.body);
+  if (!parsed) return null;
+  const startLine = thread.startLine ?? thread.line;
+  return {
+    startLine,
+    endLine: thread.line,
+    lines: parsed.lines,
+    author: thread.author,
+  };
+}

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -6,6 +6,7 @@ import type {
   Review,
   MergeStatusResult,
   CheckConclusion,
+  SuggestionBlock,
 } from "./github.mts";
 
 // ---------------------------------------------------------------------------
@@ -94,9 +95,13 @@ export interface AgentThread {
   id: string;
   path: string | null;
   line: number | null;
+  /** Set when the thread anchors a multi-line range (startLine differs from line). Omitted for single-line threads. */
+  startLine?: number;
   author: string;
   body: string;
   url: string;
+  /** Parsed suggestion block when the comment body contains a ```suggestion fence. */
+  suggestion?: SuggestionBlock;
 }
 
 /** Comment shape emitted to the monitor agent — stripped of always-false flags. */

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -95,13 +95,11 @@ export interface AgentThread {
   id: string;
   path: string | null;
   line: number | null;
-  /** Set when the thread anchors a multi-line range (startLine differs from line). Omitted for single-line threads. */
-  startLine?: number;
+  startLine?: number; // multi-line range only; omitted when equal to line
   author: string;
   body: string;
   url: string;
-  /** Parsed suggestion block when the comment body contains a ```suggestion fence. */
-  suggestion?: SuggestionBlock;
+  suggestion?: SuggestionBlock; // present when body contains a ```suggestion fence
 }
 
 /** Comment shape emitted to the monitor agent — stripped of always-false flags. */
@@ -190,10 +188,8 @@ export type CommitSuggestionResult =
   | (CommitSuggestionResultBase & {
       applied: false;
       dryRun: true;
-      /** Whether `git apply --check` succeeded. */
-      valid: boolean;
-      /** Rejection message from `git apply --check`, or null when valid. */
-      reason: string | null;
+      valid: boolean; // whether `git apply --check` succeeded
+      reason: string | null; // rejection message or null when valid
     });
 
 // CLI options


### PR DESCRIPTION
## Summary

- **Surface parsed suggestion replacements inline** — both `iterate` (`[FIX_CODE]`) and `resolve --fetch` now show a `Replaces lines N–M:` fenced block after each `[suggestion]` thread so agents see the replacement text without a `--dry-run` round-trip or body re-parsing
- **Show full line range in headings** — thread headings use `path:startLine-endLine` for multi-line threads instead of end-line only; agents no longer need to "read the surrounding file to find which lines the comment is attached to" (removes that workaround from docs/actions.md)
- **Unified suggestion handling in `iterate`** — `toAgentThread` now parses suggestion fences (matching `resolve --fetch`); `iterate`'s `## Instructions` gains a `commit-suggestion` shell-out step for `[suggestion]` threads, with the manual-edit step kept as fallback
- **`commit-suggestion` output** — `postActionInstruction` moved into a `## Instructions` numbered block; `safeFence` used for diff fences (safe against Markdown files containing backtick fences)
- **Shared helpers** — `extractSuggestion` lifted to `src/suggestions/extract.mts`; `safeFence` lifted to `src/cli/fence.mts`

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 816 tests pass (10 new tests added covering `startLine` forwarding, suggestion parsing in `toAgentThread`, suggestion block rendering in iterate and resolve-fetch output, `## Instructions` in commit-suggestion output)
- [ ] Dogfood: run `npx pr-shepherd resolve <PR> --fetch` against a PR with a multi-line suggestion thread and verify heading shows `path:start-end`, bullet shows `Replaces lines …` block
- [ ] Dogfood: run `npx pr-shepherd iterate <PR>` against the same PR and verify same heading shape, `[suggestion]` tag, and `commit-suggestion` instruction step appear
- [ ] Dogfood: run `npx pr-shepherd commit-suggestion <PR> --thread-id <id> --dry-run` and confirm `## Instructions` wraps the hint

## Shepherd Journal

- [PRRT_kwDOSGizTs59sPCk](https://github.com/jonathanong/pr-shepherd/pull/121#discussion_r3144207509) (@gemini-code-assist): Fixed — en-dash used in `range` variable definition in `formatCommitSuggestionResult`.
- [PRRT_kwDOSGizTs59sPCl](https://github.com/jonathanong/pr-shepherd/pull/121#discussion_r3144207510) (@gemini-code-assist): Fixed — failed branch now uses the pre-computed `range` variable, which also correctly labels single-line failures as "line N".

🤖 Generated with [Claude Code](https://claude.com/claude-code)