### PR TITLE
refactor: extract shared renderFirstLookItems helper, unify output (#127)

### DIFF
--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -483,10 +483,12 @@ describe("main — resolve first-look rendering", () => {
     });
     await main(["node", "shepherd", "resolve", "42"]);
     const out = getStdout();
-    expect(out).toContain("## First-look items (2)");
-    expect(out).toContain("threadId=PRRT_fl1");
+    expect(out).toContain(
+      "## First-look items (2) — already closed on GitHub; acknowledge only",
+    );
+    expect(out).toContain("`threadId=PRRT_fl1`");
     expect(out).toContain("[status: resolved]");
-    expect(out).toContain("commentId=PRRC_fl2");
+    expect(out).toContain("`commentId=PRRC_fl2`");
     expect(out).toContain("[status: minimized]");
   });
 });

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -483,9 +483,7 @@ describe("main — resolve first-look rendering", () => {
     });
     await main(["node", "shepherd", "resolve", "42"]);
     const out = getStdout();
-    expect(out).toContain(
-      "## First-look items (2) — already closed on GitHub; acknowledge only",
-    );
+    expect(out).toContain("## First-look items (2) — already closed on GitHub; acknowledge only");
     expect(out).toContain("`threadId=PRRT_fl1`");
     expect(out).toContain("[status: resolved]");
     expect(out).toContain("`commentId=PRRC_fl2`");

--- a/src/cli/first-look.mts
+++ b/src/cli/first-look.mts
@@ -1,0 +1,30 @@
+import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
+
+export function firstLine(text: string): string {
+  return (text.split("\n")[0] ?? "").trim().slice(0, 120);
+}
+
+export function renderFirstLookItems(
+  threads: FirstLookThread[],
+  comments: FirstLookComment[],
+): string | null {
+  const total = threads.length + comments.length;
+  if (total === 0) return null;
+  const lines: string[] = [
+    `## First-look items (${total}) — already closed on GitHub; acknowledge only`,
+    "",
+  ];
+  for (const t of threads) {
+    const statusTag = t.autoResolved
+      ? `[status: outdated, auto-resolved]`
+      : `[status: ${t.firstLookStatus}]`;
+    const loc = t.path ? `\`${t.path}:${t.line ?? "?"}\`` : "(no location)";
+    lines.push(`- \`threadId=${t.id}\` ${loc} (@${t.author}) ${statusTag}`);
+    lines.push(`  ${firstLine(t.body)}`);
+  }
+  for (const c of comments) {
+    lines.push(`- \`commentId=${c.id}\` (@${c.author}) [status: minimized]`);
+    lines.push(`  ${firstLine(c.body)}`);
+  }
+  return lines.join("\n");
+}

--- a/src/cli/first-look.mts
+++ b/src/cli/first-look.mts
@@ -1,7 +1,9 @@
 import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
 
 export function firstLine(text: string): string {
-  return (text.split("\n")[0] ?? "").trim().slice(0, 120);
+  const newlineIndex = text.indexOf("\n");
+  const line = newlineIndex === -1 ? text : text.slice(0, newlineIndex);
+  return line.trim().slice(0, 120);
 }
 
 export function renderFirstLookItems(

--- a/src/cli/first-look.test.mts
+++ b/src/cli/first-look.test.mts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import { firstLine, renderFirstLookItems } from "./first-look.mts";
+import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
+import { formatFetchResult } from "./formatters.mts";
+import { formatFixCodeResult } from "./fix-formatter.mts";
+import { formatText } from "../reporters/text.mts";
+import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
+import type { IterateResult, ShepherdReport } from "../types.mts";
+
+// ---------------------------------------------------------------------------
+// firstLine helper
+// ---------------------------------------------------------------------------
+
+describe("firstLine", () => {
+  it("returns the first line trimmed and sliced to 120 chars", () => {
+    const long = " " + "x".repeat(200);
+    expect(firstLine(long)).toBe("x".repeat(120));
+  });
+
+  it("stops at the first newline", () => {
+    expect(firstLine("hello\nworld")).toBe("hello");
+  });
+
+  it("handles empty string", () => {
+    expect(firstLine("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderFirstLookItems helper
+// ---------------------------------------------------------------------------
+
+describe("renderFirstLookItems", () => {
+  const baseThread: FirstLookThread = {
+    id: "PRRT_1",
+    isResolved: false,
+    isOutdated: true,
+    isMinimized: false,
+    path: "src/foo.ts",
+    line: 10,
+    startLine: null,
+    author: "alice",
+    body: "please fix this",
+    url: "",
+    createdAtUnix: 0,
+    firstLookStatus: "outdated",
+  };
+
+  const baseComment: FirstLookComment = {
+    id: "PRRC_1",
+    isMinimized: true,
+    author: "bob",
+    body: "nit comment",
+    url: "",
+    createdAtUnix: 0,
+    firstLookStatus: "minimized",
+  };
+
+  it("returns null when both arrays are empty", () => {
+    expect(renderFirstLookItems([], [])).toBeNull();
+  });
+
+  it("includes count and policy-hint suffix in heading", () => {
+    const out = renderFirstLookItems([baseThread], [baseComment])!;
+    expect(out).toContain(
+      "## First-look items (2) — already closed on GitHub; acknowledge only",
+    );
+  });
+
+  it("thread bullet uses backtick-wrapped threadId= prefix", () => {
+    const out = renderFirstLookItems([baseThread], [])!;
+    expect(out).toContain("`threadId=PRRT_1`");
+  });
+
+  it("thread bullet includes backtick-wrapped path:line location", () => {
+    const out = renderFirstLookItems([baseThread], [])!;
+    expect(out).toContain("`src/foo.ts:10`");
+  });
+
+  it("thread bullet shows (no location) when path is null", () => {
+    const t: FirstLookThread = { ...baseThread, path: null, line: null };
+    const out = renderFirstLookItems([t], [])!;
+    expect(out).toContain("(no location)");
+    expect(out).not.toContain("`null");
+  });
+
+  it("thread bullet shows path:? when line is null", () => {
+    const t: FirstLookThread = { ...baseThread, line: null };
+    const out = renderFirstLookItems([t], [])!;
+    expect(out).toContain("`src/foo.ts:?`");
+  });
+
+  it("thread bullet shows [status: outdated] for outdated non-autoResolved", () => {
+    const out = renderFirstLookItems([{ ...baseThread, firstLookStatus: "outdated" }], [])!;
+    expect(out).toContain("[status: outdated]");
+    expect(out).not.toContain("auto-resolved");
+  });
+
+  it("thread bullet shows [status: outdated, auto-resolved] when autoResolved is true", () => {
+    const t: FirstLookThread = { ...baseThread, firstLookStatus: "outdated", autoResolved: true };
+    const out = renderFirstLookItems([t], [])!;
+    expect(out).toContain("[status: outdated, auto-resolved]");
+  });
+
+  it("thread bullet shows [status: resolved] for resolved threads", () => {
+    const t: FirstLookThread = { ...baseThread, firstLookStatus: "resolved" };
+    const out = renderFirstLookItems([t], [])!;
+    expect(out).toContain("[status: resolved]");
+  });
+
+  it("thread bullet shows [status: minimized] for minimized threads", () => {
+    const t: FirstLookThread = { ...baseThread, firstLookStatus: "minimized" };
+    const out = renderFirstLookItems([t], [])!;
+    expect(out).toContain("[status: minimized]");
+  });
+
+  it("thread body appears on continuation line indented with two spaces", () => {
+    const out = renderFirstLookItems([baseThread], [])!;
+    expect(out).toContain("\n  please fix this");
+  });
+
+  it("thread body is trimmed and sliced to 120 chars", () => {
+    const longBody = "  " + "y".repeat(200) + "\nsecond line";
+    const t: FirstLookThread = { ...baseThread, body: longBody };
+    const out = renderFirstLookItems([t], [])!;
+    expect(out).toContain("\n  " + "y".repeat(120));
+    expect(out).not.toContain("second line");
+  });
+
+  it("comment bullet uses backtick-wrapped commentId= prefix", () => {
+    const out = renderFirstLookItems([], [baseComment])!;
+    expect(out).toContain("`commentId=PRRC_1`");
+  });
+
+  it("comment bullet always shows [status: minimized]", () => {
+    const out = renderFirstLookItems([], [baseComment])!;
+    expect(out).toContain("[status: minimized]");
+  });
+
+  it("comment body appears on continuation line", () => {
+    const out = renderFirstLookItems([], [baseComment])!;
+    expect(out).toContain("\n  nit comment");
+  });
+
+  it("threads appear before comments", () => {
+    const out = renderFirstLookItems([baseThread], [baseComment])!;
+    expect(out.indexOf("threadId=")).toBeLessThan(out.indexOf("commentId="));
+  });
+
+  it("heading is followed by a blank line before bullets", () => {
+    const out = renderFirstLookItems([baseThread], [])!;
+    expect(out).toMatch(/## First-look items.*\n\n-/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-call-site identity assertion (issue #127 acceptance criterion)
+//
+// All three formatters must emit a byte-equal ## First-look items section
+// for the same input.
+// ---------------------------------------------------------------------------
+
+const FL_THREAD_OUTDATED_AUTO: FirstLookThread = {
+  id: "PRRT_fl1",
+  isResolved: false,
+  isOutdated: true,
+  isMinimized: false,
+  path: "src/bar.ts",
+  line: 7,
+  startLine: null,
+  author: "alice",
+  body: "old comment",
+  url: "",
+  createdAtUnix: 0,
+  firstLookStatus: "outdated",
+  autoResolved: true,
+};
+
+const FL_THREAD_RESOLVED: FirstLookThread = {
+  id: "PRRT_fl2",
+  isResolved: true,
+  isOutdated: false,
+  isMinimized: false,
+  path: "src/baz.ts",
+  line: 3,
+  startLine: null,
+  author: "bob",
+  body: "already addressed",
+  url: "",
+  createdAtUnix: 0,
+  firstLookStatus: "resolved",
+};
+
+const FL_COMMENT: FirstLookComment = {
+  id: "PRRC_fl1",
+  isMinimized: true,
+  author: "bot",
+  body: "quota warning",
+  url: "",
+  createdAtUnix: 0,
+  firstLookStatus: "minimized",
+};
+
+function extractFirstLookSection(output: string): string {
+  const start = output.indexOf("## First-look items");
+  if (start === -1) throw new Error("## First-look items section not found in output");
+  const nextSection = output.indexOf("\n## ", start + 1);
+  return nextSection === -1 ? output.slice(start).trimEnd() : output.slice(start, nextSection).trimEnd();
+}
+
+describe("## First-look items — cross-call-site consistency", () => {
+  it("all three formatters render an identical section for the same input", () => {
+    // Site A: formatFixCodeResult (iterate fix_code)
+    const iterateResult: IterateResult = {
+      ...makeIterateResult("fix_code"),
+    };
+    if (iterateResult.action !== "fix_code") throw new Error("unreachable");
+    iterateResult.fix = {
+      ...iterateResult.fix,
+      firstLookThreads: [FL_THREAD_OUTDATED_AUTO, FL_THREAD_RESOLVED],
+      firstLookComments: [FL_COMMENT],
+    };
+    const siteA = extractFirstLookSection(
+      formatFixCodeResult("# PR #42 [FIX_CODE]", iterateResult),
+    );
+
+    // Site B: formatFetchResult (resolve --fetch)
+    const siteB = extractFirstLookSection(
+      formatFetchResult({
+        prNumber: 42,
+        actionableThreads: [],
+        actionableComments: [],
+        firstLookThreads: [FL_THREAD_OUTDATED_AUTO, FL_THREAD_RESOLVED],
+        firstLookComments: [FL_COMMENT],
+        changesRequestedReviews: [],
+        reviewSummaries: [],
+        commitSuggestionsEnabled: false,
+        instructions: [],
+      }),
+    );
+
+    // Site C: formatText (check)
+    const report: ShepherdReport = {
+      pr: 42,
+      nodeId: "PR_kgDOAAA",
+      repo: "owner/repo",
+      status: "READY",
+      baseBranch: "main",
+      mergeStatus: {
+        status: "CLEAN",
+        state: "OPEN",
+        isDraft: false,
+        mergeable: "MERGEABLE",
+        reviewDecision: null,
+        copilotReviewInProgress: false,
+        mergeStateStatus: "CLEAN",
+      },
+      checks: {
+        passing: [],
+        failing: [],
+        inProgress: [],
+        skipped: [],
+        filtered: [],
+        filteredNames: [],
+        blockedByFilteredCheck: false,
+      },
+      threads: {
+        actionable: [],
+        autoResolved: [],
+        autoResolveErrors: [],
+        firstLook: [FL_THREAD_OUTDATED_AUTO, FL_THREAD_RESOLVED],
+      },
+      comments: { actionable: [], firstLook: [FL_COMMENT] },
+      changesRequestedReviews: [],
+      reviewSummaries: [],
+      approvedReviews: [],
+    };
+    const siteC = extractFirstLookSection(formatText(report));
+
+    expect(siteA).toBe(siteB);
+    expect(siteA).toBe(siteC);
+  });
+});

--- a/src/cli/first-look.test.mts
+++ b/src/cli/first-look.test.mts
@@ -62,9 +62,7 @@ describe("renderFirstLookItems", () => {
 
   it("includes count and policy-hint suffix in heading", () => {
     const out = renderFirstLookItems([baseThread], [baseComment])!;
-    expect(out).toContain(
-      "## First-look items (2) — already closed on GitHub; acknowledge only",
-    );
+    expect(out).toContain("## First-look items (2) — already closed on GitHub; acknowledge only");
   });
 
   it("thread bullet uses backtick-wrapped threadId= prefix", () => {
@@ -205,7 +203,9 @@ function extractFirstLookSection(output: string): string {
   const start = output.indexOf("## First-look items");
   if (start === -1) throw new Error("## First-look items section not found in output");
   const nextSection = output.indexOf("\n## ", start + 1);
-  return nextSection === -1 ? output.slice(start).trimEnd() : output.slice(start, nextSection).trimEnd();
+  return nextSection === -1
+    ? output.slice(start).trimEnd()
+    : output.slice(start, nextSection).trimEnd();
 }
 
 describe("## First-look items — cross-call-site consistency", () => {

--- a/src/cli/fix-formatter.mts
+++ b/src/cli/fix-formatter.mts
@@ -1,6 +1,7 @@
 import { renderResolveCommand } from "../commands/iterate.mts";
 import { safeFence } from "./fence.mts";
 import { renderSuggestionBlock, renderLineRange } from "./suggestion-renderer.mts";
+import { renderFirstLookItems } from "./first-look.mts";
 import type { IterateResultFixCode } from "../types.mts";
 
 export function formatFixCodeResult(header: string, result: IterateResultFixCode): string {
@@ -79,28 +80,8 @@ export function formatFixCodeResult(header: string, result: IterateResultFixCode
     }
   }
 
-  const firstLookTotal = result.fix.firstLookThreads.length + result.fix.firstLookComments.length;
-  if (firstLookTotal > 0) {
-    sections.push(
-      `## First-look items (${firstLookTotal}) — already closed on GitHub; acknowledge only`,
-    );
-    const bullets: string[] = [];
-    for (const t of result.fix.firstLookThreads) {
-      const statusTag = t.autoResolved
-        ? `[status: outdated, auto-resolved]`
-        : `[status: ${t.firstLookStatus}]`;
-      const loc = t.path ? `\`${t.path}:${t.line ?? "?"}\`` : "(no location)";
-      bullets.push(
-        `- \`${t.id}\` ${loc} (@${t.author}) ${statusTag}: ${t.body.split("\n")[0]?.slice(0, 100) ?? ""}`,
-      );
-    }
-    for (const c of result.fix.firstLookComments) {
-      bullets.push(
-        `- \`${c.id}\` (@${c.author}) [status: minimized]: ${c.body.split("\n")[0]?.slice(0, 100) ?? ""}`,
-      );
-    }
-    sections.push(bullets.join("\n"));
-  }
+  const firstLook = renderFirstLookItems(result.fix.firstLookThreads, result.fix.firstLookComments);
+  if (firstLook) sections.push(firstLook);
 
   if (result.cancelled.length > 0) {
     sections.push("## Cancelled runs");

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -3,6 +3,7 @@ export { projectIterateLean } from "./iterate-lean.mts";
 
 import { safeFence } from "./fence.mts";
 import { renderSuggestionBlock, renderLineRange } from "./suggestion-renderer.mts";
+import { renderFirstLookItems } from "./first-look.mts";
 import type { FetchResult } from "../commands/resolve.mts";
 import type { CommitSuggestionResult } from "../types.mts";
 import type { ResolveResult } from "../comments/resolve.mts";
@@ -75,27 +76,8 @@ export function formatFetchResult(result: FetchResult): string {
     );
   }
 
-  if (firstLookTotal > 0) {
-    sections.push(
-      `## First-look items (${firstLookTotal}) — already closed on GitHub; acknowledge only`,
-    );
-    const bullets: string[] = [];
-    for (const t of result.firstLookThreads) {
-      const statusTag = t.autoResolved
-        ? `[status: outdated, auto-resolved]`
-        : `[status: ${t.firstLookStatus}]`;
-      const loc = t.path ? `\`${t.path}:${t.line ?? "?"}\`` : "(no location)";
-      bullets.push(
-        `- \`threadId=${t.id}\` ${loc} (@${t.author}) ${statusTag}: ${t.body.split("\n")[0]?.slice(0, 100) ?? ""}`,
-      );
-    }
-    for (const c of result.firstLookComments) {
-      bullets.push(
-        `- \`commentId=${c.id}\` (@${c.author}) [status: minimized]: ${c.body.split("\n")[0]?.slice(0, 100) ?? ""}`,
-      );
-    }
-    sections.push(bullets.join("\n"));
-  }
+  const firstLook = renderFirstLookItems(result.firstLookThreads, result.firstLookComments);
+  if (firstLook) sections.push(firstLook);
 
   sections.push("## Summary");
   sections.push(

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -182,4 +182,3 @@ export function formatText(report: ShepherdReport): string {
 
   return parts.join("\n");
 }
-

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -1,5 +1,6 @@
 import type { ShepherdReport, TriagedCheck } from "../types.mts";
 import { buildCheckInstructions } from "./check-instructions.mts";
+import { firstLine, renderFirstLookItems } from "../cli/first-look.mts";
 
 export function formatText(report: ShepherdReport): string {
   const parts: string[] = [];
@@ -156,21 +157,9 @@ export function formatText(report: ShepherdReport): string {
     parts.push("");
   }
   const firstLookTotal = firstLookThreads.length + firstLookComments.length;
-  if (firstLookTotal > 0) {
-    parts.push("## First-look items");
-    parts.push("");
-    for (const t of firstLookThreads) {
-      const statusTag = t.autoResolved
-        ? `[status: outdated, auto-resolved]`
-        : `[status: ${t.firstLookStatus}]`;
-      const loc = t.path ? `${t.path}:${t.line ?? "?"}` : "(no location)";
-      parts.push(`- threadId=${t.id} ${loc} (@${t.author}) ${statusTag}`);
-      parts.push(`  ${firstLine(t.body)}`);
-    }
-    for (const c of firstLookComments) {
-      parts.push(`- commentId=${c.id} (@${c.author}) [status: minimized]`);
-      parts.push(`  ${firstLine(c.body)}`);
-    }
+  const firstLookBlock = renderFirstLookItems(firstLookThreads, firstLookComments);
+  if (firstLookBlock) {
+    parts.push(firstLookBlock);
     parts.push("");
   }
 
@@ -194,6 +183,3 @@ export function formatText(report: ShepherdReport): string {
   return parts.join("\n");
 }
 
-function firstLine(text: string): string {
-  return (text.split("\n")[0] ?? "").trim().slice(0, 120);
-}

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -485,10 +485,12 @@ describe("formatText — first-look items", () => {
       comments: { actionable: [], firstLook: [comment] },
     });
     const out = formatText(report);
-    expect(out).toContain("## First-look items");
-    expect(out).toContain("threadId=PRRT_abc");
+    expect(out).toContain(
+      "## First-look items (2) — already closed on GitHub; acknowledge only",
+    );
+    expect(out).toContain("`threadId=PRRT_abc`");
     expect(out).toContain("[status: outdated]");
-    expect(out).toContain("commentId=PRRC_xyz");
+    expect(out).toContain("`commentId=PRRC_xyz`");
     expect(out).toContain("[status: minimized]");
   });
 });

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -485,9 +485,7 @@ describe("formatText — first-look items", () => {
       comments: { actionable: [], firstLook: [comment] },
     });
     const out = formatText(report);
-    expect(out).toContain(
-      "## First-look items (2) — already closed on GitHub; acknowledge only",
-    );
+    expect(out).toContain("## First-look items (2) — already closed on GitHub; acknowledge only");
     expect(out).toContain("`threadId=PRRT_abc`");
     expect(out).toContain("[status: outdated]");
     expect(out).toContain("`commentId=PRRC_xyz`");


### PR DESCRIPTION
## Summary

- Extracts `renderFirstLookItems` and `firstLine` into `src/cli/first-look.mts`, replacing three diverged hand-written templates in `fix-formatter.mts`, `formatters.mts`, and `reporters/text.mts`
- Unifies output to the canonical heading (`## First-look items (N) — already closed on GitHub; acknowledge only`), backtick-wrapped `threadId=`/`commentId=` ID prefixes, continuation layout, and 120-char trimmed body slice
- Adds 20 direct helper tests (`src/cli/first-look.test.mts`) and one cross-call-site byte-equality consistency test asserting all three formatters produce the same section for the same input

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 824 tests pass (21 new)
- [x] Consistency test (`## First-look items — cross-call-site consistency`) asserts `siteA === siteB === siteC`

Fixes #127

## Shepherd Journal

**Rejected [copilot suggestion on text.mts:3-4](https://github.com/jonathanong/pr-shepherd/pull/143#discussion_r3144932708)** — The suggestion proposed re-adding a local `firstLine` in `src/reporters/text.mts` (with a different type signature and no 120-char truncation), removing the shared import. This would (a) remove the 120-char body truncation that `firstLine` is specifically designed to enforce, and (b) re-introduce exactly the kind of formatter drift that this PR was created to eliminate. The `reporters → cli` import direction is a style preference — not a correctness issue — and moving the helper to `src/util/text.mts` can be done in a separate PR if desired.

**Applied [gemini suggestion on first-look.mts:3-5](https://github.com/jonathanong/pr-shepherd/pull/143#discussion_r3144925686)** — Replaced `split("\n")[0] ?? ""` with `indexOf("\n")` + `slice` to avoid allocating a full split array; removed the redundant `?? ""` (split always returns at least one element).

🤖 Generated with [Claude Code](https://claude.com/claude-code)