### PR TITLE
fix(check): render ## Merge Status as a bullet list

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -41,12 +41,12 @@ Status: UNRESOLVED_COMMENTS
 
 ## Merge Status
 
-CLEAN
-  mergeStateStatus:        CLEAN
-  mergeable:               MERGEABLE
-  reviewDecision:          APPROVED
-  isDraft:                 false
-  copilotReviewInProgress: false
+- status: `CLEAN`
+- mergeStateStatus: `CLEAN`
+- mergeable: `MERGEABLE`
+- reviewDecision: `APPROVED`
+- isDraft: `false`
+- copilotReviewInProgress: `false`
 
 ## CI Checks
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -36,8 +36,10 @@ Exit codes: `0` READY · `2` IN_PROGRESS · `3` UNRESOLVED_COMMENTS · `1` all o
 **Example output:**
 
 ```
+
 PR #42 — owner/repo
 Status: UNRESOLVED_COMMENTS
+Base: main
 
 ## Merge Status
 
@@ -61,7 +63,7 @@ Status: UNRESOLVED_COMMENTS
 
 ## Summary
 
-1 actionable item(s) remaining
+1 actionable
 
 ## Instructions
 

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -12,12 +12,12 @@ export function formatText(report: ShepherdReport): string {
   const ms = report.mergeStatus;
   parts.push("## Merge Status");
   parts.push("");
-  parts.push(`${ms.status}`);
-  parts.push(`  mergeStateStatus:        ${ms.mergeStateStatus}`);
-  parts.push(`  mergeable:               ${ms.mergeable}`);
-  parts.push(`  reviewDecision:          ${ms.reviewDecision ?? "(none)"}`);
-  parts.push(`  isDraft:                 ${ms.isDraft}`);
-  parts.push(`  copilotReviewInProgress: ${ms.copilotReviewInProgress}`);
+  parts.push(`- status: \`${ms.status}\``);
+  parts.push(`- mergeStateStatus: \`${ms.mergeStateStatus}\``);
+  parts.push(`- mergeable: \`${ms.mergeable}\``);
+  parts.push(`- reviewDecision: \`${ms.reviewDecision ?? "(none)"}\``);
+  parts.push(`- isDraft: \`${ms.isDraft}\``);
+  parts.push(`- copilotReviewInProgress: \`${ms.copilotReviewInProgress}\``);
   parts.push("");
 
   const { passing, failing, inProgress, skipped } = report.checks;

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -85,12 +85,13 @@ describe("formatText — header", () => {
     expect(out).toContain("Status: FAILING");
   });
 
-  it("includes merge status heading and fields", () => {
+  it("includes merge status heading and fields as a bullet list", () => {
     const out = formatText(makeReport());
     expect(out).toContain("## Merge Status");
-    expect(out).toContain("CLEAN");
-    expect(out).toContain("mergeStateStatus:");
-    expect(out).toContain("mergeable:");
+    expect(out).toContain("- status: `CLEAN`");
+    expect(out).toContain("- mergeStateStatus: `CLEAN`");
+    expect(out).toContain("- mergeable: `MERGEABLE`");
+    expect(out).not.toContain("  mergeStateStatus:");
   });
 });
 


### PR DESCRIPTION
Closes #125.

## Summary

- Converts the `## Merge Status` body in `formatText` from colon-aligned plain text with 2-space indents to a Markdown bullet list with backticked values.
- Updates the corresponding example in `docs/cli-usage.md`.
- Strengthens the test assertion to pin the new bullet format and guard against the indented-code-block regression.

## Test plan

- [ ] `npm test` — all 803 tests pass
- [ ] Dogfood: `npx pr-shepherd check <PR-URL>` — `## Merge Status` renders as a clean bullet list, not a monospace block

🤖 Generated with [Claude Code](https://claude.com/claude-code)