### PR TITLE
fix: check output starts with H1 heading, drop stray leading newline

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -36,8 +36,7 @@ Exit codes: `0` READY · `2` IN_PROGRESS · `3` UNRESOLVED_COMMENTS · `1` all o
 **Example output:**
 
 ```
-
-PR #42 — owner/repo
+# PR #42 [CHECK] — owner/repo
 Status: UNRESOLVED_COMMENTS
 Base: main
 

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -5,7 +5,7 @@ import { firstLine, renderFirstLookItems } from "../cli/first-look.mts";
 export function formatText(report: ShepherdReport): string {
   const parts: string[] = [];
 
-  parts.push(`\nPR #${report.pr} — ${report.repo}`);
+  parts.push(`# PR #${report.pr} [CHECK] — ${report.repo}`);
   parts.push(`Status: ${report.status}`);
   parts.push(`Base: ${report.baseBranch}`);
   parts.push("");

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -74,6 +74,11 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
 }
 
 describe("formatText — header", () => {
+  it("starts with H1 line — no leading blank line", () => {
+    const out = formatText(makeReport());
+    expect(out.split("\n")[0]).toBe("# PR #42 [CHECK] — owner/repo");
+  });
+
   it("includes PR number and repo", () => {
     const out = formatText(makeReport());
     expect(out).toContain("PR #42");
@@ -134,8 +139,9 @@ describe("formatText — failed checks", () => {
       checks: { ...makeReport().checks, failing: [failing] },
     });
     const out = formatText(report);
-    expect(out).toContain("- lint:");
-    expect(out).not.toContain("[");
+    const lintLine = out.split("\n").find((l) => l.includes("- lint:"));
+    expect(lintLine).toBeDefined();
+    expect(lintLine).not.toContain("[");
   });
 
   it("renders failedStep when present", () => {

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -75,8 +75,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
 
 describe("formatText — header", () => {
   it("starts with H1 line — no leading blank line", () => {
-    const out = formatText(makeReport());
-    expect(out.split("\n")[0]).toBe("# PR #42 [CHECK] — owner/repo");
+    expect(formatText(makeReport()).split("\n")[0]).toBe("# PR #42 [CHECK] — owner/repo");
   });
 
   it("includes PR number and repo", () => {

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -140,10 +140,7 @@ describe("formatText — failed checks", () => {
     });
     const out = formatText(report);
     const lintLine = out.split("\n").find((l) => l.includes("- lint:"));
-    expect(lintLine).toBeDefined();
-    if (lintLine === undefined) {
-      throw new Error('Expected to find a line containing "- lint:"');
-    }
+    if (lintLine === undefined) throw new Error('Expected to find a line containing "- lint:"');
     expect(lintLine).not.toContain("[");
   });
 

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -141,6 +141,9 @@ describe("formatText — failed checks", () => {
     const out = formatText(report);
     const lintLine = out.split("\n").find((l) => l.includes("- lint:"));
     expect(lintLine).toBeDefined();
+    if (lintLine === undefined) {
+      throw new Error('Expected to find a line containing "- lint:"');
+    }
     expect(lintLine).not.toContain("[");
   });
 


### PR DESCRIPTION
## Summary

- `pr-shepherd check` text output was starting with a stray blank line followed by a plain-text `PR #42 — owner/repo` heading, violating the load-bearing convention in `docs/actions.md:40` that line 1 is always an H1 of the form `# PR #<N> [<ACTION>]`
- Fixes `src/reporters/text.mts:7` to emit `# PR #<N> [CHECK] — <repo>` with no leading `\n`
- Updates `docs/cli-usage.md` example output to match
- Adds a test pinning the H1 convention; narrows the existing `not.toContain("[")` assertion to scope it to the failing-check line only (the heading now legitimately contains `[`)

Closes #124

## Test plan

- [ ] `npm test -- src/reporters/text.test.mts` — all 38 tests pass
- [ ] `npm run lint` — clean
- [ ] Manual: `npx pr-shepherd check <N>` output begins with `# PR #<N> [CHECK] — <repo>` on line 1, no preceding blank line

🤖 Generated with [Claude Code](https://claude.ai/claude-code)