### PR TITLE
chore: remove stale --no-cache flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Loop args: `4m --max-turns 50 --expires 8h`
 after completing the actions below. The cron job handles the next fire.
 
 Run in a single Bash call:
-  npx pr-shepherd iterate 123 --no-cache
+  npx pr-shepherd iterate 123
 
 …(self-dedup guidance, error-handling instructions)…
 

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -87,8 +87,8 @@ function validateReadyDelaySuffix(readyDelaySuffix?: string): string | undefined
 function buildLoopPrompt(prNumber: number, loopTag: string, readyDelaySuffix?: string): string {
   const validatedDelay = validateReadyDelaySuffix(readyDelaySuffix);
   const iterateCmd = validatedDelay
-    ? `npx pr-shepherd iterate ${prNumber} --no-cache --ready-delay ${validatedDelay}`
-    : `npx pr-shepherd iterate ${prNumber} --no-cache`;
+    ? `npx pr-shepherd iterate ${prNumber} --ready-delay ${validatedDelay}`
+    : `npx pr-shepherd iterate ${prNumber}`;
   return [
     loopTag,
     "",

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -86,9 +86,7 @@ function validateReadyDelaySuffix(readyDelaySuffix?: string): string | undefined
 
 function buildLoopPrompt(prNumber: number, loopTag: string, readyDelaySuffix?: string): string {
   const validatedDelay = validateReadyDelaySuffix(readyDelaySuffix);
-  const iterateCmd = validatedDelay
-    ? `npx pr-shepherd iterate ${prNumber} --ready-delay ${validatedDelay}`
-    : `npx pr-shepherd iterate ${prNumber}`;
+  const iterateCmd = `npx pr-shepherd iterate ${prNumber}${validatedDelay ? ` --ready-delay ${validatedDelay}` : ""}`;
   return [
     loopTag,
     "",


### PR DESCRIPTION
## Summary

- Removes `--no-cache` from `buildLoopPrompt` in `src/commands/monitor.mts` — the cron loop was instructing each iterate invocation to pass a flag removed in #101
- Removes `--no-cache` from the loop-prompt example in `README.md`

The flag was silently ignored (`strict: false` in the arg parser), so no functional impact — purely cleanup drift from #101.

## Test plan

- [x] `grep -rn "no-cache"` returns no hits
- [x] `npm test` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)