### PR TITLE
fix: markdown output polish (closes #133)

### DIFF
--- a/src/cli-parser.iterate-fixtures.mts
+++ b/src/cli-parser.iterate-fixtures.mts
@@ -64,7 +64,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
         ambiguousComments: [],
         changesRequestedReviews: [],
         suggestion: "check manually",
-        humanMessage: "⚠️  /pr-shepherd:monitor paused — needs human direction",
+        humanMessage: "⚠️ /pr-shepherd:monitor paused — needs human direction",
       },
     };
   }

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -163,7 +163,7 @@ describe("main — iterate text format", () => {
     const out = getStdout();
     expect(out).toMatch(/^# PR #42 \[ESCALATE\]\n/);
     expect(out).toContain("**status** `IN_PROGRESS`");
-    expect(out).toContain("⚠️  /pr-shepherd:monitor paused — needs human direction");
+    expect(out).toContain("⚠️ /pr-shepherd:monitor paused — needs human direction");
     expect(out).toContain("## Instructions");
     expect(out).toContain("1. Invoke `/loop cancel` via the Skill tool.");
     expect(out).toContain("2. Stop — the PR needs human direction");

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -143,7 +143,7 @@ async function handleResolve(args: string[]): Promise<void> {
     process.stdout.write(
       globalOpts.format === "json"
         ? `${JSON.stringify(result, null, 2)}\n`
-        : formatFetchResult(result),
+        : `${formatFetchResult(result)}\n`,
     );
   } else {
     const result = await runResolveMutate({
@@ -158,7 +158,7 @@ async function handleResolve(args: string[]): Promise<void> {
     process.stdout.write(
       globalOpts.format === "json"
         ? `${JSON.stringify(result, null, 2)}\n`
-        : formatMutateResult(result),
+        : `${formatMutateResult(result)}\n`,
     );
   }
 }

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -37,7 +37,7 @@ export function formatFetchResult(result: FetchResult): string {
       const loc = t.path
         ? `\`${t.path}:${renderLineRange(t.startLine ?? undefined, t.line)}\``
         : "`(no location)`";
-      const bulletLine = `- \`threadId=${t.id}\`${link} ${loc} (@${t.author})${suggestionMarker}: ${t.body.split("\n")[0]?.slice(0, 100) ?? ""}`;
+      const bulletLine = `- \`threadId=${t.id}\`${link} ${loc} (@${t.author})${suggestionMarker}: ${t.body.split("\n")[0].slice(0, 100)}`;
       if (!t.suggestion) return bulletLine;
       return `${bulletLine}\n${renderSuggestionBlock(t.suggestion)}`;
     });
@@ -50,7 +50,7 @@ export function formatFetchResult(result: FetchResult): string {
       result.actionableComments
         .map((c) => {
           const link = c.url ? ` [↗](${c.url})` : "";
-          return `- \`commentId=${c.id}\`${link} (@${c.author}): ${c.body.split("\n")[0]?.slice(0, 100) ?? ""}`;
+          return `- \`commentId=${c.id}\`${link} (@${c.author}): ${c.body.split("\n")[0].slice(0, 100)}`;
         })
         .join("\n"),
     );
@@ -70,7 +70,7 @@ export function formatFetchResult(result: FetchResult): string {
     sections.push(
       result.reviewSummaries
         .map(
-          (r) => `- \`reviewId=${r.id}\` (@${r.author}): ${r.body.split("\n")[0]!.slice(0, 100)}`,
+          (r) => `- \`reviewId=${r.id}\` (@${r.author}): ${r.body.split("\n")[0].slice(0, 100)}`,
         )
         .join("\n"),
     );
@@ -94,7 +94,7 @@ export function formatFetchResult(result: FetchResult): string {
   sections.push("## Instructions");
   sections.push(result.instructions.map((inst, i) => `${i + 1}. ${inst}`).join("\n"));
 
-  return `${sections.join("\n\n")}\n`;
+  return sections.join("\n\n");
 }
 
 export function formatCommitSuggestionResult(result: CommitSuggestionResult): string {
@@ -142,7 +142,7 @@ export function formatCommitSuggestionResult(result: CommitSuggestionResult): st
     lines.push("");
     lines.push(`1. ${result.postActionInstruction}`);
   }
-  return `${lines.join("\n")}\n`;
+  return lines.join("\n");
 }
 
 export function formatMutateResult(result: ResolveResult): string {
@@ -160,5 +160,5 @@ export function formatMutateResult(result: ResolveResult): string {
       `Dismissed reviews (${result.dismissedReviews.length}): ${result.dismissedReviews.join(", ")}`,
     );
   if (result.errors.length) lines.push(`Errors:\n  ${result.errors.join("\n  ")}`);
-  return `${lines.join("\n")}\n`;
+  return lines.join("\n");
 }

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -69,9 +69,7 @@ export function formatFetchResult(result: FetchResult): string {
     sections.push(`## Review summaries (${result.reviewSummaries.length})`);
     sections.push(
       result.reviewSummaries
-        .map(
-          (r) => `- \`reviewId=${r.id}\` (@${r.author}): ${r.body.split("\n")[0].slice(0, 100)}`,
-        )
+        .map((r) => `- \`reviewId=${r.id}\` (@${r.author}): ${r.body.split("\n")[0].slice(0, 100)}`)
         .join("\n"),
     );
   }

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -58,7 +58,7 @@ export async function handleCommitSuggestion(args: string[]): Promise<void> {
   process.stdout.write(
     globalOpts.format === "json"
       ? `${JSON.stringify(result, null, 2)}\n`
-      : formatCommitSuggestionResult(result),
+      : `${formatCommitSuggestionResult(result)}\n`,
   );
 
   if (result.dryRun) {

--- a/src/commands/iterate/escalate.mts
+++ b/src/commands/iterate/escalate.mts
@@ -95,7 +95,7 @@ export function buildEscalateHumanMessage(
   pr: number,
 ): string {
   const lines: string[] = [];
-  lines.push("⚠️  /pr-shepherd:monitor paused — needs human direction");
+  lines.push("⚠️ /pr-shepherd:monitor paused — needs human direction");
   lines.push("");
   lines.push(`**Triggers:** ${escalate.triggers.map((t) => `\`${t}\``).join(", ")}`);
   lines.push("");

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -67,11 +67,11 @@ export function formatText(report: ShepherdReport): string {
     parts.push("");
     if (report.checks.blockedByFilteredCheck) {
       parts.push(
-        "  Note: PR is BLOCKED and all filtered checks are non-PR-trigger — one of these filtered checks may be a required status check blocking merge.",
+        "> Note: PR is BLOCKED and all filtered checks are non-PR-trigger — one of these filtered checks may be a required status check blocking merge.",
       );
     } else if (report.mergeStatus.status === "BLOCKED") {
       parts.push(
-        "  Note: one or more of these filtered checks may be a required status check blocking merge.",
+        "> Note: one or more of these filtered checks may be a required status check blocking merge.",
       );
     }
     parts.push("");


### PR DESCRIPTION
Fixes #133.

## Changes

1. **Emoji spacing** (`escalate.mts`) — drop the extra space after `⚠️`; modern terminals don't need the double-space rendering hack.

2. **Dead operators** (`fix-formatter.mts`, `formatters.mts`) — remove `?.` and `?? ""` (and one `!`) from `.split("\n")[0]` expressions. `String.prototype.split` always returns a non-empty array, so `[0]` is never `undefined`; all three operators were dead code.

3. **Trailing-newline contract** (`formatters.mts`, `cli-parser.mts`, `handlers.mts`) — `formatFetchResult`, `formatCommitSuggestionResult`, and `formatMutateResult` were the only formatters appending a trailing `\n`. Moved the newline to the print site on all three, matching the convention already used by `formatText`, `formatFixCodeResult`, and `formatIterateResult`.

4. **Filtered-checks note indent** (`text.mts`) — the two-space-indented note lines read ambiguously close to a CommonMark code-block indent. Converted to `> ` blockquotes.

## Out of scope (tracked in other issues)

- Promoting `firstLine()` to a shared util → #128
- Unifying 100 vs 120 char slice-length drift → #127

## Shepherd Journal

- [PRRT_kwDOSGizTs59uSXi](https://github.com/jonathanong/pr-shepherd/pull/137#discussion_r3144920366) (Gemini): flagged that removing `?.` could cause a runtime error if `body` is `null`/`undefined`. Rejected — `body` is typed as `string` (non-nullable) in `src/github/batch-raw-types.mts` for all review/comment/thread types; there is no code path that passes a nullable body to these formatters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)