### PR TITLE
fix: replace ASCII-padded status table with Markdown table

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -359,9 +359,13 @@ pr-shepherd status 100
 ```
 # owner/repo — PR status (3)
 
-PR #41    Add new feature for user authentication           READY        SUCCESS
-PR #42    Refactor internal module                          IN PROGRESS  PENDING
-PR #43    Fix edge case in parser                           BLOCKED      SUCCESS (threads truncated — run pr-shepherd check for full count)
+| PR | Title | Verdict | CI |
+| --- | --- | --- | --- |
+| #41 | Add new feature for user authentication | READY | SUCCESS |
+| #42 | Refactor internal module | IN PROGRESS | PENDING |
+| #43 | Fix edge case in parser | BLOCKED | SUCCESS |
+
+> Note: PR #43 threads truncated — run `pr-shepherd check 43` for full count.
 ```
 
 Exit code: `0` if every PR is READY, `1` otherwise.

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -142,7 +142,10 @@ export function formatStatusTable(summaries: PrSummary[], repoFull: string): str
   const table = ["| PR | Title | Verdict | CI |", "| --- | --- | --- | --- |", ...rows].join("\n");
   const footnotes = summaries
     .filter((s) => s.threadsTruncated)
-    .map((s) => `> Note: PR #${s.number} threads truncated — run \`pr-shepherd check ${s.number}\` for full count.`);
+    .map(
+      (s) =>
+        `> Note: PR #${s.number} threads truncated — run \`pr-shepherd check ${s.number}\` for full count.`,
+    );
   return [heading, table, ...footnotes].join("\n\n");
 }
 

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -132,21 +132,28 @@ async function paginateAndBuild(
 // ---------------------------------------------------------------------------
 
 export function formatStatusTable(summaries: PrSummary[], repoFull: string): string {
-  const lines: string[] = [`\n# ${repoFull} — PR status (${summaries.length})\n`];
+  const heading = `# ${repoFull} — PR status (${summaries.length})`;
+  if (summaries.length === 0) return heading;
 
-  for (const s of summaries) {
+  const rows = summaries.map((s) => {
     const verdict = deriveVerdict(s);
     const ciLabel = s.ciState ?? "—";
-    const title = s.title.slice(0, 50);
-    const truncNote = s.threadsTruncated
-      ? " (threads truncated — run shepherd check for full count)"
-      : "";
-    lines.push(
-      `PR #${String(s.number).padEnd(5)} ${title.padEnd(52)} ${verdict.padEnd(12)} ${ciLabel}${truncNote}`,
-    );
-  }
+    const title = s.title.slice(0, 50).replace(/\|/g, "\\|");
+    return `| #${s.number} | ${title} | ${verdict} | ${ciLabel} |`;
+  });
 
-  return lines.join("\n");
+  const table = [
+    "| PR | Title | Verdict | CI |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+  ].join("\n");
+
+  const footnotes = summaries
+    .filter((s) => s.threadsTruncated)
+    .map((s) => `> Note: PR #${s.number} threads truncated — run \`pr-shepherd check ${s.number}\` for full count.`);
+
+  const parts = [heading, table, ...footnotes];
+  return parts.join("\n\n");
 }
 
 export function deriveVerdict(s: PrSummary): string {

--- a/src/commands/status.mts
+++ b/src/commands/status.mts
@@ -134,26 +134,16 @@ async function paginateAndBuild(
 export function formatStatusTable(summaries: PrSummary[], repoFull: string): string {
   const heading = `# ${repoFull} — PR status (${summaries.length})`;
   if (summaries.length === 0) return heading;
-
   const rows = summaries.map((s) => {
-    const verdict = deriveVerdict(s);
-    const ciLabel = s.ciState ?? "—";
-    const title = s.title.slice(0, 50).replace(/\|/g, "\\|");
-    return `| #${s.number} | ${title} | ${verdict} | ${ciLabel} |`;
+    const raw = s.title.length > 50 ? `${s.title.slice(0, 47)}...` : s.title;
+    const title = raw.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ");
+    return `| #${s.number} | ${title} | ${deriveVerdict(s)} | ${s.ciState ?? "—"} |`;
   });
-
-  const table = [
-    "| PR | Title | Verdict | CI |",
-    "| --- | --- | --- | --- |",
-    ...rows,
-  ].join("\n");
-
+  const table = ["| PR | Title | Verdict | CI |", "| --- | --- | --- | --- |", ...rows].join("\n");
   const footnotes = summaries
     .filter((s) => s.threadsTruncated)
     .map((s) => `> Note: PR #${s.number} threads truncated — run \`pr-shepherd check ${s.number}\` for full count.`);
-
-  const parts = [heading, table, ...footnotes];
-  return parts.join("\n\n");
+  return [heading, table, ...footnotes].join("\n\n");
 }
 
 export function deriveVerdict(s: PrSummary): string {

--- a/src/commands/status.test.mts
+++ b/src/commands/status.test.mts
@@ -144,11 +144,11 @@ describe("formatStatusTable — deriveVerdict precedence", () => {
 // ---------------------------------------------------------------------------
 
 describe("formatStatusTable — formatting", () => {
-  it("truncates title to 50 chars", () => {
+  it("truncates title with ellipsis at 50 chars total", () => {
     const longTitle = "A".repeat(60);
     const out = formatStatusTable([makeSummary({ title: longTitle })], "owner/repo");
-    expect(out).toContain("A".repeat(50));
-    expect(out).not.toContain("A".repeat(51));
+    expect(out).toContain("A".repeat(47) + "...");
+    expect(out).not.toContain("A".repeat(48));
   });
 
   it("appends threadsTruncated note when flag is true", () => {

--- a/src/commands/status.test.mts
+++ b/src/commands/status.test.mts
@@ -160,6 +160,24 @@ describe("formatStatusTable — formatting", () => {
     const out = formatStatusTable([makeSummary({ threadsTruncated: false })], "owner/repo");
     expect(out).not.toContain("threads truncated");
   });
+
+  it("renders a Markdown table header and separator", () => {
+    const out = formatStatusTable([makeSummary()], "owner/repo");
+    expect(out).toContain("| PR | Title | Verdict | CI |");
+    expect(out).toContain("| --- | --- | --- | --- |");
+  });
+
+  it("escapes pipe characters in titles", () => {
+    const out = formatStatusTable([makeSummary({ title: "feat: a|b" })], "owner/repo");
+    expect(out).toContain("a\\|b");
+    expect(out).not.toContain("a|b");
+  });
+
+  it("returns only heading for empty summaries", () => {
+    const out = formatStatusTable([], "owner/repo");
+    expect(out).toBe("# owner/repo — PR status (0)");
+    expect(out).not.toContain("| --- |");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #126
- Replaces `padEnd()`-based ASCII column alignment in `formatStatusTable` with a GFM pipe table
- Pipe characters in PR titles are escaped to `\|` to avoid breaking table structure
- Truncated-threads notes are emitted as blockquote footnotes after the table rather than inline

## Test plan

- [x] All 24 existing + new tests in `src/commands/status.test.mts` pass
- [x] New tests cover: Markdown table header/separator present, pipe-in-title escaping, empty-summaries returns heading only
- [x] `npm run build` clean
- [x] `docs/cli-usage.md` updated to reflect new output shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)