### PR TITLE
Add pr-shepherd-mcp MCP server with webhook push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,30 @@ See [docs/skills.md](docs/skills.md) for full argument reference.
 
 On each tick (4-minute default, tunable via `watch.interval`): fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (`fix_code`, `mark_ready`, `cancel`, `escalate`, `wait`, or `cooldown`). See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
 
+## MCP Server
+
+`pr-shepherd-mcp` is a long-lived MCP server that exposes all CLI commands as MCP tools and can receive GitHub webhooks to push PR activity notifications directly into the connected Claude Code session.
+
+```json
+{
+  "mcpServers": {
+    "pr-shepherd": {
+      "command": "npx",
+      "args": ["pr-shepherd-mcp"],
+      "env": {
+        "GH_TOKEN": "ghp_...",
+        "SHEPHERD_WEBHOOK_PORT": "3000",
+        "GITHUB_WEBHOOK_SECRET": "your-secret"
+      }
+    }
+  }
+}
+```
+
+Once connected, call `shepherd_subscribe_pr` with a PR number to receive `<github-webhook-activity>` notifications whenever GitHub sends a matching webhook event. All 10 tools (`shepherd_check`, `shepherd_iterate`, `shepherd_resolve_fetch`, `shepherd_resolve_mutate`, `shepherd_commit_suggestion`, `shepherd_monitor`, `shepherd_status`, `shepherd_log_file`, `shepherd_subscribe_pr`, `shepherd_unsubscribe_pr`) are available directly in Claude Code's tool list.
+
+See [docs/mcp-server.md](docs/mcp-server.md) for full setup and tool reference.
+
 ## Install
 
 > **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `npx pr-shepherd`, so you also need the CLI available. If you're using `pr-shepherd` as development tooling for your repo, install it as a dev dependency so `npx` resolves it without prompting:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -7,7 +7,7 @@
 The CLI is pull-based — Claude Code calls `npx pr-shepherd` each time it wants data. The MCP server adds two things the CLI cannot do:
 
 1. **Direct tool calls** — Claude Code can call `shepherd_check`, `shepherd_iterate`, etc. without spawning a subprocess.
-2. **Push notifications** — The MCP server runs a webhook HTTP endpoint. When GitHub sends a PR event, the server immediately notifies the connected session via an MCP `notifications/message` containing a `<github-webhook-activity>` block — the same format handled by Claude Code's PR activity event system.
+2. **Push notifications** — The MCP server runs a webhook HTTP endpoint. When GitHub sends a PR event, the server immediately notifies the connected session via an MCP logging notification (`notifications/message` with `method: logging`) containing a `<github-webhook-activity>` block.
 
 ## Setup
 
@@ -180,5 +180,5 @@ Stop forwarding webhook events for a PR to this session.
 | Process model      | Short-lived per invocation | Long-lived, persistent connection     |
 | Invocation         | Bash subprocess            | Direct MCP tool call                  |
 | Webhook support    | None                       | HTTP endpoint + push notifications    |
-| Subscription state | None                       | Per-connection in-memory set          |
+| Subscription state | None                       | Per-process in-memory set             |
 | `setupLog()`       | Yes (stdout tee)           | No (stdout reserved for MCP protocol) |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,184 @@
+# MCP Server (`pr-shepherd-mcp`)
+
+`pr-shepherd-mcp` is a long-lived MCP server that exposes all pr-shepherd CLI commands as MCP tools and optionally receives GitHub webhook events to push PR activity notifications to the connected Claude Code session.
+
+## Why an MCP server?
+
+The CLI is pull-based — Claude Code calls `npx pr-shepherd` each time it wants data. The MCP server adds two things the CLI cannot do:
+
+1. **Direct tool calls** — Claude Code can call `shepherd_check`, `shepherd_iterate`, etc. without spawning a subprocess.
+2. **Push notifications** — The MCP server runs a webhook HTTP endpoint. When GitHub sends a PR event, the server immediately notifies the connected session via an MCP `notifications/message` containing a `<github-webhook-activity>` block — the same format handled by Claude Code's PR activity event system.
+
+## Setup
+
+### 1. Configure Claude Code
+
+Add to your Claude Code MCP config (e.g. `~/.claude.json` or `.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "pr-shepherd": {
+      "command": "npx",
+      "args": ["pr-shepherd-mcp"],
+      "env": {
+        "GH_TOKEN": "ghp_...",
+        "SHEPHERD_WEBHOOK_PORT": "3000",
+        "GITHUB_WEBHOOK_SECRET": "your-secret"
+      }
+    }
+  }
+}
+```
+
+### 2. Set up the GitHub webhook
+
+In your repository's Settings → Webhooks → Add webhook:
+
+- **Payload URL**: `http://your-host:3000/webhook`
+- **Content type**: `application/json`
+- **Secret**: value of `GITHUB_WEBHOOK_SECRET`
+- **Events**: Push, Pull request, Pull request review, Check suite, Check run
+
+### 3. Subscribe to PR events
+
+Once a session is active, subscribe to a PR so webhook events are forwarded:
+
+```
+Call shepherd_subscribe_pr with { prNumber: 123 }
+```
+
+Events for PR #123 will then appear as `<github-webhook-activity>` notifications in the session.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SHEPHERD_WEBHOOK_PORT` | `3000` | HTTP port for the webhook endpoint. Set to `0` to disable. |
+| `GITHUB_WEBHOOK_SECRET` | — | HMAC secret for `X-Hub-Signature-256` validation. Optional but recommended. |
+| `GH_TOKEN` / `GITHUB_TOKEN` | — | GitHub API token. Required for all tool calls. |
+
+## Webhook notification format
+
+When a webhook event arrives for a subscribed PR, the session receives:
+
+```
+<github-webhook-activity>
+event: pull_request
+action: synchronize
+pr: 123
+repo: owner/repo
+ref: refs/heads/feature-branch
+sha: abc123def456
+actor: username
+timestamp: 2026-04-27T12:00:00Z
+</github-webhook-activity>
+```
+
+Fields `action`, `ref`, `sha`, and `actor` are omitted when not present in the GitHub payload.
+
+## Tool reference
+
+All tools return plain text output identical to the corresponding CLI command's `--format=text` output. Tools return `isError: true` when the underlying command fails.
+
+### `shepherd_check`
+
+Get a PR status snapshot.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | no | PR number (auto-detected from current branch if omitted) |
+| `skipTriage` | boolean | no | Skip fetching job info and log tails for failing checks |
+
+### `shepherd_resolve_fetch`
+
+Fetch actionable review threads and comments. Auto-resolves outdated threads and surfaces first-look items with instructions.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | no | PR number |
+
+### `shepherd_resolve_mutate`
+
+Resolve, minimize, or dismiss review items by ID.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | no | PR number |
+| `resolveThreadIds` | string[] | no | Thread node IDs to resolve |
+| `minimizeCommentIds` | string[] | no | Comment node IDs to minimize |
+| `dismissReviewIds` | string[] | no | Review node IDs to dismiss |
+| `dismissMessage` | string | no | Required when dismissing reviews |
+| `requireSha` | string | no | Wait for GitHub to receive this commit SHA before resolving |
+
+### `shepherd_commit_suggestion`
+
+Apply a suggestion block from a review thread and create a git commit.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `threadId` | string | **yes** | Review thread node ID |
+| `prNumber` | number | no | PR number |
+| `message` | string | no | Commit message (required unless `dryRun`) |
+| `description` | string | no | Extended commit description |
+| `dryRun` | boolean | no | Validate patch without applying |
+
+### `shepherd_iterate`
+
+Run one iterate cycle and return the next action (`fix_code`, `wait`, `mark_ready`, `cancel`, or `escalate`) with instructions.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | no | PR number |
+| `cooldownSeconds` | number | no | Min seconds between code changes |
+| `readyDelaySeconds` | number | no | Delay before marking ready |
+| `stallTimeoutSeconds` | number | no | Abort if no progress after N seconds |
+| `noAutoMarkReady` | boolean | no | Disable draft → ready transition |
+| `noAutoCancelActionable` | boolean | no | Disable auto-cancel of actionable checks |
+
+### `shepherd_monitor`
+
+Get the `/loop` arguments and prompt body to bootstrap continuous monitoring.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | no | PR number |
+| `readyDelaySuffix` | string | no | Ready-delay duration, e.g. `"15m"` |
+
+### `shepherd_status`
+
+Get a status table for one or more PRs.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumbers` | number[] | **yes** | PR numbers to check (min 1) |
+
+### `shepherd_log_file`
+
+Return the path to the per-worktree debug log file. No inputs.
+
+### `shepherd_subscribe_pr`
+
+Subscribe the current session to GitHub webhook events for a PR.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | **yes** | PR to subscribe to |
+
+### `shepherd_unsubscribe_pr`
+
+Stop forwarding webhook events for a PR to this session.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prNumber` | number | **yes** | PR to unsubscribe from |
+
+## Differences from CLI
+
+| | CLI (`npx pr-shepherd`) | MCP server (`pr-shepherd-mcp`) |
+|-|------------------------|-------------------------------|
+| Process model | Short-lived per invocation | Long-lived, persistent connection |
+| Invocation | Bash subprocess | Direct MCP tool call |
+| Webhook support | None | HTTP endpoint + push notifications |
+| Subscription state | None | Per-connection in-memory set |
+| `setupLog()` | Yes (stdout tee) | No (stdout reserved for MCP protocol) |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -52,11 +52,11 @@ Events for PR #123 will then appear as `<github-webhook-activity>` notifications
 
 ## Environment variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SHEPHERD_WEBHOOK_PORT` | `3000` | HTTP port for the webhook endpoint. Set to `0` to disable. |
-| `GITHUB_WEBHOOK_SECRET` | — | HMAC secret for `X-Hub-Signature-256` validation. Optional but recommended. |
-| `GH_TOKEN` / `GITHUB_TOKEN` | — | GitHub API token. Required for all tool calls. |
+| Variable                    | Default | Description                                                                 |
+| --------------------------- | ------- | --------------------------------------------------------------------------- |
+| `SHEPHERD_WEBHOOK_PORT`     | `3000`  | HTTP port for the webhook endpoint. Set to `0` to disable.                  |
+| `GITHUB_WEBHOOK_SECRET`     | —       | HMAC secret for `X-Hub-Signature-256` validation. Optional but recommended. |
+| `GH_TOKEN` / `GITHUB_TOKEN` | —       | GitHub API token. Required for all tool calls.                              |
 
 ## Webhook notification format
 
@@ -85,73 +85,73 @@ All tools return plain text output identical to the corresponding CLI command's 
 
 Get a PR status snapshot.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | no | PR number (auto-detected from current branch if omitted) |
-| `skipTriage` | boolean | no | Skip fetching job info and log tails for failing checks |
+| Input        | Type    | Required | Description                                              |
+| ------------ | ------- | -------- | -------------------------------------------------------- |
+| `prNumber`   | number  | no       | PR number (auto-detected from current branch if omitted) |
+| `skipTriage` | boolean | no       | Skip fetching job info and log tails for failing checks  |
 
 ### `shepherd_resolve_fetch`
 
 Fetch actionable review threads and comments. Auto-resolves outdated threads and surfaces first-look items with instructions.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | no | PR number |
+| Input      | Type   | Required | Description |
+| ---------- | ------ | -------- | ----------- |
+| `prNumber` | number | no       | PR number   |
 
 ### `shepherd_resolve_mutate`
 
 Resolve, minimize, or dismiss review items by ID.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | no | PR number |
-| `resolveThreadIds` | string[] | no | Thread node IDs to resolve |
-| `minimizeCommentIds` | string[] | no | Comment node IDs to minimize |
-| `dismissReviewIds` | string[] | no | Review node IDs to dismiss |
-| `dismissMessage` | string | no | Required when dismissing reviews |
-| `requireSha` | string | no | Wait for GitHub to receive this commit SHA before resolving |
+| Input                | Type     | Required | Description                                                 |
+| -------------------- | -------- | -------- | ----------------------------------------------------------- |
+| `prNumber`           | number   | no       | PR number                                                   |
+| `resolveThreadIds`   | string[] | no       | Thread node IDs to resolve                                  |
+| `minimizeCommentIds` | string[] | no       | Comment node IDs to minimize                                |
+| `dismissReviewIds`   | string[] | no       | Review node IDs to dismiss                                  |
+| `dismissMessage`     | string   | no       | Required when dismissing reviews                            |
+| `requireSha`         | string   | no       | Wait for GitHub to receive this commit SHA before resolving |
 
 ### `shepherd_commit_suggestion`
 
 Apply a suggestion block from a review thread and create a git commit.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `threadId` | string | **yes** | Review thread node ID |
-| `prNumber` | number | no | PR number |
-| `message` | string | no | Commit message (required unless `dryRun`) |
-| `description` | string | no | Extended commit description |
-| `dryRun` | boolean | no | Validate patch without applying |
+| Input         | Type    | Required | Description                               |
+| ------------- | ------- | -------- | ----------------------------------------- |
+| `threadId`    | string  | **yes**  | Review thread node ID                     |
+| `prNumber`    | number  | no       | PR number                                 |
+| `message`     | string  | no       | Commit message (required unless `dryRun`) |
+| `description` | string  | no       | Extended commit description               |
+| `dryRun`      | boolean | no       | Validate patch without applying           |
 
 ### `shepherd_iterate`
 
 Run one iterate cycle and return the next action (`fix_code`, `wait`, `mark_ready`, `cancel`, or `escalate`) with instructions.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | no | PR number |
-| `cooldownSeconds` | number | no | Min seconds between code changes |
-| `readyDelaySeconds` | number | no | Delay before marking ready |
-| `stallTimeoutSeconds` | number | no | Abort if no progress after N seconds |
-| `noAutoMarkReady` | boolean | no | Disable draft → ready transition |
-| `noAutoCancelActionable` | boolean | no | Disable auto-cancel of actionable checks |
+| Input                    | Type    | Required | Description                              |
+| ------------------------ | ------- | -------- | ---------------------------------------- |
+| `prNumber`               | number  | no       | PR number                                |
+| `cooldownSeconds`        | number  | no       | Min seconds between code changes         |
+| `readyDelaySeconds`      | number  | no       | Delay before marking ready               |
+| `stallTimeoutSeconds`    | number  | no       | Abort if no progress after N seconds     |
+| `noAutoMarkReady`        | boolean | no       | Disable draft → ready transition         |
+| `noAutoCancelActionable` | boolean | no       | Disable auto-cancel of actionable checks |
 
 ### `shepherd_monitor`
 
 Get the `/loop` arguments and prompt body to bootstrap continuous monitoring.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | no | PR number |
-| `readyDelaySuffix` | string | no | Ready-delay duration, e.g. `"15m"` |
+| Input              | Type   | Required | Description                        |
+| ------------------ | ------ | -------- | ---------------------------------- |
+| `prNumber`         | number | no       | PR number                          |
+| `readyDelaySuffix` | string | no       | Ready-delay duration, e.g. `"15m"` |
 
 ### `shepherd_status`
 
 Get a status table for one or more PRs.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumbers` | number[] | **yes** | PR numbers to check (min 1) |
+| Input       | Type     | Required | Description                 |
+| ----------- | -------- | -------- | --------------------------- |
+| `prNumbers` | number[] | **yes**  | PR numbers to check (min 1) |
 
 ### `shepherd_log_file`
 
@@ -161,24 +161,24 @@ Return the path to the per-worktree debug log file. No inputs.
 
 Subscribe the current session to GitHub webhook events for a PR.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | **yes** | PR to subscribe to |
+| Input      | Type   | Required | Description        |
+| ---------- | ------ | -------- | ------------------ |
+| `prNumber` | number | **yes**  | PR to subscribe to |
 
 ### `shepherd_unsubscribe_pr`
 
 Stop forwarding webhook events for a PR to this session.
 
-| Input | Type | Required | Description |
-|-------|------|----------|-------------|
-| `prNumber` | number | **yes** | PR to unsubscribe from |
+| Input      | Type   | Required | Description            |
+| ---------- | ------ | -------- | ---------------------- |
+| `prNumber` | number | **yes**  | PR to unsubscribe from |
 
 ## Differences from CLI
 
-| | CLI (`npx pr-shepherd`) | MCP server (`pr-shepherd-mcp`) |
-|-|------------------------|-------------------------------|
-| Process model | Short-lived per invocation | Long-lived, persistent connection |
-| Invocation | Bash subprocess | Direct MCP tool call |
-| Webhook support | None | HTTP endpoint + push notifications |
-| Subscription state | None | Per-connection in-memory set |
-| `setupLog()` | Yes (stdout tee) | No (stdout reserved for MCP protocol) |
+|                    | CLI (`npx pr-shepherd`)    | MCP server (`pr-shepherd-mcp`)        |
+| ------------------ | -------------------------- | ------------------------------------- |
+| Process model      | Short-lived per invocation | Long-lived, persistent connection     |
+| Invocation         | Bash subprocess            | Direct MCP tool call                  |
+| Webhook support    | None                       | HTTP endpoint + push notifications    |
+| Subscription state | None                       | Per-connection in-memory set          |
+| `setupLog()`       | Yes (stdout tee)           | No (stdout reserved for MCP protocol) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "yaml": "^2.7.0"
       },
       "bin": {
-        "pr-shepherd": "bin/pr-shepherd"
+        "pr-shepherd": "bin/pr-shepherd",
+        "pr-shepherd-mcp": "bin/pr-shepherd-mcp"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -120,6 +122,18 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -146,6 +160,46 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1284,6 +1338,52 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1306,6 +1406,68 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1316,12 +1478,109 @@
         "node": ">=18"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1333,11 +1592,76 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/estree-walker": {
@@ -1350,6 +1674,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1359,6 +1713,89 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1378,6 +1815,45 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1393,6 +1869,64 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1403,12 +1937,117 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1449,12 +2088,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1755,6 +2415,67 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1774,6 +2495,36 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1784,6 +2535,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oxfmt": {
       "version": "0.46.0",
@@ -1870,6 +2642,34 @@
         }
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1895,6 +2695,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -1924,6 +2733,67 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -1960,6 +2830,28 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -1971,6 +2863,150 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -1996,6 +3032,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -2071,6 +3116,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2078,6 +3132,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -2099,6 +3167,24 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.10",
@@ -2268,6 +3354,21 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2285,6 +3386,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -2298,6 +3405,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Jonathan Ong",
   "type": "module",
   "bin": {
-    "pr-shepherd": "bin/pr-shepherd"
+    "pr-shepherd": "bin/pr-shepherd",
+    "pr-shepherd-mcp": "bin/pr-shepherd-mcp"
   },
   "files": [
     "bin/**",
@@ -20,6 +21,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -27,3 +27,13 @@ chmodSync('bin/pr-shepherd', 0o755)
 try { unlinkSync('node_modules/.bin/pr-shepherd') } catch {}
 mkdirSync('node_modules/.bin', { recursive: true })
 symlinkSync('../../bin/pr-shepherd', 'node_modules/.bin/pr-shepherd')
+
+// 8. Write bin/pr-shepherd-mcp entry point
+writeFileSync('bin/pr-shepherd-mcp', '#!/usr/bin/env node\nimport("./mcp-index.mjs")\n')
+
+// 9. Set executable bit
+chmodSync('bin/pr-shepherd-mcp', 0o755)
+
+// 10. Self-link into node_modules/.bin so `npx pr-shepherd-mcp` resolves to this build
+try { unlinkSync('node_modules/.bin/pr-shepherd-mcp') } catch {}
+symlinkSync('../../bin/pr-shepherd-mcp', 'node_modules/.bin/pr-shepherd-mcp')

--- a/src/mcp-index.mock.test.mts
+++ b/src/mcp-index.mock.test.mts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockStartMcpServer } = vi.hoisted(() => ({
+  mockStartMcpServer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./mcp/server.mts", () => ({ startMcpServer: mockStartMcpServer }));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let exitSpy: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stderrSpy: any;
+
+beforeEach(() => {
+  vi.resetModules();
+  mockStartMcpServer.mockReset();
+  mockStartMcpServer.mockResolvedValue(undefined);
+  exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as () => never);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  delete process.env["SHEPHERD_WEBHOOK_PORT"];
+  delete process.env["GITHUB_WEBHOOK_SECRET"];
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+async function loadIndex() {
+  await import("./mcp-index.mts");
+  await Promise.resolve();
+}
+
+describe("mcp-index — startMcpServer invocation", () => {
+  it("calls startMcpServer with default port 3000 when env not set", async () => {
+    await loadIndex();
+    expect(mockStartMcpServer).toHaveBeenCalledWith({
+      webhookPort: 3000,
+      webhookSecret: undefined,
+    });
+  });
+
+  it("passes parsed SHEPHERD_WEBHOOK_PORT to startMcpServer", async () => {
+    process.env["SHEPHERD_WEBHOOK_PORT"] = "4567";
+    await loadIndex();
+    expect(mockStartMcpServer).toHaveBeenCalledWith(expect.objectContaining({ webhookPort: 4567 }));
+  });
+
+  it("disables webhook when SHEPHERD_WEBHOOK_PORT=0", async () => {
+    process.env["SHEPHERD_WEBHOOK_PORT"] = "0";
+    await loadIndex();
+    expect(mockStartMcpServer).toHaveBeenCalledWith(expect.objectContaining({ webhookPort: 0 }));
+  });
+
+  it("falls back to 3000 for non-numeric SHEPHERD_WEBHOOK_PORT", async () => {
+    process.env["SHEPHERD_WEBHOOK_PORT"] = "notanumber";
+    await loadIndex();
+    expect(mockStartMcpServer).toHaveBeenCalledWith(expect.objectContaining({ webhookPort: 3000 }));
+  });
+
+  it("falls back to 3000 for negative SHEPHERD_WEBHOOK_PORT", async () => {
+    process.env["SHEPHERD_WEBHOOK_PORT"] = "-1";
+    await loadIndex();
+    expect(mockStartMcpServer).toHaveBeenCalledWith(expect.objectContaining({ webhookPort: 3000 }));
+  });
+
+  it("passes GITHUB_WEBHOOK_SECRET to startMcpServer", async () => {
+    process.env["GITHUB_WEBHOOK_SECRET"] = "mysecret";
+    await loadIndex();
+    expect(mockStartMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookSecret: "mysecret" }),
+    );
+  });
+});
+
+describe("mcp-index — error handling", () => {
+  it("writes error message to stderr and exits 1 when startMcpServer rejects with Error", async () => {
+    mockStartMcpServer.mockRejectedValueOnce(new Error("connection refused"));
+    await loadIndex();
+    expect(stderrSpy).toHaveBeenCalledWith("pr-shepherd-mcp error: connection refused\n");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("stringifies non-Error rejections", async () => {
+    mockStartMcpServer.mockRejectedValueOnce("fatal");
+    await loadIndex();
+    expect(stderrSpy).toHaveBeenCalledWith("pr-shepherd-mcp error: fatal\n");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/mcp-index.mts
+++ b/src/mcp-index.mts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * pr-shepherd-mcp — MCP server entry point.
+ *
+ * Exposes all pr-shepherd CLI commands as MCP tools and optionally runs an
+ * HTTP webhook server to forward GitHub PR events to the connected Claude Code
+ * session as <github-webhook-activity> MCP notifications.
+ *
+ * Environment variables:
+ *   SHEPHERD_WEBHOOK_PORT   HTTP port for the webhook endpoint (default: 3000, 0 = disabled)
+ *   GITHUB_WEBHOOK_SECRET   HMAC secret for X-Hub-Signature-256 validation (optional)
+ *   GH_TOKEN / GITHUB_TOKEN GitHub API token (required for all tool calls)
+ */
+
+import { startMcpServer } from "./mcp/server.mts";
+
+const webhookPort = parsePort(process.env["SHEPHERD_WEBHOOK_PORT"]);
+const webhookSecret = process.env["GITHUB_WEBHOOK_SECRET"] ?? undefined;
+
+startMcpServer({ webhookPort, webhookSecret }).catch((err: unknown) => {
+  process.stderr.write(
+    `pr-shepherd-mcp error: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});
+
+function parsePort(raw: string | undefined): number {
+  if (raw === undefined) return 3000;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 3000;
+}

--- a/src/mcp/server.mock.test.mts
+++ b/src/mcp/server.mock.test.mts
@@ -11,7 +11,6 @@ const {
   MockServer,
   MockStdioTransport,
   mockWebhookStart,
-  mockWebhookStop,
   MockWebhookServer,
   getCapturedOnEvent,
 } = vi.hoisted(() => {
@@ -46,7 +45,6 @@ const {
     MockServer,
     MockStdioTransport,
     mockWebhookStart,
-    mockWebhookStop,
     MockWebhookServer,
     getCapturedOnEvent: () => capturedOnEvent,
   };

--- a/src/mcp/server.mock.test.mts
+++ b/src/mcp/server.mock.test.mts
@@ -35,7 +35,11 @@ const {
     onEvent: (p: unknown) => void;
   }) {
     capturedOnEvent = opts.onEvent;
-    return { start: mockWebhookStart, stop: mockWebhookStop };
+    return {
+      start: mockWebhookStart,
+      stop: mockWebhookStop,
+      isRunning: vi.fn().mockReturnValue(true),
+    };
   });
 
   return {

--- a/src/mcp/server.mock.test.mts
+++ b/src/mcp/server.mock.test.mts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.mock factories are hoisted, so referenced vars must be too
+// ---------------------------------------------------------------------------
+
+const {
+  mockConnect,
+  mockSetRequestHandler,
+  mockSendLoggingMessage,
+  MockServer,
+  MockStdioTransport,
+  mockWebhookStart,
+  mockWebhookStop,
+  MockWebhookServer,
+  getCapturedOnEvent,
+} = vi.hoisted(() => {
+  const mockConnect = vi.fn().mockResolvedValue(undefined);
+  const mockSetRequestHandler = vi.fn();
+  const mockSendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+  const MockServer = vi.fn().mockImplementation(function () {
+    return {
+      connect: mockConnect,
+      setRequestHandler: mockSetRequestHandler,
+      sendLoggingMessage: mockSendLoggingMessage,
+    };
+  });
+  const MockStdioTransport = vi.fn().mockImplementation(function () {
+    return {};
+  });
+
+  const mockWebhookStart = vi.fn().mockResolvedValue(undefined);
+  const mockWebhookStop = vi.fn().mockResolvedValue(undefined);
+  let capturedOnEvent: ((payload: unknown) => void) | undefined;
+  const MockWebhookServer = vi.fn().mockImplementation(function (opts: {
+    onEvent: (p: unknown) => void;
+  }) {
+    capturedOnEvent = opts.onEvent;
+    return { start: mockWebhookStart, stop: mockWebhookStop };
+  });
+
+  return {
+    mockConnect,
+    mockSetRequestHandler,
+    mockSendLoggingMessage,
+    MockServer,
+    MockStdioTransport,
+    mockWebhookStart,
+    mockWebhookStop,
+    MockWebhookServer,
+    getCapturedOnEvent: () => capturedOnEvent,
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({ Server: MockServer }));
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: MockStdioTransport,
+}));
+vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
+  ListToolsRequestSchema: "LIST_TOOLS",
+  CallToolRequestSchema: "CALL_TOOL",
+}));
+vi.mock("./subscriptions.mts", () => ({
+  SubscriptionStore: vi.fn().mockImplementation(function () {
+    return { isSubscribed: vi.fn().mockReturnValue(false) };
+  }),
+}));
+vi.mock("./webhook.mts", () => ({ WebhookServer: MockWebhookServer }));
+vi.mock("./tools.mts", () => ({
+  buildToolList: vi.fn().mockReturnValue([]),
+  buildToolHandler: vi.fn().mockReturnValue(vi.fn()),
+}));
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn().mockReturnValue('{"version":"0.0.0-test"}'),
+}));
+
+import { startMcpServer } from "./server.mts";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConnect.mockResolvedValue(undefined);
+  mockSendLoggingMessage.mockResolvedValue(undefined);
+  mockWebhookStart.mockResolvedValue(undefined);
+});
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+let processSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  processSpy = vi.spyOn(process, "on").mockImplementation(() => process);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  processSpy.mockRestore();
+});
+
+describe("startMcpServer — basic wiring", () => {
+  it("creates MCP Server with pr-shepherd name and version", async () => {
+    await startMcpServer({ webhookPort: 0 });
+    expect(MockServer).toHaveBeenCalledWith(
+      { name: "pr-shepherd", version: "0.0.0-test" },
+      expect.objectContaining({ capabilities: expect.any(Object) }),
+    );
+  });
+
+  it("registers ListTools and CallTool handlers", async () => {
+    await startMcpServer({ webhookPort: 0 });
+    expect(mockSetRequestHandler).toHaveBeenCalledWith("LIST_TOOLS", expect.any(Function));
+    expect(mockSetRequestHandler).toHaveBeenCalledWith("CALL_TOOL", expect.any(Function));
+  });
+
+  it("connects stdio transport", async () => {
+    await startMcpServer({ webhookPort: 0 });
+    expect(MockStdioTransport).toHaveBeenCalled();
+    expect(mockConnect).toHaveBeenCalledWith(expect.any(Object));
+  });
+});
+
+describe("startMcpServer — webhook disabled (port 0)", () => {
+  it("does not create WebhookServer", async () => {
+    await startMcpServer({ webhookPort: 0 });
+    expect(MockWebhookServer).not.toHaveBeenCalled();
+  });
+});
+
+describe("startMcpServer — webhook enabled", () => {
+  it("starts WebhookServer on the given port", async () => {
+    await startMcpServer({ webhookPort: 3000 });
+    expect(MockWebhookServer).toHaveBeenCalledWith(expect.objectContaining({ port: 3000 }));
+    expect(mockWebhookStart).toHaveBeenCalled();
+  });
+
+  it("logs the webhook port to stderr", async () => {
+    await startMcpServer({ webhookPort: 3000 });
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "pr-shepherd-mcp: webhook server listening on port 3000\n",
+    );
+  });
+
+  it("passes the webhook secret to WebhookServer", async () => {
+    await startMcpServer({ webhookPort: 3000, webhookSecret: "s3cr3t" });
+    expect(MockWebhookServer).toHaveBeenCalledWith(expect.objectContaining({ secret: "s3cr3t" }));
+  });
+
+  it("registers SIGTERM and SIGINT handlers", async () => {
+    await startMcpServer({ webhookPort: 3000 });
+    expect(processSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(processSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+  });
+});
+
+describe("webhook onEvent — notification forwarding", () => {
+  it("sends MCP logging message when PR is subscribed", async () => {
+    const { SubscriptionStore } = await import("./subscriptions.mts");
+    vi.mocked(SubscriptionStore).mockImplementationOnce(function () {
+      return { isSubscribed: vi.fn().mockReturnValue(true) };
+    } as never);
+    await startMcpServer({ webhookPort: 3000 });
+    getCapturedOnEvent()!({
+      event: "pull_request",
+      action: "synchronize",
+      prNumber: 42,
+      repoFullName: "owner/repo",
+      timestamp: "2026-01-01T00:00:00Z",
+    });
+    await Promise.resolve();
+    expect(mockSendLoggingMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "info",
+        data: expect.stringContaining("<github-webhook-activity>"),
+      }),
+    );
+    const data: string = mockSendLoggingMessage.mock.calls[0][0].data;
+    expect(data).toContain("event: pull_request");
+    expect(data).toContain("action: synchronize");
+    expect(data).toContain("pr: 42");
+    expect(data).toContain("repo: owner/repo");
+  });
+
+  it("skips notification when PR is not subscribed", async () => {
+    await startMcpServer({ webhookPort: 3000 });
+    getCapturedOnEvent()!({ event: "push", prNumber: 99, repoFullName: "x/y", timestamp: "t" });
+    await Promise.resolve();
+    expect(mockSendLoggingMessage).not.toHaveBeenCalled();
+  });
+
+  it("logs error when sendLoggingMessage rejects", async () => {
+    const { SubscriptionStore } = await import("./subscriptions.mts");
+    vi.mocked(SubscriptionStore).mockImplementationOnce(function () {
+      return { isSubscribed: vi.fn().mockReturnValue(true) };
+    } as never);
+    mockSendLoggingMessage.mockRejectedValueOnce(new Error("send failed"));
+    await startMcpServer({ webhookPort: 3000 });
+    getCapturedOnEvent()!({ event: "push", prNumber: 1, repoFullName: "x/y", timestamp: "t" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to send webhook notification"),
+    );
+  });
+
+  it("includes optional fields in notification when present", async () => {
+    const { SubscriptionStore } = await import("./subscriptions.mts");
+    vi.mocked(SubscriptionStore).mockImplementationOnce(function () {
+      return { isSubscribed: vi.fn().mockReturnValue(true) };
+    } as never);
+    await startMcpServer({ webhookPort: 3000 });
+    getCapturedOnEvent()!({
+      event: "push",
+      prNumber: 1,
+      repoFullName: "x/y",
+      ref: "refs/heads/main",
+      sha: "abc123",
+      actor: "bob",
+      timestamp: "2026-01-01T00:00:00Z",
+    });
+    await Promise.resolve();
+    const data: string = mockSendLoggingMessage.mock.calls[0][0].data;
+    expect(data).toContain("ref: refs/heads/main");
+    expect(data).toContain("sha: abc123");
+    expect(data).toContain("actor: bob");
+  });
+});

--- a/src/mcp/server.mts
+++ b/src/mcp/server.mts
@@ -52,6 +52,12 @@ export async function startMcpServer(opts: McpServerOptions): Promise<void> {
 
   // Start HTTP webhook server if enabled.
   if (opts.webhookPort !== 0) {
+    if (!opts.webhookSecret) {
+      process.stderr.write(
+        `pr-shepherd-mcp: WARNING — GITHUB_WEBHOOK_SECRET is not set; webhook auth is disabled\n`,
+      );
+    }
+
     const webhookServer = new WebhookServer({
       port: opts.webhookPort,
       secret: opts.webhookSecret,
@@ -68,14 +74,22 @@ export async function startMcpServer(opts: McpServerOptions): Promise<void> {
     });
 
     await webhookServer.start();
-    process.stderr.write(`pr-shepherd-mcp: webhook server listening on port ${opts.webhookPort}\n`);
+    // start() swallows bind errors and sets server=null, so only log if it actually bound.
+    if (webhookServer.isRunning()) {
+      process.stderr.write(
+        `pr-shepherd-mcp: webhook server listening on port ${opts.webhookPort}\n`,
+      );
+    }
 
-    process.on("SIGTERM", () => {
-      void webhookServer.stop();
-    });
-    process.on("SIGINT", () => {
-      void webhookServer.stop();
-    });
+    const shutdown = (signal: string) => {
+      void (async () => {
+        process.stderr.write(`pr-shepherd-mcp: received ${signal}, shutting down\n`);
+        await webhookServer.stop();
+        process.exit(0);
+      })();
+    };
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
   }
 
   const transport = new StdioServerTransport();
@@ -90,7 +104,7 @@ function formatWebhookNotification(payload: WebhookPayload): string {
   const lines: string[] = ["<github-webhook-activity>", `event: ${payload.event}`];
   if (payload.action !== undefined) lines.push(`action: ${payload.action}`);
   lines.push(`pr: ${payload.prNumber}`);
-  lines.push(`repo: ${payload.repoFullName}`);
+  if (payload.repoFullName !== undefined) lines.push(`repo: ${payload.repoFullName}`);
   if (payload.ref !== undefined) lines.push(`ref: ${payload.ref}`);
   if (payload.sha !== undefined) lines.push(`sha: ${payload.sha}`);
   if (payload.actor !== undefined) lines.push(`actor: ${payload.actor}`);

--- a/src/mcp/server.mts
+++ b/src/mcp/server.mts
@@ -10,10 +10,7 @@
 import { readFileSync } from "node:fs";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import { SubscriptionStore } from "./subscriptions.mts";
 import { WebhookServer } from "./webhook.mts";
@@ -71,9 +68,7 @@ export async function startMcpServer(opts: McpServerOptions): Promise<void> {
     });
 
     await webhookServer.start();
-    process.stderr.write(
-      `pr-shepherd-mcp: webhook server listening on port ${opts.webhookPort}\n`,
-    );
+    process.stderr.write(`pr-shepherd-mcp: webhook server listening on port ${opts.webhookPort}\n`);
 
     process.on("SIGTERM", () => {
       void webhookServer.stop();

--- a/src/mcp/server.mts
+++ b/src/mcp/server.mts
@@ -1,0 +1,111 @@
+/**
+ * MCP server for pr-shepherd.
+ *
+ * Exposes all pr-shepherd CLI commands as MCP tools and optionally starts an
+ * HTTP webhook server. When a webhook arrives for a subscribed PR, it is
+ * forwarded to the connected Claude Code session as an MCP logging notification
+ * wrapped in <github-webhook-activity> tags.
+ */
+
+import { readFileSync } from "node:fs";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { SubscriptionStore } from "./subscriptions.mts";
+import { WebhookServer } from "./webhook.mts";
+import type { WebhookPayload } from "./webhook.mts";
+import { buildToolList, buildToolHandler } from "./tools.mts";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface McpServerOptions {
+  /** HTTP port for the GitHub webhook endpoint. 0 = disabled. */
+  webhookPort: number;
+  /** HMAC secret for X-Hub-Signature-256 validation. Optional. */
+  webhookSecret?: string;
+}
+
+export async function startMcpServer(opts: McpServerOptions): Promise<void> {
+  const version = readVersion();
+
+  const server = new Server(
+    { name: "pr-shepherd", version },
+    { capabilities: { tools: {}, logging: {} } },
+  );
+
+  const subscriptions = new SubscriptionStore();
+  const handleTool = buildToolHandler({ subscriptions });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: buildToolList(),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, (request) => {
+    const name = request.params.name;
+    const input = (request.params.arguments ?? {}) as Record<string, unknown>;
+    // CallToolResult is a valid ServerResult member; cast needed due to SDK union complexity
+    return handleTool(name, input) as Promise<Record<string, unknown>>;
+  });
+
+  // Start HTTP webhook server if enabled.
+  if (opts.webhookPort !== 0) {
+    const webhookServer = new WebhookServer({
+      port: opts.webhookPort,
+      secret: opts.webhookSecret,
+      onEvent: (payload) => {
+        if (!subscriptions.isSubscribed(payload.prNumber)) return;
+        server
+          .sendLoggingMessage({ level: "info", data: formatWebhookNotification(payload) })
+          .catch((e: unknown) => {
+            process.stderr.write(
+              `pr-shepherd-mcp: failed to send webhook notification: ${String(e)}\n`,
+            );
+          });
+      },
+    });
+
+    await webhookServer.start();
+    process.stderr.write(
+      `pr-shepherd-mcp: webhook server listening on port ${opts.webhookPort}\n`,
+    );
+
+    process.on("SIGTERM", () => {
+      void webhookServer.stop();
+    });
+    process.on("SIGINT", () => {
+      void webhookServer.stop();
+    });
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatWebhookNotification(payload: WebhookPayload): string {
+  const lines: string[] = ["<github-webhook-activity>", `event: ${payload.event}`];
+  if (payload.action !== undefined) lines.push(`action: ${payload.action}`);
+  lines.push(`pr: ${payload.prNumber}`);
+  lines.push(`repo: ${payload.repoFullName}`);
+  if (payload.ref !== undefined) lines.push(`ref: ${payload.ref}`);
+  if (payload.sha !== undefined) lines.push(`sha: ${payload.sha}`);
+  if (payload.actor !== undefined) lines.push(`actor: ${payload.actor}`);
+  lines.push(`timestamp: ${payload.timestamp}`);
+  lines.push("</github-webhook-activity>");
+  return lines.join("\n");
+}
+
+function readVersion(): string {
+  const pkgUrl = new URL("../../package.json", import.meta.url);
+  const pkg = JSON.parse(readFileSync(pkgUrl, "utf8")) as { version: string };
+  return pkg.version;
+}

--- a/src/mcp/subscriptions.mts
+++ b/src/mcp/subscriptions.mts
@@ -1,0 +1,21 @@
+/** Per-session PR subscription state for webhook event forwarding. */
+
+export class SubscriptionStore {
+  private readonly subs = new Set<number>();
+
+  subscribe(prNumber: number): void {
+    this.subs.add(prNumber);
+  }
+
+  unsubscribe(prNumber: number): void {
+    this.subs.delete(prNumber);
+  }
+
+  isSubscribed(prNumber: number): boolean {
+    return this.subs.has(prNumber);
+  }
+
+  listSubscribed(): number[] {
+    return [...this.subs].sort((a, b) => a - b);
+  }
+}

--- a/src/mcp/subscriptions.test.mts
+++ b/src/mcp/subscriptions.test.mts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SubscriptionStore } from "./subscriptions.mts";
+
+let store: SubscriptionStore;
+
+beforeEach(() => {
+  store = new SubscriptionStore();
+});
+
+describe("subscribe / isSubscribed", () => {
+  it("returns false for unsubscribed PR", () => {
+    expect(store.isSubscribed(42)).toBe(false);
+  });
+
+  it("returns true after subscribe", () => {
+    store.subscribe(42);
+    expect(store.isSubscribed(42)).toBe(true);
+  });
+
+  it("does not affect other PRs", () => {
+    store.subscribe(42);
+    expect(store.isSubscribed(99)).toBe(false);
+  });
+
+  it("subscribe is idempotent", () => {
+    store.subscribe(42);
+    store.subscribe(42);
+    expect(store.listSubscribed()).toEqual([42]);
+  });
+});
+
+describe("unsubscribe", () => {
+  it("removes a subscribed PR", () => {
+    store.subscribe(42);
+    store.unsubscribe(42);
+    expect(store.isSubscribed(42)).toBe(false);
+  });
+
+  it("is a no-op for unsubscribed PR", () => {
+    expect(() => store.unsubscribe(99)).not.toThrow();
+  });
+});
+
+describe("listSubscribed", () => {
+  it("returns empty array when no subscriptions", () => {
+    expect(store.listSubscribed()).toEqual([]);
+  });
+
+  it("returns subscribed PRs sorted ascending", () => {
+    store.subscribe(100);
+    store.subscribe(5);
+    store.subscribe(42);
+    expect(store.listSubscribed()).toEqual([5, 42, 100]);
+  });
+
+  it("excludes unsubscribed PRs", () => {
+    store.subscribe(1);
+    store.subscribe(2);
+    store.unsubscribe(1);
+    expect(store.listSubscribed()).toEqual([2]);
+  });
+});

--- a/src/mcp/tool-coerce.mts
+++ b/src/mcp/tool-coerce.mts
@@ -1,0 +1,44 @@
+/** Input coercion helpers for MCP tool handlers. */
+
+export function optNum(input: Record<string, unknown>, key: string): number | undefined {
+  const v = input[key];
+  return typeof v === "number" ? v : undefined;
+}
+
+export function reqNum(input: Record<string, unknown>, key: string): number {
+  const v = input[key];
+  if (typeof v !== "number") throw new Error(`${key} is required and must be a number`);
+  return v;
+}
+
+export function optStr(input: Record<string, unknown>, key: string): string | undefined {
+  const v = input[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+export function reqStr(input: Record<string, unknown>, key: string): string {
+  const v = input[key];
+  if (typeof v !== "string" || v === "") {
+    throw new Error(`${key} is required and must be a non-empty string`);
+  }
+  return v;
+}
+
+export function optBool(input: Record<string, unknown>, key: string): boolean | undefined {
+  const v = input[key];
+  return typeof v === "boolean" ? v : undefined;
+}
+
+export function optStringArray(input: Record<string, unknown>, key: string): string[] | undefined {
+  const v = input[key];
+  if (!Array.isArray(v)) return undefined;
+  return v.filter((x): x is string => typeof x === "string");
+}
+
+export function reqNumArray(input: Record<string, unknown>, key: string): number[] {
+  const v = input[key];
+  if (!Array.isArray(v) || v.length === 0) {
+    throw new Error(`${key} must be a non-empty array of numbers`);
+  }
+  return v.filter((x): x is number => typeof x === "number");
+}

--- a/src/mcp/tool-coerce.mts
+++ b/src/mcp/tool-coerce.mts
@@ -32,7 +32,10 @@ export function optBool(input: Record<string, unknown>, key: string): boolean | 
 export function optStringArray(input: Record<string, unknown>, key: string): string[] | undefined {
   const v = input[key];
   if (!Array.isArray(v)) return undefined;
-  return v.filter((x): x is string => typeof x === "string");
+  return v.map((x, i) => {
+    if (typeof x !== "string") throw new Error(`${key}[${i}] must be a string, got ${typeof x}`);
+    return x;
+  });
 }
 
 export function reqNumArray(input: Record<string, unknown>, key: string): number[] {
@@ -40,5 +43,9 @@ export function reqNumArray(input: Record<string, unknown>, key: string): number
   if (!Array.isArray(v) || v.length === 0) {
     throw new Error(`${key} must be a non-empty array of numbers`);
   }
-  return v.filter((x): x is number => typeof x === "number");
+  const result = v.map((x, i) => {
+    if (typeof x !== "number") throw new Error(`${key}[${i}] must be a number, got ${typeof x}`);
+    return x;
+  });
+  return result;
 }

--- a/src/mcp/tool-coerce.test.mts
+++ b/src/mcp/tool-coerce.test.mts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  optNum,
+  reqNum,
+  optStr,
+  reqStr,
+  optBool,
+  optStringArray,
+  reqNumArray,
+} from "./tool-coerce.mts";
+
+describe("optNum", () => {
+  it("returns number when present", () => {
+    expect(optNum({ n: 42 }, "n")).toBe(42);
+  });
+
+  it("returns undefined when missing", () => {
+    expect(optNum({}, "n")).toBeUndefined();
+  });
+
+  it("returns undefined for non-number", () => {
+    expect(optNum({ n: "42" }, "n")).toBeUndefined();
+  });
+});
+
+describe("reqNum", () => {
+  it("returns number when present", () => {
+    expect(reqNum({ n: 7 }, "n")).toBe(7);
+  });
+
+  it("throws when missing", () => {
+    expect(() => reqNum({}, "n")).toThrow("n is required and must be a number");
+  });
+
+  it("throws for non-number", () => {
+    expect(() => reqNum({ n: "7" }, "n")).toThrow("n is required and must be a number");
+  });
+});
+
+describe("optStr", () => {
+  it("returns string when present", () => {
+    expect(optStr({ s: "hello" }, "s")).toBe("hello");
+  });
+
+  it("returns undefined when missing", () => {
+    expect(optStr({}, "s")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string", () => {
+    expect(optStr({ s: 42 }, "s")).toBeUndefined();
+  });
+});
+
+describe("reqStr", () => {
+  it("returns string when present", () => {
+    expect(reqStr({ s: "hello" }, "s")).toBe("hello");
+  });
+
+  it("throws when missing", () => {
+    expect(() => reqStr({}, "s")).toThrow("s is required and must be a non-empty string");
+  });
+
+  it("throws for empty string", () => {
+    expect(() => reqStr({ s: "" }, "s")).toThrow("s is required and must be a non-empty string");
+  });
+
+  it("throws for non-string", () => {
+    expect(() => reqStr({ s: 42 }, "s")).toThrow("s is required and must be a non-empty string");
+  });
+});
+
+describe("optBool", () => {
+  it("returns boolean when present", () => {
+    expect(optBool({ b: true }, "b")).toBe(true);
+    expect(optBool({ b: false }, "b")).toBe(false);
+  });
+
+  it("returns undefined when missing", () => {
+    expect(optBool({}, "b")).toBeUndefined();
+  });
+
+  it("returns undefined for non-boolean", () => {
+    expect(optBool({ b: 1 }, "b")).toBeUndefined();
+  });
+});
+
+describe("optStringArray", () => {
+  it("returns string array when present", () => {
+    expect(optStringArray({ a: ["x", "y"] }, "a")).toEqual(["x", "y"]);
+  });
+
+  it("filters out non-strings", () => {
+    expect(optStringArray({ a: ["x", 42, "y"] }, "a")).toEqual(["x", "y"]);
+  });
+
+  it("returns undefined when not an array", () => {
+    expect(optStringArray({ a: "x" }, "a")).toBeUndefined();
+    expect(optStringArray({}, "a")).toBeUndefined();
+  });
+});
+
+describe("reqNumArray", () => {
+  it("returns number array when present", () => {
+    expect(reqNumArray({ a: [1, 2, 3] }, "a")).toEqual([1, 2, 3]);
+  });
+
+  it("filters out non-numbers", () => {
+    expect(reqNumArray({ a: [1, "x", 2] }, "a")).toEqual([1, 2]);
+  });
+
+  it("throws when missing", () => {
+    expect(() => reqNumArray({}, "a")).toThrow("a must be a non-empty array of numbers");
+  });
+
+  it("throws for empty array", () => {
+    expect(() => reqNumArray({ a: [] }, "a")).toThrow("a must be a non-empty array of numbers");
+  });
+
+  it("throws for non-array", () => {
+    expect(() => reqNumArray({ a: "x" }, "a")).toThrow("a must be a non-empty array of numbers");
+  });
+});

--- a/src/mcp/tool-coerce.test.mts
+++ b/src/mcp/tool-coerce.test.mts
@@ -89,8 +89,8 @@ describe("optStringArray", () => {
     expect(optStringArray({ a: ["x", "y"] }, "a")).toEqual(["x", "y"]);
   });
 
-  it("filters out non-strings", () => {
-    expect(optStringArray({ a: ["x", 42, "y"] }, "a")).toEqual(["x", "y"]);
+  it("throws on non-string element", () => {
+    expect(() => optStringArray({ a: ["x", 42, "y"] }, "a")).toThrow("a[1] must be a string");
   });
 
   it("returns undefined when not an array", () => {
@@ -104,8 +104,8 @@ describe("reqNumArray", () => {
     expect(reqNumArray({ a: [1, 2, 3] }, "a")).toEqual([1, 2, 3]);
   });
 
-  it("filters out non-numbers", () => {
-    expect(reqNumArray({ a: [1, "x", 2] }, "a")).toEqual([1, 2]);
+  it("throws on non-number element", () => {
+    expect(() => reqNumArray({ a: [1, "x", 2] }, "a")).toThrow("a[1] must be a number");
   });
 
   it("throws when missing", () => {

--- a/src/mcp/tool-handlers.mock.test.mts
+++ b/src/mcp/tool-handlers.mock.test.mts
@@ -72,7 +72,7 @@ describe("ok / err helpers", () => {
   it("err sets isError and prefixes message", () => {
     const result = err("oops");
     expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toBe("Error: oops");
+    expect((result.content[0]! as { text: string }).text).toBe("Error: oops");
   });
 });
 
@@ -84,7 +84,7 @@ describe("handleCheck", () => {
 
     const result = await handleCheck({ prNumber: 1 });
     expect(runCheck).toHaveBeenCalledWith({ format: "text", prNumber: 1, skipTriage: undefined });
-    expect(result.content[0]!.text).toBe("check output");
+    expect((result.content[0]! as { text: string }).text).toBe("check output");
   });
 
   it("works without prNumber", async () => {
@@ -106,7 +106,7 @@ describe("handleResolveFetch", () => {
     vi.mocked(formatFetchResult).mockReturnValue("fetch output");
 
     const out = await handleResolveFetch({ prNumber: 1 });
-    expect(out.content[0]!.text).toBe("fetch output");
+    expect((out.content[0]! as { text: string }).text).toBe("fetch output");
   });
 });
 
@@ -143,7 +143,7 @@ describe("handleCommitSuggestion", () => {
     expect(runCommitSuggestion).toHaveBeenCalledWith(
       expect.objectContaining({ threadId: "t1", message: "fix" }),
     );
-    expect(out.content[0]!.text).toBe("cs output");
+    expect((out.content[0]! as { text: string }).text).toBe("cs output");
   });
 
   it("throws when threadId missing", async () => {
@@ -160,7 +160,7 @@ describe("handleIterate", () => {
     expect(runIterate).toHaveBeenCalledWith(
       expect.objectContaining({ cooldownSeconds: 10, noAutoMarkReady: true }),
     );
-    expect(out.content[0]!.text).toBe("iterate output");
+    expect((out.content[0]! as { text: string }).text).toBe("iterate output");
   });
 });
 
@@ -170,7 +170,7 @@ describe("handleMonitor", () => {
     vi.mocked(formatMonitorResult).mockReturnValue("monitor output");
 
     const out = await handleMonitor({ readyDelaySuffix: "15m" });
-    expect(out.content[0]!.text).toBe("monitor output");
+    expect((out.content[0]! as { text: string }).text).toBe("monitor output");
   });
 });
 
@@ -182,7 +182,7 @@ describe("handleStatus", () => {
     const out = await handleStatus({ prNumbers: [1, 2] });
     expect(runStatus).toHaveBeenCalledWith(expect.objectContaining({ prNumbers: [1, 2] }));
     expect(formatStatusTable).toHaveBeenCalledWith([], "owner/repo");
-    expect(out.content[0]!.text).toBe("status output");
+    expect((out.content[0]! as { text: string }).text).toBe("status output");
   });
 
   it("throws when prNumbers missing", async () => {
@@ -194,7 +194,7 @@ describe("handleLogFile", () => {
   it("returns the log file path", async () => {
     vi.mocked(runLogFile).mockResolvedValue({ path: "/tmp/log.md" });
     const out = await handleLogFile();
-    expect(out.content[0]!.text).toBe("/tmp/log.md");
+    expect((out.content[0]! as { text: string }).text).toBe("/tmp/log.md");
   });
 });
 
@@ -208,7 +208,7 @@ describe("handleSubscribePr / handleUnsubscribePr", () => {
   it("subscribes a PR and lists it", () => {
     const out = handleSubscribePr({ prNumber: 42 }, subs);
     expect(subs.isSubscribed(42)).toBe(true);
-    expect(out.content[0]!.text).toContain("42");
+    expect((out.content[0]! as { text: string }).text).toContain("42");
   });
 
   it("throws when prNumber missing", () => {
@@ -219,13 +219,13 @@ describe("handleSubscribePr / handleUnsubscribePr", () => {
     subs.subscribe(42);
     const out = handleUnsubscribePr({ prNumber: 42 }, subs);
     expect(subs.isSubscribed(42)).toBe(false);
-    expect(out.content[0]!.text).toContain("(none)");
+    expect((out.content[0]! as { text: string }).text).toContain("(none)");
   });
 
   it("shows remaining PRs after unsubscribe", () => {
     subs.subscribe(1);
     subs.subscribe(2);
     const out = handleUnsubscribePr({ prNumber: 1 }, subs);
-    expect(out.content[0]!.text).toContain("2");
+    expect((out.content[0]! as { text: string }).text).toContain("2");
   });
 });

--- a/src/mcp/tool-handlers.mock.test.mts
+++ b/src/mcp/tool-handlers.mock.test.mts
@@ -219,13 +219,14 @@ describe("handleSubscribePr / handleUnsubscribePr", () => {
     subs.subscribe(42);
     const out = handleUnsubscribePr({ prNumber: 42 }, subs);
     expect(subs.isSubscribed(42)).toBe(false);
-    expect((out.content[0]! as { text: string }).text).toContain("(none)");
+    expect((out.content[0]! as { text: string }).text).toContain("42");
   });
 
-  it("shows remaining PRs after unsubscribe", () => {
+  it("shows confirmation after unsubscribe", () => {
     subs.subscribe(1);
     subs.subscribe(2);
     const out = handleUnsubscribePr({ prNumber: 1 }, subs);
-    expect((out.content[0]! as { text: string }).text).toContain("2");
+    expect((out.content[0]! as { text: string }).text).toContain("1");
+    expect(subs.isSubscribed(1)).toBe(false);
   });
 });

--- a/src/mcp/tool-handlers.mock.test.mts
+++ b/src/mcp/tool-handlers.mock.test.mts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../commands/check.mts", () => ({ runCheck: vi.fn() }));
+vi.mock("../commands/resolve.mts", () => ({
+  runResolveFetch: vi.fn(),
+  runResolveMutate: vi.fn(),
+}));
+vi.mock("../commands/commit-suggestion.mts", () => ({ runCommitSuggestion: vi.fn() }));
+vi.mock("../commands/iterate.mts", () => ({ runIterate: vi.fn() }));
+vi.mock("../commands/monitor.mts", () => ({
+  runMonitor: vi.fn(),
+  formatMonitorResult: vi.fn(),
+}));
+vi.mock("../commands/status.mts", () => ({
+  runStatus: vi.fn(),
+  formatStatusTable: vi.fn(),
+}));
+vi.mock("../commands/log-file.mts", () => ({ runLogFile: vi.fn() }));
+vi.mock("../github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
+}));
+vi.mock("../reporters/text.mts", () => ({ formatText: vi.fn() }));
+vi.mock("../cli/formatters.mts", () => ({
+  formatFetchResult: vi.fn(),
+  formatCommitSuggestionResult: vi.fn(),
+  formatMutateResult: vi.fn(),
+  formatIterateResult: vi.fn(),
+}));
+vi.mock("./tool-coerce.mts", async (importOriginal) => {
+  return importOriginal();
+});
+
+import { runCheck } from "../commands/check.mts";
+import { runResolveFetch, runResolveMutate } from "../commands/resolve.mts";
+import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
+import { runIterate } from "../commands/iterate.mts";
+import { runMonitor, formatMonitorResult } from "../commands/monitor.mts";
+import { runStatus, formatStatusTable } from "../commands/status.mts";
+import { runLogFile } from "../commands/log-file.mts";
+import { formatText } from "../reporters/text.mts";
+import {
+  formatFetchResult,
+  formatCommitSuggestionResult,
+  formatMutateResult,
+  formatIterateResult,
+} from "../cli/formatters.mts";
+import { SubscriptionStore } from "./subscriptions.mts";
+import {
+  handleCheck,
+  handleResolveFetch,
+  handleResolveMutate,
+  handleCommitSuggestion,
+  handleIterate,
+  handleMonitor,
+  handleStatus,
+  handleLogFile,
+  handleSubscribePr,
+  handleUnsubscribePr,
+  ok,
+  err,
+} from "./tool-handlers.mts";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ok / err helpers", () => {
+  it("ok wraps text in content array", () => {
+    expect(ok("hello")).toEqual({ content: [{ type: "text", text: "hello" }] });
+  });
+
+  it("err sets isError and prefixes message", () => {
+    const result = err("oops");
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe("Error: oops");
+  });
+});
+
+describe("handleCheck", () => {
+  it("calls runCheck and formats the report", async () => {
+    const report = { pr: 1 };
+    vi.mocked(runCheck).mockResolvedValue(report as never);
+    vi.mocked(formatText).mockReturnValue("check output");
+
+    const result = await handleCheck({ prNumber: 1 });
+    expect(runCheck).toHaveBeenCalledWith({ format: "text", prNumber: 1, skipTriage: undefined });
+    expect(result.content[0]!.text).toBe("check output");
+  });
+
+  it("works without prNumber", async () => {
+    vi.mocked(runCheck).mockResolvedValue({} as never);
+    vi.mocked(formatText).mockReturnValue("ok");
+    await handleCheck({});
+    expect(runCheck).toHaveBeenCalledWith({
+      format: "text",
+      prNumber: undefined,
+      skipTriage: undefined,
+    });
+  });
+});
+
+describe("handleResolveFetch", () => {
+  it("calls runResolveFetch and formats result", async () => {
+    const result = { prNumber: 1 };
+    vi.mocked(runResolveFetch).mockResolvedValue(result as never);
+    vi.mocked(formatFetchResult).mockReturnValue("fetch output");
+
+    const out = await handleResolveFetch({ prNumber: 1 });
+    expect(out.content[0]!.text).toBe("fetch output");
+  });
+});
+
+describe("handleResolveMutate", () => {
+  it("calls runResolveMutate with all options", async () => {
+    vi.mocked(runResolveMutate).mockResolvedValue({} as never);
+    vi.mocked(formatMutateResult).mockReturnValue("mutate output");
+
+    await handleResolveMutate({
+      resolveThreadIds: ["t1"],
+      minimizeCommentIds: ["c1"],
+      dismissReviewIds: ["r1"],
+      dismissMessage: "msg",
+      requireSha: "abc",
+    });
+    expect(runResolveMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolveThreadIds: ["t1"],
+        minimizeCommentIds: ["c1"],
+        dismissReviewIds: ["r1"],
+        dismissMessage: "msg",
+        requireSha: "abc",
+      }),
+    );
+  });
+});
+
+describe("handleCommitSuggestion", () => {
+  it("calls runCommitSuggestion with required threadId", async () => {
+    vi.mocked(runCommitSuggestion).mockResolvedValue({} as never);
+    vi.mocked(formatCommitSuggestionResult).mockReturnValue("cs output");
+
+    const out = await handleCommitSuggestion({ threadId: "t1", message: "fix" });
+    expect(runCommitSuggestion).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "t1", message: "fix" }),
+    );
+    expect(out.content[0]!.text).toBe("cs output");
+  });
+
+  it("throws when threadId missing", async () => {
+    await expect(handleCommitSuggestion({})).rejects.toThrow("threadId");
+  });
+});
+
+describe("handleIterate", () => {
+  it("calls runIterate and formats result", async () => {
+    vi.mocked(runIterate).mockResolvedValue({} as never);
+    vi.mocked(formatIterateResult).mockReturnValue("iterate output");
+
+    const out = await handleIterate({ cooldownSeconds: 10, noAutoMarkReady: true });
+    expect(runIterate).toHaveBeenCalledWith(
+      expect.objectContaining({ cooldownSeconds: 10, noAutoMarkReady: true }),
+    );
+    expect(out.content[0]!.text).toBe("iterate output");
+  });
+});
+
+describe("handleMonitor", () => {
+  it("calls runMonitor and formatMonitorResult", async () => {
+    vi.mocked(runMonitor).mockResolvedValue({} as never);
+    vi.mocked(formatMonitorResult).mockReturnValue("monitor output");
+
+    const out = await handleMonitor({ readyDelaySuffix: "15m" });
+    expect(out.content[0]!.text).toBe("monitor output");
+  });
+});
+
+describe("handleStatus", () => {
+  it("calls runStatus and formatStatusTable with repo", async () => {
+    vi.mocked(runStatus).mockResolvedValue([]);
+    vi.mocked(formatStatusTable).mockReturnValue("status output");
+
+    const out = await handleStatus({ prNumbers: [1, 2] });
+    expect(runStatus).toHaveBeenCalledWith(expect.objectContaining({ prNumbers: [1, 2] }));
+    expect(formatStatusTable).toHaveBeenCalledWith([], "owner/repo");
+    expect(out.content[0]!.text).toBe("status output");
+  });
+
+  it("throws when prNumbers missing", async () => {
+    await expect(handleStatus({})).rejects.toThrow("prNumbers");
+  });
+});
+
+describe("handleLogFile", () => {
+  it("returns the log file path", async () => {
+    vi.mocked(runLogFile).mockResolvedValue({ path: "/tmp/log.md" });
+    const out = await handleLogFile();
+    expect(out.content[0]!.text).toBe("/tmp/log.md");
+  });
+});
+
+describe("handleSubscribePr / handleUnsubscribePr", () => {
+  let subs: SubscriptionStore;
+
+  beforeEach(() => {
+    subs = new SubscriptionStore();
+  });
+
+  it("subscribes a PR and lists it", () => {
+    const out = handleSubscribePr({ prNumber: 42 }, subs);
+    expect(subs.isSubscribed(42)).toBe(true);
+    expect(out.content[0]!.text).toContain("42");
+  });
+
+  it("throws when prNumber missing", () => {
+    expect(() => handleSubscribePr({}, subs)).toThrow("prNumber");
+  });
+
+  it("unsubscribes a PR", () => {
+    subs.subscribe(42);
+    const out = handleUnsubscribePr({ prNumber: 42 }, subs);
+    expect(subs.isSubscribed(42)).toBe(false);
+    expect(out.content[0]!.text).toContain("(none)");
+  });
+
+  it("shows remaining PRs after unsubscribe", () => {
+    subs.subscribe(1);
+    subs.subscribe(2);
+    const out = handleUnsubscribePr({ prNumber: 1 }, subs);
+    expect(out.content[0]!.text).toContain("2");
+  });
+});

--- a/src/mcp/tool-handlers.mts
+++ b/src/mcp/tool-handlers.mts
@@ -1,0 +1,161 @@
+/** MCP tool handler implementations — one function per tool. */
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import { runCheck } from "../commands/check.mts";
+import { runResolveFetch, runResolveMutate } from "../commands/resolve.mts";
+import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
+import { runIterate } from "../commands/iterate.mts";
+import { runMonitor, formatMonitorResult } from "../commands/monitor.mts";
+import { runStatus, formatStatusTable } from "../commands/status.mts";
+import { runLogFile } from "../commands/log-file.mts";
+import { getRepoInfo } from "../github/client.mts";
+import { formatText } from "../reporters/text.mts";
+import {
+  formatFetchResult,
+  formatCommitSuggestionResult,
+  formatMutateResult,
+  formatIterateResult,
+} from "../cli/formatters.mts";
+import type { SubscriptionStore } from "./subscriptions.mts";
+import {
+  optNum,
+  reqNum,
+  optStr,
+  reqStr,
+  optBool,
+  optStringArray,
+  reqNumArray,
+} from "./tool-coerce.mts";
+
+// ---------------------------------------------------------------------------
+// Result helpers
+// ---------------------------------------------------------------------------
+
+const TEXT = "text" as const;
+const FORMAT_TEXT = { format: TEXT } as const;
+
+export function ok(text: string): CallToolResult {
+  return { content: [{ type: TEXT, text }] };
+}
+
+export function err(msg: string): CallToolResult {
+  return { content: [{ type: TEXT, text: `Error: ${msg}` }], isError: true };
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export async function handleCheck(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const skipTriage = optBool(input, "skipTriage");
+  const report = await runCheck({ ...FORMAT_TEXT, prNumber, skipTriage });
+  return ok(formatText(report));
+}
+
+export async function handleResolveFetch(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const result = await runResolveFetch({ ...FORMAT_TEXT, prNumber });
+  return ok(formatFetchResult(result));
+}
+
+export async function handleResolveMutate(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const resolveThreadIds = optStringArray(input, "resolveThreadIds");
+  const minimizeCommentIds = optStringArray(input, "minimizeCommentIds");
+  const dismissReviewIds = optStringArray(input, "dismissReviewIds");
+  const dismissMessage = optStr(input, "dismissMessage");
+  const requireSha = optStr(input, "requireSha");
+  const result = await runResolveMutate({
+    ...FORMAT_TEXT,
+    prNumber,
+    resolveThreadIds,
+    minimizeCommentIds,
+    dismissReviewIds,
+    dismissMessage,
+    requireSha,
+  });
+  return ok(formatMutateResult(result));
+}
+
+export async function handleCommitSuggestion(
+  input: Record<string, unknown>,
+): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const threadId = reqStr(input, "threadId");
+  const message = optStr(input, "message");
+  const description = optStr(input, "description");
+  const dryRun = optBool(input, "dryRun");
+  const result = await runCommitSuggestion({
+    ...FORMAT_TEXT,
+    prNumber,
+    threadId,
+    message,
+    description,
+    dryRun,
+  });
+  return ok(formatCommitSuggestionResult(result));
+}
+
+export async function handleIterate(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const cooldownSeconds = optNum(input, "cooldownSeconds");
+  const readyDelaySeconds = optNum(input, "readyDelaySeconds");
+  const stallTimeoutSeconds = optNum(input, "stallTimeoutSeconds");
+  const noAutoMarkReady = optBool(input, "noAutoMarkReady");
+  const noAutoCancelActionable = optBool(input, "noAutoCancelActionable");
+  const result = await runIterate({
+    ...FORMAT_TEXT,
+    prNumber,
+    cooldownSeconds,
+    readyDelaySeconds,
+    stallTimeoutSeconds,
+    noAutoMarkReady,
+    noAutoCancelActionable,
+  });
+  return ok(formatIterateResult(result));
+}
+
+export async function handleMonitor(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const readyDelaySuffix = optStr(input, "readyDelaySuffix");
+  const result = await runMonitor({ ...FORMAT_TEXT, prNumber, readyDelaySuffix });
+  return ok(formatMonitorResult(result));
+}
+
+export async function handleStatus(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumbers = reqNumArray(input, "prNumbers");
+  const repo = await getRepoInfo();
+  const summaries = await runStatus({ ...FORMAT_TEXT, prNumbers });
+  return ok(formatStatusTable(summaries, `${repo.owner}/${repo.name}`));
+}
+
+export async function handleLogFile(): Promise<CallToolResult> {
+  const result = await runLogFile();
+  return ok(result.path);
+}
+
+export function handleSubscribePr(
+  input: Record<string, unknown>,
+  subs: SubscriptionStore,
+): CallToolResult {
+  const prNumber = reqNum(input, "prNumber");
+  subs.subscribe(prNumber);
+  const all = subs.listSubscribed();
+  return ok(
+    `Subscribed to PR #${prNumber}. Webhook events for this PR will be forwarded as MCP notifications.\nCurrently subscribed PRs: ${all.join(", ")}`,
+  );
+}
+
+export function handleUnsubscribePr(
+  input: Record<string, unknown>,
+  subs: SubscriptionStore,
+): CallToolResult {
+  const prNumber = reqNum(input, "prNumber");
+  subs.unsubscribe(prNumber);
+  const all = subs.listSubscribed();
+  return ok(
+    `Unsubscribed from PR #${prNumber}.\nCurrently subscribed PRs: ${all.length > 0 ? all.join(", ") : "(none)"}`,
+  );
+}

--- a/src/mcp/tool-handlers.mts
+++ b/src/mcp/tool-handlers.mts
@@ -67,6 +67,13 @@ export async function handleResolveMutate(input: Record<string, unknown>): Promi
   const dismissReviewIds = optStringArray(input, "dismissReviewIds");
   const dismissMessage = optStr(input, "dismissMessage");
   const requireSha = optStr(input, "requireSha");
+
+  if (!resolveThreadIds?.length && !minimizeCommentIds?.length && !dismissReviewIds?.length) {
+    return err("Provide at least one of: resolveThreadIds, minimizeCommentIds, dismissReviewIds");
+  }
+  if (dismissReviewIds?.length && !dismissMessage) {
+    return err("dismissMessage is required when dismissReviewIds is non-empty");
+  }
   const result = await runResolveMutate({
     ...FORMAT_TEXT,
     prNumber,
@@ -142,9 +149,8 @@ export function handleSubscribePr(
 ): CallToolResult {
   const prNumber = reqNum(input, "prNumber");
   subs.subscribe(prNumber);
-  const all = subs.listSubscribed();
   return ok(
-    `Subscribed to PR #${prNumber}. Webhook events for this PR will be forwarded as MCP notifications.\nCurrently subscribed PRs: ${all.join(", ")}`,
+    `Subscribed to PR #${prNumber}. Webhook events for this PR will be forwarded as MCP notifications.`,
   );
 }
 
@@ -154,8 +160,5 @@ export function handleUnsubscribePr(
 ): CallToolResult {
   const prNumber = reqNum(input, "prNumber");
   subs.unsubscribe(prNumber);
-  const all = subs.listSubscribed();
-  return ok(
-    `Unsubscribed from PR #${prNumber}.\nCurrently subscribed PRs: ${all.length > 0 ? all.join(", ") : "(none)"}`,
-  );
+  return ok(`Unsubscribed from PR #${prNumber}.`);
 }

--- a/src/mcp/tool-list-ops.mts
+++ b/src/mcp/tool-list-ops.mts
@@ -1,0 +1,62 @@
+/** MCP tool definitions for monitoring, status, and subscription operations. */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const OPS_TOOLS: Tool[] = [
+  {
+    name: "shepherd_monitor",
+    description:
+      "Get the /loop arguments and prompt body to start continuous PR monitoring. Use this to bootstrap the monitoring loop.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        readyDelaySuffix: { type: "string", description: "Ready-delay duration string, e.g. '15m'" },
+      },
+    },
+  },
+  {
+    name: "shepherd_status",
+    description: "Get a status table for one or more PRs in a single GitHub request.",
+    inputSchema: {
+      type: "object",
+      required: ["prNumbers"],
+      properties: {
+        prNumbers: {
+          type: "array",
+          items: { type: "number" },
+          minItems: 1,
+          description: "List of PR numbers to check",
+        },
+      },
+    },
+  },
+  {
+    name: "shepherd_log_file",
+    description: "Return the path to the per-worktree debug log file.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "shepherd_subscribe_pr",
+    description:
+      "Subscribe this session to GitHub webhook events for the given PR number. Matching events will be forwarded as MCP notifications wrapped in <github-webhook-activity> tags.",
+    inputSchema: {
+      type: "object",
+      required: ["prNumber"],
+      properties: {
+        prNumber: { type: "number", description: "PR number to subscribe to" },
+      },
+    },
+  },
+  {
+    name: "shepherd_unsubscribe_pr",
+    description: "Unsubscribe this session from GitHub webhook events for the given PR number.",
+    inputSchema: {
+      type: "object",
+      required: ["prNumber"],
+      properties: {
+        prNumber: { type: "number", description: "PR number to unsubscribe from" },
+      },
+    },
+  },
+];

--- a/src/mcp/tool-list-ops.mts
+++ b/src/mcp/tool-list-ops.mts
@@ -10,8 +10,14 @@ export const OPS_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-        readyDelaySuffix: { type: "string", description: "Ready-delay duration string, e.g. '15m'" },
+        prNumber: {
+          type: "number",
+          description: "PR number (auto-detected from current branch if omitted)",
+        },
+        readyDelaySuffix: {
+          type: "string",
+          description: "Ready-delay duration string, e.g. '15m'",
+        },
       },
     },
   },

--- a/src/mcp/tool-list-pr.mts
+++ b/src/mcp/tool-list-pr.mts
@@ -10,8 +10,14 @@ export const PR_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-        skipTriage: { type: "boolean", description: "Skip fetching job info and log tails for failing checks" },
+        prNumber: {
+          type: "number",
+          description: "PR number (auto-detected from current branch if omitted)",
+        },
+        skipTriage: {
+          type: "boolean",
+          description: "Skip fetching job info and log tails for failing checks",
+        },
       },
     },
   },
@@ -22,7 +28,10 @@ export const PR_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        prNumber: {
+          type: "number",
+          description: "PR number (auto-detected from current branch if omitted)",
+        },
       },
     },
   },
@@ -33,12 +42,30 @@ export const PR_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-        resolveThreadIds: { type: "array", items: { type: "string" }, description: "Thread node IDs to resolve" },
-        minimizeCommentIds: { type: "array", items: { type: "string" }, description: "Comment node IDs to minimize" },
-        dismissReviewIds: { type: "array", items: { type: "string" }, description: "Review node IDs to dismiss" },
+        prNumber: {
+          type: "number",
+          description: "PR number (auto-detected from current branch if omitted)",
+        },
+        resolveThreadIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Thread node IDs to resolve",
+        },
+        minimizeCommentIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Comment node IDs to minimize",
+        },
+        dismissReviewIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Review node IDs to dismiss",
+        },
         dismissMessage: { type: "string", description: "Required when dismissing reviews" },
-        requireSha: { type: "string", description: "Wait for GitHub to receive this commit SHA before resolving" },
+        requireSha: {
+          type: "string",
+          description: "Wait for GitHub to receive this commit SHA before resolving",
+        },
       },
     },
   },
@@ -50,8 +77,14 @@ export const PR_TOOLS: Tool[] = [
       type: "object",
       required: ["threadId"],
       properties: {
-        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-        threadId: { type: "string", description: "Review thread node ID containing the suggestion" },
+        prNumber: {
+          type: "number",
+          description: "PR number (auto-detected from current branch if omitted)",
+        },
+        threadId: {
+          type: "string",
+          description: "Review thread node ID containing the suggestion",
+        },
         message: { type: "string", description: "Commit message (required unless dryRun is true)" },
         description: { type: "string", description: "Optional extended commit description" },
         dryRun: { type: "boolean", description: "Validate the patch without applying it" },
@@ -65,12 +98,27 @@ export const PR_TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        prNumber: {
+          type: "number",
+          description: "PR number (auto-detected from current branch if omitted)",
+        },
         cooldownSeconds: { type: "number", description: "Minimum seconds between code changes" },
-        readyDelaySeconds: { type: "number", description: "Seconds to wait after all checks pass before marking ready" },
-        stallTimeoutSeconds: { type: "number", description: "Abort if no progress after this many seconds" },
-        noAutoMarkReady: { type: "boolean", description: "Disable automatic draft → ready transition" },
-        noAutoCancelActionable: { type: "boolean", description: "Disable automatic cancellation of actionable checks" },
+        readyDelaySeconds: {
+          type: "number",
+          description: "Seconds to wait after all checks pass before marking ready",
+        },
+        stallTimeoutSeconds: {
+          type: "number",
+          description: "Abort if no progress after this many seconds",
+        },
+        noAutoMarkReady: {
+          type: "boolean",
+          description: "Disable automatic draft → ready transition",
+        },
+        noAutoCancelActionable: {
+          type: "boolean",
+          description: "Disable automatic cancellation of actionable checks",
+        },
       },
     },
   },

--- a/src/mcp/tool-list-pr.mts
+++ b/src/mcp/tool-list-pr.mts
@@ -1,0 +1,77 @@
+/** MCP tool definitions for PR inspection and mutation commands. */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const PR_TOOLS: Tool[] = [
+  {
+    name: "shepherd_check",
+    description:
+      "Get a PR status snapshot: CI checks (passing/failing/in-progress), review threads, PR comments, and merge status. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        skipTriage: { type: "boolean", description: "Skip fetching job info and log tails for failing checks" },
+      },
+    },
+  },
+  {
+    name: "shepherd_resolve_fetch",
+    description:
+      "Fetch actionable review threads and PR comments for a PR. Auto-resolves outdated threads and surfaces first-look items. Returns structured triage output with instructions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+      },
+    },
+  },
+  {
+    name: "shepherd_resolve_mutate",
+    description:
+      "Resolve, minimize, or dismiss review items by ID. Provide at least one of resolveThreadIds, minimizeCommentIds, or dismissReviewIds.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        resolveThreadIds: { type: "array", items: { type: "string" }, description: "Thread node IDs to resolve" },
+        minimizeCommentIds: { type: "array", items: { type: "string" }, description: "Comment node IDs to minimize" },
+        dismissReviewIds: { type: "array", items: { type: "string" }, description: "Review node IDs to dismiss" },
+        dismissMessage: { type: "string", description: "Required when dismissing reviews" },
+        requireSha: { type: "string", description: "Wait for GitHub to receive this commit SHA before resolving" },
+      },
+    },
+  },
+  {
+    name: "shepherd_commit_suggestion",
+    description:
+      "Apply a suggestion block from a review thread and create a local git commit. Optionally dry-run to validate without committing.",
+    inputSchema: {
+      type: "object",
+      required: ["threadId"],
+      properties: {
+        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        threadId: { type: "string", description: "Review thread node ID containing the suggestion" },
+        message: { type: "string", description: "Commit message (required unless dryRun is true)" },
+        description: { type: "string", description: "Optional extended commit description" },
+        dryRun: { type: "boolean", description: "Validate the patch without applying it" },
+      },
+    },
+  },
+  {
+    name: "shepherd_iterate",
+    description:
+      "Run one iterate cycle: assess PR state and return the next action (fix_code, wait, mark_ready, cancel, or escalate) with instructions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        cooldownSeconds: { type: "number", description: "Minimum seconds between code changes" },
+        readyDelaySeconds: { type: "number", description: "Seconds to wait after all checks pass before marking ready" },
+        stallTimeoutSeconds: { type: "number", description: "Abort if no progress after this many seconds" },
+        noAutoMarkReady: { type: "boolean", description: "Disable automatic draft → ready transition" },
+        noAutoCancelActionable: { type: "boolean", description: "Disable automatic cancellation of actionable checks" },
+      },
+    },
+  },
+];

--- a/src/mcp/tools.mock.test.mts
+++ b/src/mcp/tools.mock.test.mts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("./tool-handlers.mts", () => ({
+  handleCheck: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "check" }] }),
+  handleResolveFetch: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "fetch" }] }),
+  handleResolveMutate: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "mutate" }] }),
+  handleCommitSuggestion: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "cs" }] }),
+  handleIterate: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "iterate" }] }),
+  handleMonitor: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "monitor" }] }),
+  handleStatus: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "status" }] }),
+  handleLogFile: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "/tmp/log.md" }] }),
+  handleSubscribePr: vi.fn().mockReturnValue({ content: [{ type: "text", text: "subscribed" }] }),
+  handleUnsubscribePr: vi
+    .fn()
+    .mockReturnValue({ content: [{ type: "text", text: "unsubscribed" }] }),
+  err: vi.fn((msg: string) => ({
+    content: [{ type: "text", text: `Error: ${msg}` }],
+    isError: true,
+  })),
+}));
+
+import { buildToolList, buildToolHandler } from "./tools.mts";
+import { SubscriptionStore } from "./subscriptions.mts";
+
+describe("buildToolList", () => {
+  it("returns 10 tools", () => {
+    expect(buildToolList()).toHaveLength(10);
+  });
+
+  it("includes all expected tool names", () => {
+    const names = buildToolList().map((t) => t.name);
+    expect(names).toContain("shepherd_check");
+    expect(names).toContain("shepherd_resolve_fetch");
+    expect(names).toContain("shepherd_resolve_mutate");
+    expect(names).toContain("shepherd_commit_suggestion");
+    expect(names).toContain("shepherd_iterate");
+    expect(names).toContain("shepherd_monitor");
+    expect(names).toContain("shepherd_status");
+    expect(names).toContain("shepherd_log_file");
+    expect(names).toContain("shepherd_subscribe_pr");
+    expect(names).toContain("shepherd_unsubscribe_pr");
+  });
+
+  it("each tool has a name, description, and inputSchema", () => {
+    for (const tool of buildToolList()) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeTruthy();
+    }
+  });
+});
+
+describe("buildToolHandler", () => {
+  const deps = { subscriptions: new SubscriptionStore() };
+
+  it("routes shepherd_check to handleCheck", async () => {
+    const handler = buildToolHandler(deps);
+    const result = await handler("shepherd_check", {});
+    expect(result.content[0]!.text).toBe("check");
+  });
+
+  it("routes shepherd_resolve_fetch", async () => {
+    const result = await buildToolHandler(deps)("shepherd_resolve_fetch", {});
+    expect(result.content[0]!.text).toBe("fetch");
+  });
+
+  it("routes shepherd_resolve_mutate", async () => {
+    const result = await buildToolHandler(deps)("shepherd_resolve_mutate", {});
+    expect(result.content[0]!.text).toBe("mutate");
+  });
+
+  it("routes shepherd_commit_suggestion", async () => {
+    const result = await buildToolHandler(deps)("shepherd_commit_suggestion", {});
+    expect(result.content[0]!.text).toBe("cs");
+  });
+
+  it("routes shepherd_iterate", async () => {
+    const result = await buildToolHandler(deps)("shepherd_iterate", {});
+    expect(result.content[0]!.text).toBe("iterate");
+  });
+
+  it("routes shepherd_monitor", async () => {
+    const result = await buildToolHandler(deps)("shepherd_monitor", {});
+    expect(result.content[0]!.text).toBe("monitor");
+  });
+
+  it("routes shepherd_status", async () => {
+    const result = await buildToolHandler(deps)("shepherd_status", {});
+    expect(result.content[0]!.text).toBe("status");
+  });
+
+  it("routes shepherd_log_file", async () => {
+    const result = await buildToolHandler(deps)("shepherd_log_file", {});
+    expect(result.content[0]!.text).toBe("/tmp/log.md");
+  });
+
+  it("routes shepherd_subscribe_pr", async () => {
+    const result = await buildToolHandler(deps)("shepherd_subscribe_pr", { prNumber: 1 });
+    expect(result.content[0]!.text).toBe("subscribed");
+  });
+
+  it("routes shepherd_unsubscribe_pr", async () => {
+    const result = await buildToolHandler(deps)("shepherd_unsubscribe_pr", { prNumber: 1 });
+    expect(result.content[0]!.text).toBe("unsubscribed");
+  });
+
+  it("returns error for unknown tool", async () => {
+    const result = await buildToolHandler(deps)("unknown_tool", {});
+    expect(result.isError).toBe(true);
+  });
+
+  it("catches thrown errors and returns isError result", async () => {
+    const { handleCheck } = await import("./tool-handlers.mts");
+    vi.mocked(handleCheck).mockRejectedValueOnce(new Error("boom"));
+    const result = await buildToolHandler(deps)("shepherd_check", {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("boom");
+  });
+});

--- a/src/mcp/tools.mock.test.mts
+++ b/src/mcp/tools.mock.test.mts
@@ -56,52 +56,52 @@ describe("buildToolHandler", () => {
   it("routes shepherd_check to handleCheck", async () => {
     const handler = buildToolHandler(deps);
     const result = await handler("shepherd_check", {});
-    expect(result.content[0]!.text).toBe("check");
+    expect((result.content[0]! as { text: string }).text).toBe("check");
   });
 
   it("routes shepherd_resolve_fetch", async () => {
     const result = await buildToolHandler(deps)("shepherd_resolve_fetch", {});
-    expect(result.content[0]!.text).toBe("fetch");
+    expect((result.content[0]! as { text: string }).text).toBe("fetch");
   });
 
   it("routes shepherd_resolve_mutate", async () => {
     const result = await buildToolHandler(deps)("shepherd_resolve_mutate", {});
-    expect(result.content[0]!.text).toBe("mutate");
+    expect((result.content[0]! as { text: string }).text).toBe("mutate");
   });
 
   it("routes shepherd_commit_suggestion", async () => {
     const result = await buildToolHandler(deps)("shepherd_commit_suggestion", {});
-    expect(result.content[0]!.text).toBe("cs");
+    expect((result.content[0]! as { text: string }).text).toBe("cs");
   });
 
   it("routes shepherd_iterate", async () => {
     const result = await buildToolHandler(deps)("shepherd_iterate", {});
-    expect(result.content[0]!.text).toBe("iterate");
+    expect((result.content[0]! as { text: string }).text).toBe("iterate");
   });
 
   it("routes shepherd_monitor", async () => {
     const result = await buildToolHandler(deps)("shepherd_monitor", {});
-    expect(result.content[0]!.text).toBe("monitor");
+    expect((result.content[0]! as { text: string }).text).toBe("monitor");
   });
 
   it("routes shepherd_status", async () => {
     const result = await buildToolHandler(deps)("shepherd_status", {});
-    expect(result.content[0]!.text).toBe("status");
+    expect((result.content[0]! as { text: string }).text).toBe("status");
   });
 
   it("routes shepherd_log_file", async () => {
     const result = await buildToolHandler(deps)("shepherd_log_file", {});
-    expect(result.content[0]!.text).toBe("/tmp/log.md");
+    expect((result.content[0]! as { text: string }).text).toBe("/tmp/log.md");
   });
 
   it("routes shepherd_subscribe_pr", async () => {
     const result = await buildToolHandler(deps)("shepherd_subscribe_pr", { prNumber: 1 });
-    expect(result.content[0]!.text).toBe("subscribed");
+    expect((result.content[0]! as { text: string }).text).toBe("subscribed");
   });
 
   it("routes shepherd_unsubscribe_pr", async () => {
     const result = await buildToolHandler(deps)("shepherd_unsubscribe_pr", { prNumber: 1 });
-    expect(result.content[0]!.text).toBe("unsubscribed");
+    expect((result.content[0]! as { text: string }).text).toBe("unsubscribed");
   });
 
   it("returns error for unknown tool", async () => {
@@ -114,6 +114,6 @@ describe("buildToolHandler", () => {
     vi.mocked(handleCheck).mockRejectedValueOnce(new Error("boom"));
     const result = await buildToolHandler(deps)("shepherd_check", {});
     expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toContain("boom");
+    expect((result.content[0]! as { text: string }).text).toContain("boom");
   });
 });

--- a/src/mcp/tools.mts
+++ b/src/mcp/tools.mts
@@ -1,0 +1,374 @@
+/**
+ * MCP tool definitions for pr-shepherd.
+ *
+ * Each tool delegates to the corresponding run*() command function and returns
+ * formatted text output (same as CLI --format=text) as MCP TextContent.
+ */
+
+import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import { runCheck } from "../commands/check.mts";
+import { runResolveFetch, runResolveMutate } from "../commands/resolve.mts";
+import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
+import { runIterate } from "../commands/iterate.mts";
+import { runMonitor, formatMonitorResult } from "../commands/monitor.mts";
+import { runStatus, formatStatusTable } from "../commands/status.mts";
+import { runLogFile } from "../commands/log-file.mts";
+import { getRepoInfo } from "../github/client.mts";
+import { formatText } from "../reporters/text.mts";
+import {
+  formatFetchResult,
+  formatCommitSuggestionResult,
+  formatMutateResult,
+  formatIterateResult,
+} from "../cli/formatters.mts";
+import type { SubscriptionStore } from "./subscriptions.mts";
+
+// ---------------------------------------------------------------------------
+// Common types
+// ---------------------------------------------------------------------------
+
+const TEXT: "text" = "text";
+const FORMAT_TEXT = { format: TEXT } as const;
+
+export interface ToolDependencies {
+  subscriptions: SubscriptionStore;
+}
+
+// ---------------------------------------------------------------------------
+// Tool list
+// ---------------------------------------------------------------------------
+
+export function buildToolList(): Tool[] {
+  return [
+    {
+      name: "shepherd_check",
+      description:
+        "Get a PR status snapshot: CI checks (passing/failing/in-progress), review threads, PR comments, and merge status. Read-only.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          skipTriage: { type: "boolean", description: "Skip fetching job info and log tails for failing checks" },
+        },
+      },
+    },
+    {
+      name: "shepherd_resolve_fetch",
+      description:
+        "Fetch actionable review threads and PR comments for a PR. Auto-resolves outdated threads and surfaces first-look items. Returns structured triage output with instructions.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+        },
+      },
+    },
+    {
+      name: "shepherd_resolve_mutate",
+      description:
+        "Resolve, minimize, or dismiss review items by ID. Provide at least one of resolveThreadIds, minimizeCommentIds, or dismissReviewIds.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          resolveThreadIds: { type: "array", items: { type: "string" }, description: "Thread node IDs to resolve" },
+          minimizeCommentIds: { type: "array", items: { type: "string" }, description: "Comment node IDs to minimize" },
+          dismissReviewIds: { type: "array", items: { type: "string" }, description: "Review node IDs to dismiss" },
+          dismissMessage: { type: "string", description: "Required when dismissing reviews" },
+          requireSha: { type: "string", description: "Wait for GitHub to receive this commit SHA before resolving" },
+        },
+      },
+    },
+    {
+      name: "shepherd_commit_suggestion",
+      description:
+        "Apply a suggestion block from a review thread and create a local git commit. Optionally dry-run to validate without committing.",
+      inputSchema: {
+        type: "object",
+        required: ["threadId"],
+        properties: {
+          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          threadId: { type: "string", description: "Review thread node ID containing the suggestion" },
+          message: { type: "string", description: "Commit message (required unless dryRun is true)" },
+          description: { type: "string", description: "Optional extended commit description" },
+          dryRun: { type: "boolean", description: "Validate the patch without applying it" },
+        },
+      },
+    },
+    {
+      name: "shepherd_iterate",
+      description:
+        "Run one iterate cycle: assess PR state and return the next action (fix_code, wait, mark_ready, cancel, or escalate) with instructions.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          cooldownSeconds: { type: "number", description: "Minimum seconds between code changes" },
+          readyDelaySeconds: { type: "number", description: "Seconds to wait after all checks pass before marking ready" },
+          stallTimeoutSeconds: { type: "number", description: "Abort if no progress after this many seconds" },
+          noAutoMarkReady: { type: "boolean", description: "Disable automatic draft → ready transition" },
+          noAutoCancelActionable: { type: "boolean", description: "Disable automatic cancellation of actionable checks" },
+        },
+      },
+    },
+    {
+      name: "shepherd_monitor",
+      description:
+        "Get the /loop arguments and prompt body to start continuous PR monitoring. Use this to bootstrap the monitoring loop.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          readyDelaySuffix: { type: "string", description: "Ready-delay duration string, e.g. '15m'" },
+        },
+      },
+    },
+    {
+      name: "shepherd_status",
+      description: "Get a status table for one or more PRs in a single GitHub request.",
+      inputSchema: {
+        type: "object",
+        required: ["prNumbers"],
+        properties: {
+          prNumbers: {
+            type: "array",
+            items: { type: "number" },
+            minItems: 1,
+            description: "List of PR numbers to check",
+          },
+        },
+      },
+    },
+    {
+      name: "shepherd_log_file",
+      description: "Return the path to the per-worktree debug log file.",
+      inputSchema: { type: "object", properties: {} },
+    },
+    {
+      name: "shepherd_subscribe_pr",
+      description:
+        "Subscribe this session to GitHub webhook events for the given PR number. Matching events will be forwarded as MCP notifications wrapped in <github-webhook-activity> tags.",
+      inputSchema: {
+        type: "object",
+        required: ["prNumber"],
+        properties: {
+          prNumber: { type: "number", description: "PR number to subscribe to" },
+        },
+      },
+    },
+    {
+      name: "shepherd_unsubscribe_pr",
+      description: "Unsubscribe this session from GitHub webhook events for the given PR number.",
+      inputSchema: {
+        type: "object",
+        required: ["prNumber"],
+        properties: {
+          prNumber: { type: "number", description: "PR number to unsubscribe from" },
+        },
+      },
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler dispatcher
+// ---------------------------------------------------------------------------
+
+export function buildToolHandler(
+  deps: ToolDependencies,
+): (name: string, input: Record<string, unknown>) => Promise<CallToolResult> {
+  return async (name, input) => {
+    try {
+      switch (name) {
+        case "shepherd_check":
+          return await handleCheck(input);
+        case "shepherd_resolve_fetch":
+          return await handleResolveFetch(input);
+        case "shepherd_resolve_mutate":
+          return await handleResolveMutate(input);
+        case "shepherd_commit_suggestion":
+          return await handleCommitSuggestion(input);
+        case "shepherd_iterate":
+          return await handleIterate(input);
+        case "shepherd_monitor":
+          return await handleMonitor(input);
+        case "shepherd_status":
+          return await handleStatus(input);
+        case "shepherd_log_file":
+          return await handleLogFile();
+        case "shepherd_subscribe_pr":
+          return handleSubscribePr(input, deps.subscriptions);
+        case "shepherd_unsubscribe_pr":
+          return handleUnsubscribePr(input, deps.subscriptions);
+        default:
+          return err(`Unknown tool: ${name}`);
+      }
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Individual handlers
+// ---------------------------------------------------------------------------
+
+async function handleCheck(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const skipTriage = optBool(input, "skipTriage");
+  const report = await runCheck({ ...FORMAT_TEXT, prNumber, skipTriage });
+  return ok(formatText(report));
+}
+
+async function handleResolveFetch(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const result = await runResolveFetch({ ...FORMAT_TEXT, prNumber });
+  return ok(formatFetchResult(result));
+}
+
+async function handleResolveMutate(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const resolveThreadIds = optStringArray(input, "resolveThreadIds");
+  const minimizeCommentIds = optStringArray(input, "minimizeCommentIds");
+  const dismissReviewIds = optStringArray(input, "dismissReviewIds");
+  const dismissMessage = optStr(input, "dismissMessage");
+  const requireSha = optStr(input, "requireSha");
+
+  const result = await runResolveMutate({
+    ...FORMAT_TEXT,
+    prNumber,
+    resolveThreadIds,
+    minimizeCommentIds,
+    dismissReviewIds,
+    dismissMessage,
+    requireSha,
+  });
+  return ok(formatMutateResult(result));
+}
+
+async function handleCommitSuggestion(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const threadId = reqStr(input, "threadId");
+  const message = optStr(input, "message");
+  const description = optStr(input, "description");
+  const dryRun = optBool(input, "dryRun");
+  const result = await runCommitSuggestion({ ...FORMAT_TEXT, prNumber, threadId, message, description, dryRun });
+  return ok(formatCommitSuggestionResult(result));
+}
+
+async function handleIterate(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const cooldownSeconds = optNum(input, "cooldownSeconds");
+  const readyDelaySeconds = optNum(input, "readyDelaySeconds");
+  const stallTimeoutSeconds = optNum(input, "stallTimeoutSeconds");
+  const noAutoMarkReady = optBool(input, "noAutoMarkReady");
+  const noAutoCancelActionable = optBool(input, "noAutoCancelActionable");
+  const result = await runIterate({
+    ...FORMAT_TEXT,
+    prNumber,
+    cooldownSeconds,
+    readyDelaySeconds,
+    stallTimeoutSeconds,
+    noAutoMarkReady,
+    noAutoCancelActionable,
+  });
+  return ok(formatIterateResult(result));
+}
+
+async function handleMonitor(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumber = optNum(input, "prNumber");
+  const readyDelaySuffix = optStr(input, "readyDelaySuffix");
+  const result = await runMonitor({ ...FORMAT_TEXT, prNumber, readyDelaySuffix });
+  return ok(formatMonitorResult(result));
+}
+
+async function handleStatus(input: Record<string, unknown>): Promise<CallToolResult> {
+  const prNumbers = reqNumArray(input, "prNumbers");
+  const repo = await getRepoInfo();
+  const summaries = await runStatus({ ...FORMAT_TEXT, prNumbers });
+  return ok(formatStatusTable(summaries, `${repo.owner}/${repo.name}`));
+}
+
+async function handleLogFile(): Promise<CallToolResult> {
+  const result = await runLogFile();
+  return ok(result.path);
+}
+
+function handleSubscribePr(
+  input: Record<string, unknown>,
+  subs: SubscriptionStore,
+): CallToolResult {
+  const prNumber = reqNum(input, "prNumber");
+  subs.subscribe(prNumber);
+  const all = subs.listSubscribed();
+  return ok(
+    `Subscribed to PR #${prNumber}. Webhook events for this PR will be forwarded as MCP notifications.\nCurrently subscribed PRs: ${all.join(", ")}`,
+  );
+}
+
+function handleUnsubscribePr(
+  input: Record<string, unknown>,
+  subs: SubscriptionStore,
+): CallToolResult {
+  const prNumber = reqNum(input, "prNumber");
+  subs.unsubscribe(prNumber);
+  const all = subs.listSubscribed();
+  const remaining = all.length > 0 ? all.join(", ") : "(none)";
+  return ok(`Unsubscribed from PR #${prNumber}.\nCurrently subscribed PRs: ${remaining}`);
+}
+
+// ---------------------------------------------------------------------------
+// Result helpers
+// ---------------------------------------------------------------------------
+
+function ok(text: string): CallToolResult {
+  return { content: [{ type: TEXT, text }] };
+}
+
+function err(msg: string): CallToolResult {
+  return { content: [{ type: TEXT, text: `Error: ${msg}` }], isError: true };
+}
+
+// ---------------------------------------------------------------------------
+// Input coercion helpers
+// ---------------------------------------------------------------------------
+
+function optNum(input: Record<string, unknown>, key: string): number | undefined {
+  const v = input[key];
+  return typeof v === "number" ? v : undefined;
+}
+
+function reqNum(input: Record<string, unknown>, key: string): number {
+  const v = input[key];
+  if (typeof v !== "number") throw new Error(`${key} is required and must be a number`);
+  return v;
+}
+
+function optStr(input: Record<string, unknown>, key: string): string | undefined {
+  const v = input[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function reqStr(input: Record<string, unknown>, key: string): string {
+  const v = input[key];
+  if (typeof v !== "string" || v === "") throw new Error(`${key} is required and must be a non-empty string`);
+  return v;
+}
+
+function optBool(input: Record<string, unknown>, key: string): boolean | undefined {
+  const v = input[key];
+  return typeof v === "boolean" ? v : undefined;
+}
+
+function optStringArray(input: Record<string, unknown>, key: string): string[] | undefined {
+  const v = input[key];
+  if (!Array.isArray(v)) return undefined;
+  return v.filter((x): x is string => typeof x === "string");
+}
+
+function reqNumArray(input: Record<string, unknown>, key: string): number[] {
+  const v = input[key];
+  if (!Array.isArray(v) || v.length === 0) throw new Error(`${key} must be a non-empty array of numbers`);
+  return v.filter((x): x is number => typeof x === "number");
+}

--- a/src/mcp/tools.mts
+++ b/src/mcp/tools.mts
@@ -1,14 +1,15 @@
 /**
- * MCP tool definitions for pr-shepherd.
+ * MCP tool registration for pr-shepherd.
  *
- * buildToolList()    — returns the Tool[] for ListTools responses.
- * buildToolHandler() — returns a dispatcher that routes CallTool requests to
- *                      the corresponding handler in tool-handlers.mts.
+ * buildToolList()    — combines PR_TOOLS and OPS_TOOLS for ListTools responses.
+ * buildToolHandler() — routes CallTool requests to the right handler.
  */
 
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import type { SubscriptionStore } from "./subscriptions.mts";
+import { PR_TOOLS } from "./tool-list-pr.mts";
+import { OPS_TOOLS } from "./tool-list-ops.mts";
 import {
   handleCheck,
   handleResolveFetch,
@@ -27,202 +28,9 @@ export interface ToolDependencies {
   subscriptions: SubscriptionStore;
 }
 
-// ---------------------------------------------------------------------------
-// Tool list
-// ---------------------------------------------------------------------------
-
 export function buildToolList(): Tool[] {
-  return [
-    {
-      name: "shepherd_check",
-      description:
-        "Get a PR status snapshot: CI checks (passing/failing/in-progress), review threads, PR comments, and merge status. Read-only.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          prNumber: {
-            type: "number",
-            description: "PR number (auto-detected from current branch if omitted)",
-          },
-          skipTriage: {
-            type: "boolean",
-            description: "Skip fetching job info and log tails for failing checks",
-          },
-        },
-      },
-    },
-    {
-      name: "shepherd_resolve_fetch",
-      description:
-        "Fetch actionable review threads and PR comments for a PR. Auto-resolves outdated threads and surfaces first-look items. Returns structured triage output with instructions.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          prNumber: {
-            type: "number",
-            description: "PR number (auto-detected from current branch if omitted)",
-          },
-        },
-      },
-    },
-    {
-      name: "shepherd_resolve_mutate",
-      description:
-        "Resolve, minimize, or dismiss review items by ID. Provide at least one of resolveThreadIds, minimizeCommentIds, or dismissReviewIds.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          prNumber: {
-            type: "number",
-            description: "PR number (auto-detected from current branch if omitted)",
-          },
-          resolveThreadIds: {
-            type: "array",
-            items: { type: "string" },
-            description: "Thread node IDs to resolve",
-          },
-          minimizeCommentIds: {
-            type: "array",
-            items: { type: "string" },
-            description: "Comment node IDs to minimize",
-          },
-          dismissReviewIds: {
-            type: "array",
-            items: { type: "string" },
-            description: "Review node IDs to dismiss",
-          },
-          dismissMessage: { type: "string", description: "Required when dismissing reviews" },
-          requireSha: {
-            type: "string",
-            description: "Wait for GitHub to receive this commit SHA before resolving",
-          },
-        },
-      },
-    },
-    {
-      name: "shepherd_commit_suggestion",
-      description:
-        "Apply a suggestion block from a review thread and create a local git commit. Optionally dry-run to validate without committing.",
-      inputSchema: {
-        type: "object",
-        required: ["threadId"],
-        properties: {
-          prNumber: {
-            type: "number",
-            description: "PR number (auto-detected from current branch if omitted)",
-          },
-          threadId: {
-            type: "string",
-            description: "Review thread node ID containing the suggestion",
-          },
-          message: {
-            type: "string",
-            description: "Commit message (required unless dryRun is true)",
-          },
-          description: { type: "string", description: "Optional extended commit description" },
-          dryRun: { type: "boolean", description: "Validate the patch without applying it" },
-        },
-      },
-    },
-    {
-      name: "shepherd_iterate",
-      description:
-        "Run one iterate cycle: assess PR state and return the next action (fix_code, wait, mark_ready, cancel, or escalate) with instructions.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          prNumber: {
-            type: "number",
-            description: "PR number (auto-detected from current branch if omitted)",
-          },
-          cooldownSeconds: { type: "number", description: "Minimum seconds between code changes" },
-          readyDelaySeconds: {
-            type: "number",
-            description: "Seconds to wait after all checks pass before marking ready",
-          },
-          stallTimeoutSeconds: {
-            type: "number",
-            description: "Abort if no progress after this many seconds",
-          },
-          noAutoMarkReady: {
-            type: "boolean",
-            description: "Disable automatic draft → ready transition",
-          },
-          noAutoCancelActionable: {
-            type: "boolean",
-            description: "Disable automatic cancellation of actionable checks",
-          },
-        },
-      },
-    },
-    {
-      name: "shepherd_monitor",
-      description:
-        "Get the /loop arguments and prompt body to start continuous PR monitoring. Use this to bootstrap the monitoring loop.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          prNumber: {
-            type: "number",
-            description: "PR number (auto-detected from current branch if omitted)",
-          },
-          readyDelaySuffix: {
-            type: "string",
-            description: "Ready-delay duration string, e.g. '15m'",
-          },
-        },
-      },
-    },
-    {
-      name: "shepherd_status",
-      description: "Get a status table for one or more PRs in a single GitHub request.",
-      inputSchema: {
-        type: "object",
-        required: ["prNumbers"],
-        properties: {
-          prNumbers: {
-            type: "array",
-            items: { type: "number" },
-            minItems: 1,
-            description: "List of PR numbers to check",
-          },
-        },
-      },
-    },
-    {
-      name: "shepherd_log_file",
-      description: "Return the path to the per-worktree debug log file.",
-      inputSchema: { type: "object", properties: {} },
-    },
-    {
-      name: "shepherd_subscribe_pr",
-      description:
-        "Subscribe this session to GitHub webhook events for the given PR number. Matching events will be forwarded as MCP notifications wrapped in <github-webhook-activity> tags.",
-      inputSchema: {
-        type: "object",
-        required: ["prNumber"],
-        properties: {
-          prNumber: { type: "number", description: "PR number to subscribe to" },
-        },
-      },
-    },
-    {
-      name: "shepherd_unsubscribe_pr",
-      description: "Unsubscribe this session from GitHub webhook events for the given PR number.",
-      inputSchema: {
-        type: "object",
-        required: ["prNumber"],
-        properties: {
-          prNumber: { type: "number", description: "PR number to unsubscribe from" },
-        },
-      },
-    },
-  ];
+  return [...PR_TOOLS, ...OPS_TOOLS];
 }
-
-// ---------------------------------------------------------------------------
-// Tool handler dispatcher
-// ---------------------------------------------------------------------------
 
 export function buildToolHandler(
   deps: ToolDependencies,

--- a/src/mcp/tools.mts
+++ b/src/mcp/tools.mts
@@ -1,35 +1,27 @@
 /**
  * MCP tool definitions for pr-shepherd.
  *
- * Each tool delegates to the corresponding run*() command function and returns
- * formatted text output (same as CLI --format=text) as MCP TextContent.
+ * buildToolList()    — returns the Tool[] for ListTools responses.
+ * buildToolHandler() — returns a dispatcher that routes CallTool requests to
+ *                      the corresponding handler in tool-handlers.mts.
  */
 
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-import { runCheck } from "../commands/check.mts";
-import { runResolveFetch, runResolveMutate } from "../commands/resolve.mts";
-import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
-import { runIterate } from "../commands/iterate.mts";
-import { runMonitor, formatMonitorResult } from "../commands/monitor.mts";
-import { runStatus, formatStatusTable } from "../commands/status.mts";
-import { runLogFile } from "../commands/log-file.mts";
-import { getRepoInfo } from "../github/client.mts";
-import { formatText } from "../reporters/text.mts";
-import {
-  formatFetchResult,
-  formatCommitSuggestionResult,
-  formatMutateResult,
-  formatIterateResult,
-} from "../cli/formatters.mts";
 import type { SubscriptionStore } from "./subscriptions.mts";
-
-// ---------------------------------------------------------------------------
-// Common types
-// ---------------------------------------------------------------------------
-
-const TEXT: "text" = "text";
-const FORMAT_TEXT = { format: TEXT } as const;
+import {
+  handleCheck,
+  handleResolveFetch,
+  handleResolveMutate,
+  handleCommitSuggestion,
+  handleIterate,
+  handleMonitor,
+  handleStatus,
+  handleLogFile,
+  handleSubscribePr,
+  handleUnsubscribePr,
+  err,
+} from "./tool-handlers.mts";
 
 export interface ToolDependencies {
   subscriptions: SubscriptionStore;
@@ -181,194 +173,20 @@ export function buildToolHandler(
   return async (name, input) => {
     try {
       switch (name) {
-        case "shepherd_check":
-          return await handleCheck(input);
-        case "shepherd_resolve_fetch":
-          return await handleResolveFetch(input);
-        case "shepherd_resolve_mutate":
-          return await handleResolveMutate(input);
-        case "shepherd_commit_suggestion":
-          return await handleCommitSuggestion(input);
-        case "shepherd_iterate":
-          return await handleIterate(input);
-        case "shepherd_monitor":
-          return await handleMonitor(input);
-        case "shepherd_status":
-          return await handleStatus(input);
-        case "shepherd_log_file":
-          return await handleLogFile();
-        case "shepherd_subscribe_pr":
-          return handleSubscribePr(input, deps.subscriptions);
-        case "shepherd_unsubscribe_pr":
-          return handleUnsubscribePr(input, deps.subscriptions);
-        default:
-          return err(`Unknown tool: ${name}`);
+        case "shepherd_check": return await handleCheck(input);
+        case "shepherd_resolve_fetch": return await handleResolveFetch(input);
+        case "shepherd_resolve_mutate": return await handleResolveMutate(input);
+        case "shepherd_commit_suggestion": return await handleCommitSuggestion(input);
+        case "shepherd_iterate": return await handleIterate(input);
+        case "shepherd_monitor": return await handleMonitor(input);
+        case "shepherd_status": return await handleStatus(input);
+        case "shepherd_log_file": return await handleLogFile();
+        case "shepherd_subscribe_pr": return handleSubscribePr(input, deps.subscriptions);
+        case "shepherd_unsubscribe_pr": return handleUnsubscribePr(input, deps.subscriptions);
+        default: return err(`Unknown tool: ${name}`);
       }
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }
   };
-}
-
-// ---------------------------------------------------------------------------
-// Individual handlers
-// ---------------------------------------------------------------------------
-
-async function handleCheck(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumber = optNum(input, "prNumber");
-  const skipTriage = optBool(input, "skipTriage");
-  const report = await runCheck({ ...FORMAT_TEXT, prNumber, skipTriage });
-  return ok(formatText(report));
-}
-
-async function handleResolveFetch(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumber = optNum(input, "prNumber");
-  const result = await runResolveFetch({ ...FORMAT_TEXT, prNumber });
-  return ok(formatFetchResult(result));
-}
-
-async function handleResolveMutate(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumber = optNum(input, "prNumber");
-  const resolveThreadIds = optStringArray(input, "resolveThreadIds");
-  const minimizeCommentIds = optStringArray(input, "minimizeCommentIds");
-  const dismissReviewIds = optStringArray(input, "dismissReviewIds");
-  const dismissMessage = optStr(input, "dismissMessage");
-  const requireSha = optStr(input, "requireSha");
-
-  const result = await runResolveMutate({
-    ...FORMAT_TEXT,
-    prNumber,
-    resolveThreadIds,
-    minimizeCommentIds,
-    dismissReviewIds,
-    dismissMessage,
-    requireSha,
-  });
-  return ok(formatMutateResult(result));
-}
-
-async function handleCommitSuggestion(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumber = optNum(input, "prNumber");
-  const threadId = reqStr(input, "threadId");
-  const message = optStr(input, "message");
-  const description = optStr(input, "description");
-  const dryRun = optBool(input, "dryRun");
-  const result = await runCommitSuggestion({ ...FORMAT_TEXT, prNumber, threadId, message, description, dryRun });
-  return ok(formatCommitSuggestionResult(result));
-}
-
-async function handleIterate(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumber = optNum(input, "prNumber");
-  const cooldownSeconds = optNum(input, "cooldownSeconds");
-  const readyDelaySeconds = optNum(input, "readyDelaySeconds");
-  const stallTimeoutSeconds = optNum(input, "stallTimeoutSeconds");
-  const noAutoMarkReady = optBool(input, "noAutoMarkReady");
-  const noAutoCancelActionable = optBool(input, "noAutoCancelActionable");
-  const result = await runIterate({
-    ...FORMAT_TEXT,
-    prNumber,
-    cooldownSeconds,
-    readyDelaySeconds,
-    stallTimeoutSeconds,
-    noAutoMarkReady,
-    noAutoCancelActionable,
-  });
-  return ok(formatIterateResult(result));
-}
-
-async function handleMonitor(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumber = optNum(input, "prNumber");
-  const readyDelaySuffix = optStr(input, "readyDelaySuffix");
-  const result = await runMonitor({ ...FORMAT_TEXT, prNumber, readyDelaySuffix });
-  return ok(formatMonitorResult(result));
-}
-
-async function handleStatus(input: Record<string, unknown>): Promise<CallToolResult> {
-  const prNumbers = reqNumArray(input, "prNumbers");
-  const repo = await getRepoInfo();
-  const summaries = await runStatus({ ...FORMAT_TEXT, prNumbers });
-  return ok(formatStatusTable(summaries, `${repo.owner}/${repo.name}`));
-}
-
-async function handleLogFile(): Promise<CallToolResult> {
-  const result = await runLogFile();
-  return ok(result.path);
-}
-
-function handleSubscribePr(
-  input: Record<string, unknown>,
-  subs: SubscriptionStore,
-): CallToolResult {
-  const prNumber = reqNum(input, "prNumber");
-  subs.subscribe(prNumber);
-  const all = subs.listSubscribed();
-  return ok(
-    `Subscribed to PR #${prNumber}. Webhook events for this PR will be forwarded as MCP notifications.\nCurrently subscribed PRs: ${all.join(", ")}`,
-  );
-}
-
-function handleUnsubscribePr(
-  input: Record<string, unknown>,
-  subs: SubscriptionStore,
-): CallToolResult {
-  const prNumber = reqNum(input, "prNumber");
-  subs.unsubscribe(prNumber);
-  const all = subs.listSubscribed();
-  const remaining = all.length > 0 ? all.join(", ") : "(none)";
-  return ok(`Unsubscribed from PR #${prNumber}.\nCurrently subscribed PRs: ${remaining}`);
-}
-
-// ---------------------------------------------------------------------------
-// Result helpers
-// ---------------------------------------------------------------------------
-
-function ok(text: string): CallToolResult {
-  return { content: [{ type: TEXT, text }] };
-}
-
-function err(msg: string): CallToolResult {
-  return { content: [{ type: TEXT, text: `Error: ${msg}` }], isError: true };
-}
-
-// ---------------------------------------------------------------------------
-// Input coercion helpers
-// ---------------------------------------------------------------------------
-
-function optNum(input: Record<string, unknown>, key: string): number | undefined {
-  const v = input[key];
-  return typeof v === "number" ? v : undefined;
-}
-
-function reqNum(input: Record<string, unknown>, key: string): number {
-  const v = input[key];
-  if (typeof v !== "number") throw new Error(`${key} is required and must be a number`);
-  return v;
-}
-
-function optStr(input: Record<string, unknown>, key: string): string | undefined {
-  const v = input[key];
-  return typeof v === "string" ? v : undefined;
-}
-
-function reqStr(input: Record<string, unknown>, key: string): string {
-  const v = input[key];
-  if (typeof v !== "string" || v === "") throw new Error(`${key} is required and must be a non-empty string`);
-  return v;
-}
-
-function optBool(input: Record<string, unknown>, key: string): boolean | undefined {
-  const v = input[key];
-  return typeof v === "boolean" ? v : undefined;
-}
-
-function optStringArray(input: Record<string, unknown>, key: string): string[] | undefined {
-  const v = input[key];
-  if (!Array.isArray(v)) return undefined;
-  return v.filter((x): x is string => typeof x === "string");
-}
-
-function reqNumArray(input: Record<string, unknown>, key: string): number[] {
-  const v = input[key];
-  if (!Array.isArray(v) || v.length === 0) throw new Error(`${key} must be a non-empty array of numbers`);
-  return v.filter((x): x is number => typeof x === "number");
 }

--- a/src/mcp/tools.mts
+++ b/src/mcp/tools.mts
@@ -40,8 +40,14 @@ export function buildToolList(): Tool[] {
       inputSchema: {
         type: "object",
         properties: {
-          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-          skipTriage: { type: "boolean", description: "Skip fetching job info and log tails for failing checks" },
+          prNumber: {
+            type: "number",
+            description: "PR number (auto-detected from current branch if omitted)",
+          },
+          skipTriage: {
+            type: "boolean",
+            description: "Skip fetching job info and log tails for failing checks",
+          },
         },
       },
     },
@@ -52,7 +58,10 @@ export function buildToolList(): Tool[] {
       inputSchema: {
         type: "object",
         properties: {
-          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          prNumber: {
+            type: "number",
+            description: "PR number (auto-detected from current branch if omitted)",
+          },
         },
       },
     },
@@ -63,12 +72,30 @@ export function buildToolList(): Tool[] {
       inputSchema: {
         type: "object",
         properties: {
-          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-          resolveThreadIds: { type: "array", items: { type: "string" }, description: "Thread node IDs to resolve" },
-          minimizeCommentIds: { type: "array", items: { type: "string" }, description: "Comment node IDs to minimize" },
-          dismissReviewIds: { type: "array", items: { type: "string" }, description: "Review node IDs to dismiss" },
+          prNumber: {
+            type: "number",
+            description: "PR number (auto-detected from current branch if omitted)",
+          },
+          resolveThreadIds: {
+            type: "array",
+            items: { type: "string" },
+            description: "Thread node IDs to resolve",
+          },
+          minimizeCommentIds: {
+            type: "array",
+            items: { type: "string" },
+            description: "Comment node IDs to minimize",
+          },
+          dismissReviewIds: {
+            type: "array",
+            items: { type: "string" },
+            description: "Review node IDs to dismiss",
+          },
           dismissMessage: { type: "string", description: "Required when dismissing reviews" },
-          requireSha: { type: "string", description: "Wait for GitHub to receive this commit SHA before resolving" },
+          requireSha: {
+            type: "string",
+            description: "Wait for GitHub to receive this commit SHA before resolving",
+          },
         },
       },
     },
@@ -80,9 +107,18 @@ export function buildToolList(): Tool[] {
         type: "object",
         required: ["threadId"],
         properties: {
-          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-          threadId: { type: "string", description: "Review thread node ID containing the suggestion" },
-          message: { type: "string", description: "Commit message (required unless dryRun is true)" },
+          prNumber: {
+            type: "number",
+            description: "PR number (auto-detected from current branch if omitted)",
+          },
+          threadId: {
+            type: "string",
+            description: "Review thread node ID containing the suggestion",
+          },
+          message: {
+            type: "string",
+            description: "Commit message (required unless dryRun is true)",
+          },
           description: { type: "string", description: "Optional extended commit description" },
           dryRun: { type: "boolean", description: "Validate the patch without applying it" },
         },
@@ -95,12 +131,27 @@ export function buildToolList(): Tool[] {
       inputSchema: {
         type: "object",
         properties: {
-          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
+          prNumber: {
+            type: "number",
+            description: "PR number (auto-detected from current branch if omitted)",
+          },
           cooldownSeconds: { type: "number", description: "Minimum seconds between code changes" },
-          readyDelaySeconds: { type: "number", description: "Seconds to wait after all checks pass before marking ready" },
-          stallTimeoutSeconds: { type: "number", description: "Abort if no progress after this many seconds" },
-          noAutoMarkReady: { type: "boolean", description: "Disable automatic draft → ready transition" },
-          noAutoCancelActionable: { type: "boolean", description: "Disable automatic cancellation of actionable checks" },
+          readyDelaySeconds: {
+            type: "number",
+            description: "Seconds to wait after all checks pass before marking ready",
+          },
+          stallTimeoutSeconds: {
+            type: "number",
+            description: "Abort if no progress after this many seconds",
+          },
+          noAutoMarkReady: {
+            type: "boolean",
+            description: "Disable automatic draft → ready transition",
+          },
+          noAutoCancelActionable: {
+            type: "boolean",
+            description: "Disable automatic cancellation of actionable checks",
+          },
         },
       },
     },
@@ -111,8 +162,14 @@ export function buildToolList(): Tool[] {
       inputSchema: {
         type: "object",
         properties: {
-          prNumber: { type: "number", description: "PR number (auto-detected from current branch if omitted)" },
-          readyDelaySuffix: { type: "string", description: "Ready-delay duration string, e.g. '15m'" },
+          prNumber: {
+            type: "number",
+            description: "PR number (auto-detected from current branch if omitted)",
+          },
+          readyDelaySuffix: {
+            type: "string",
+            description: "Ready-delay duration string, e.g. '15m'",
+          },
         },
       },
     },
@@ -173,17 +230,28 @@ export function buildToolHandler(
   return async (name, input) => {
     try {
       switch (name) {
-        case "shepherd_check": return await handleCheck(input);
-        case "shepherd_resolve_fetch": return await handleResolveFetch(input);
-        case "shepherd_resolve_mutate": return await handleResolveMutate(input);
-        case "shepherd_commit_suggestion": return await handleCommitSuggestion(input);
-        case "shepherd_iterate": return await handleIterate(input);
-        case "shepherd_monitor": return await handleMonitor(input);
-        case "shepherd_status": return await handleStatus(input);
-        case "shepherd_log_file": return await handleLogFile();
-        case "shepherd_subscribe_pr": return handleSubscribePr(input, deps.subscriptions);
-        case "shepherd_unsubscribe_pr": return handleUnsubscribePr(input, deps.subscriptions);
-        default: return err(`Unknown tool: ${name}`);
+        case "shepherd_check":
+          return await handleCheck(input);
+        case "shepherd_resolve_fetch":
+          return await handleResolveFetch(input);
+        case "shepherd_resolve_mutate":
+          return await handleResolveMutate(input);
+        case "shepherd_commit_suggestion":
+          return await handleCommitSuggestion(input);
+        case "shepherd_iterate":
+          return await handleIterate(input);
+        case "shepherd_monitor":
+          return await handleMonitor(input);
+        case "shepherd_status":
+          return await handleStatus(input);
+        case "shepherd_log_file":
+          return await handleLogFile();
+        case "shepherd_subscribe_pr":
+          return handleSubscribePr(input, deps.subscriptions);
+        case "shepherd_unsubscribe_pr":
+          return handleUnsubscribePr(input, deps.subscriptions);
+        default:
+          return err(`Unknown tool: ${name}`);
       }
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));

--- a/src/mcp/webhook.mts
+++ b/src/mcp/webhook.mts
@@ -9,11 +9,13 @@
 import { createServer, type Server as HttpServer } from "node:http";
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+const MAX_BODY_BYTES = 5 * 1024 * 1024; // 5 MB
+
 export interface WebhookPayload {
   event: string;
   action?: string;
   prNumber: number;
-  repoFullName: string;
+  repoFullName?: string;
   ref?: string;
   sha?: string;
   actor?: string;
@@ -43,15 +45,34 @@ export class WebhookServer {
         return;
       }
 
+      if (req.url !== "/" && req.url !== "/webhook") {
+        res.writeHead(404).end("Not Found");
+        return;
+      }
+
+      let bodySize = 0;
       const chunks: Buffer[] = [];
-      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("data", (chunk: Buffer) => {
+        bodySize += chunk.length;
+        if (bodySize > MAX_BODY_BYTES) {
+          res.writeHead(413).end("Payload Too Large");
+          req.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
       req.on("end", () => {
+        if (res.headersSent) return;
         const body = Buffer.concat(chunks);
 
         if (this.opts.secret) {
           const sig = req.headers["x-hub-signature-256"];
-          if (typeof sig !== "string" || !verifySignature(body, sig, this.opts.secret)) {
-            res.writeHead(400).end("Invalid signature");
+          if (typeof sig !== "string") {
+            res.writeHead(401).end("Missing signature");
+            return;
+          }
+          if (!verifySignature(body, sig, this.opts.secret)) {
+            res.writeHead(401).end("Invalid signature");
             return;
           }
         }
@@ -69,19 +90,36 @@ export class WebhookServer {
         const prNumber = extractPrNumber(eventStr, parsed);
 
         if (prNumber !== null && prNumber > 0) {
-          const payload = buildPayload(eventStr, parsed, prNumber);
-          this.opts.onEvent(payload);
+          try {
+            const payload = buildPayload(eventStr, parsed, prNumber);
+            this.opts.onEvent(payload);
+          } catch (e: unknown) {
+            process.stderr.write(`pr-shepherd-mcp: error processing webhook event: ${String(e)}\n`);
+          }
         }
 
         res.writeHead(204).end();
       });
-      req.on("error", () => res.writeHead(400).end("Request error"));
+      req.on("error", () => {
+        if (!res.headersSent) res.writeHead(400).end("Request error");
+      });
     });
 
-    await new Promise<void>((resolve, reject) => {
-      this.server!.listen(this.opts.port, () => resolve());
-      this.server!.once("error", reject);
-    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        this.server!.listen(this.opts.port, () => resolve());
+        this.server!.once("error", reject);
+      });
+    } catch (e: unknown) {
+      process.stderr.write(
+        `pr-shepherd-mcp: webhook port ${this.opts.port} unavailable (${String(e)}), notifications disabled\n`,
+      );
+      this.server = null;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.server !== null;
   }
 
   async stop(): Promise<void> {
@@ -135,9 +173,10 @@ function buildPayload(
   const payload: WebhookPayload = {
     event,
     prNumber,
-    repoFullName: repo?.full_name ?? "unknown/unknown",
     timestamp: new Date().toISOString(),
   };
+
+  if (repo?.full_name) payload.repoFullName = repo.full_name;
 
   const action = body["action"];
   if (typeof action === "string") payload.action = action;

--- a/src/mcp/webhook.mts
+++ b/src/mcp/webhook.mts
@@ -109,16 +109,14 @@ function extractPrNumber(event: string, body: Record<string, unknown>): number |
   if (typeof body["number"] === "number") return body["number"];
 
   if (event === "check_run") {
-    const prs = (
-      body["check_run"] as { pull_requests?: Array<{ number: number }> } | undefined
-    )?.pull_requests;
+    const prs = (body["check_run"] as { pull_requests?: Array<{ number: number }> } | undefined)
+      ?.pull_requests;
     if (prs?.[0]) return prs[0].number;
   }
 
   if (event === "workflow_run") {
-    const prs = (
-      body["workflow_run"] as { pull_requests?: Array<{ number: number }> } | undefined
-    )?.pull_requests;
+    const prs = (body["workflow_run"] as { pull_requests?: Array<{ number: number }> } | undefined)
+      ?.pull_requests;
     if (prs?.[0]) return prs[0].number;
   }
 

--- a/src/mcp/webhook.mts
+++ b/src/mcp/webhook.mts
@@ -1,0 +1,156 @@
+/**
+ * HTTP server for receiving GitHub webhook events.
+ *
+ * Uses Node.js built-in http + crypto — no extra dependencies.
+ * Validates X-Hub-Signature-256 when GITHUB_WEBHOOK_SECRET is set.
+ * Extracts the PR number from the webhook payload and fires onEvent.
+ */
+
+import { createServer, type Server as HttpServer } from "node:http";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export interface WebhookPayload {
+  event: string;
+  action?: string;
+  prNumber: number;
+  repoFullName: string;
+  ref?: string;
+  sha?: string;
+  actor?: string;
+  timestamp: string;
+}
+
+export interface WebhookServerOptions {
+  port: number;
+  secret?: string;
+  onEvent: (payload: WebhookPayload) => void;
+}
+
+export class WebhookServer {
+  private readonly opts: WebhookServerOptions;
+  private server: HttpServer | null = null;
+
+  constructor(opts: WebhookServerOptions) {
+    this.opts = opts;
+  }
+
+  async start(): Promise<void> {
+    if (this.opts.port === 0) return;
+
+    this.server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405).end("Method Not Allowed");
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks);
+
+        if (this.opts.secret) {
+          const sig = req.headers["x-hub-signature-256"];
+          if (typeof sig !== "string" || !verifySignature(body, sig, this.opts.secret)) {
+            res.writeHead(400).end("Invalid signature");
+            return;
+          }
+        }
+
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+        } catch {
+          res.writeHead(400).end("Invalid JSON");
+          return;
+        }
+
+        const event = req.headers["x-github-event"];
+        const eventStr = typeof event === "string" ? event : "unknown";
+        const prNumber = extractPrNumber(eventStr, parsed);
+
+        if (prNumber !== null && prNumber > 0) {
+          const payload = buildPayload(eventStr, parsed, prNumber);
+          this.opts.onEvent(payload);
+        }
+
+        res.writeHead(204).end();
+      });
+      req.on("error", () => res.writeHead(400).end("Request error"));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.listen(this.opts.port, () => resolve());
+      this.server!.once("error", reject);
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+    this.server = null;
+  }
+}
+
+function verifySignature(body: Buffer, signature: string, secret: string): boolean {
+  const expected = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(signature, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function extractPrNumber(event: string, body: Record<string, unknown>): number | null {
+  const pr = body["pull_request"];
+  if (pr && typeof pr === "object" && "number" in pr) {
+    const n = (pr as { number: unknown }).number;
+    if (typeof n === "number") return n;
+  }
+
+  if (typeof body["number"] === "number") return body["number"];
+
+  if (event === "check_run") {
+    const prs = (
+      body["check_run"] as { pull_requests?: Array<{ number: number }> } | undefined
+    )?.pull_requests;
+    if (prs?.[0]) return prs[0].number;
+  }
+
+  if (event === "workflow_run") {
+    const prs = (
+      body["workflow_run"] as { pull_requests?: Array<{ number: number }> } | undefined
+    )?.pull_requests;
+    if (prs?.[0]) return prs[0].number;
+  }
+
+  return null;
+}
+
+function buildPayload(
+  event: string,
+  body: Record<string, unknown>,
+  prNumber: number,
+): WebhookPayload {
+  const repo = body["repository"] as { full_name?: string } | undefined;
+  const sender = body["sender"] as { login?: string } | undefined;
+  const headCommit = body["head_commit"] as { id?: string } | undefined;
+
+  const payload: WebhookPayload = {
+    event,
+    prNumber,
+    repoFullName: repo?.full_name ?? "unknown/unknown",
+    timestamp: new Date().toISOString(),
+  };
+
+  const action = body["action"];
+  if (typeof action === "string") payload.action = action;
+
+  const ref = body["ref"];
+  if (typeof ref === "string") payload.ref = ref;
+
+  const sha = body["after"] ?? headCommit?.id;
+  if (typeof sha === "string") payload.sha = sha;
+
+  if (sender?.login) payload.actor = sender.login;
+
+  return payload;
+}

--- a/src/mcp/webhook.test.mts
+++ b/src/mcp/webhook.test.mts
@@ -177,7 +177,7 @@ describe("WebhookServer — signature validation", () => {
   it("rejects request with invalid signature", async () => {
     const body = JSON.stringify({ pull_request: { number: 1 } });
     const res = await postSigned(body, "sha256=deadbeef");
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
     expect(events).toHaveLength(0);
   });
 
@@ -187,6 +187,6 @@ describe("WebhookServer — signature validation", () => {
       method: "POST",
       body,
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
   });
 });

--- a/src/mcp/webhook.test.mts
+++ b/src/mcp/webhook.test.mts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHmac } from "node:crypto";
+import { WebhookServer } from "./webhook.mts";
+import type { WebhookPayload } from "./webhook.mts";
+
+const PORT = 47823; // fixed test port unlikely to conflict
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+async function post(
+  path: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number }> {
+  const res = await fetch(`http://127.0.0.1:${PORT}${path}`, {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+  return { status: res.status };
+}
+
+describe("WebhookServer — port 0 (disabled)", () => {
+  it("start() is a no-op and stop() does not throw", async () => {
+    const server = new WebhookServer({ port: 0, onEvent: vi.fn() });
+    await expect(server.start()).resolves.toBeUndefined();
+    await expect(server.stop()).resolves.toBeUndefined();
+  });
+});
+
+describe("WebhookServer — HTTP", () => {
+  let server: WebhookServer;
+  let events: WebhookPayload[];
+
+  beforeEach(async () => {
+    events = [];
+    server = new WebhookServer({
+      port: PORT,
+      onEvent: (p) => events.push(p),
+    });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("rejects non-POST requests with 405", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/webhook`);
+    expect(res.status).toBe(405);
+  });
+
+  it("accepts a pull_request event and fires onEvent", async () => {
+    const body = JSON.stringify({
+      action: "synchronize",
+      pull_request: { number: 42 },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "alice" },
+    });
+    const { status } = await post("/webhook", body, {
+      "x-github-event": "pull_request",
+    });
+    expect(status).toBe(204);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: "pull_request",
+      action: "synchronize",
+      prNumber: 42,
+      repoFullName: "owner/repo",
+      actor: "alice",
+    });
+    expect(events[0]!.timestamp).toMatch(/^\d{4}-/);
+  });
+
+  it("extracts PR from body.number for issue events", async () => {
+    const body = JSON.stringify({
+      number: 7,
+      repository: { full_name: "owner/repo" },
+    });
+    await post("/webhook", body, { "x-github-event": "issues" });
+    expect(events[0]).toMatchObject({ prNumber: 7 });
+  });
+
+  it("extracts PR from check_run.pull_requests", async () => {
+    const body = JSON.stringify({
+      check_run: { pull_requests: [{ number: 99 }] },
+      repository: { full_name: "owner/repo" },
+    });
+    await post("/webhook", body, { "x-github-event": "check_run" });
+    expect(events[0]).toMatchObject({ prNumber: 99 });
+  });
+
+  it("extracts PR from workflow_run.pull_requests", async () => {
+    const body = JSON.stringify({
+      workflow_run: { pull_requests: [{ number: 55 }] },
+      repository: { full_name: "owner/repo" },
+    });
+    await post("/webhook", body, { "x-github-event": "workflow_run" });
+    expect(events[0]).toMatchObject({ prNumber: 55 });
+  });
+
+  it("silently drops events with no PR number", async () => {
+    const body = JSON.stringify({ repository: { full_name: "owner/repo" } });
+    const { status } = await post("/webhook", body, { "x-github-event": "ping" });
+    expect(status).toBe(204);
+    expect(events).toHaveLength(0);
+  });
+
+  it("includes ref and sha when present", async () => {
+    const body = JSON.stringify({
+      pull_request: { number: 1 },
+      repository: { full_name: "owner/repo" },
+      ref: "refs/heads/main",
+      after: "abc123",
+    });
+    await post("/webhook", body, { "x-github-event": "push" });
+    expect(events[0]).toMatchObject({ ref: "refs/heads/main", sha: "abc123" });
+  });
+
+  it("falls back to head_commit.id for sha", async () => {
+    const body = JSON.stringify({
+      pull_request: { number: 1 },
+      repository: { full_name: "owner/repo" },
+      head_commit: { id: "def456" },
+    });
+    await post("/webhook", body, { "x-github-event": "push" });
+    expect(events[0]).toMatchObject({ sha: "def456" });
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { status } = await post("/webhook", "not-json", { "x-github-event": "push" });
+    expect(status).toBe(400);
+  });
+});
+
+describe("WebhookServer — signature validation", () => {
+  let server: WebhookServer;
+  let events: WebhookPayload[];
+  const SECRET = "test-secret";
+  const SECRET_PORT = PORT + 1;
+
+  beforeEach(async () => {
+    events = [];
+    server = new WebhookServer({
+      port: SECRET_PORT,
+      secret: SECRET,
+      onEvent: (p) => events.push(p),
+    });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  async function postSigned(body: string, sigOverride?: string) {
+    const sig = sigOverride ?? sign(body, SECRET);
+    return fetch(`http://127.0.0.1:${SECRET_PORT}/webhook`, {
+      method: "POST",
+      body,
+      headers: { "x-github-event": "pull_request", "x-hub-signature-256": sig },
+    });
+  }
+
+  it("accepts request with valid signature", async () => {
+    const body = JSON.stringify({
+      pull_request: { number: 1 },
+      repository: { full_name: "owner/repo" },
+    });
+    const res = await postSigned(body);
+    expect(res.status).toBe(204);
+    expect(events).toHaveLength(1);
+  });
+
+  it("rejects request with invalid signature", async () => {
+    const body = JSON.stringify({ pull_request: { number: 1 } });
+    const res = await postSigned(body, "sha256=deadbeef");
+    expect(res.status).toBe(400);
+    expect(events).toHaveLength(0);
+  });
+
+  it("rejects request with missing signature", async () => {
+    const body = JSON.stringify({ pull_request: { number: 1 } });
+    const res = await fetch(`http://127.0.0.1:${SECRET_PORT}/webhook`, {
+      method: "POST",
+      body,
+    });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `pr-shepherd-mcp` binary — a long-lived MCP server that exposes all pr-shepherd CLI commands as 10 MCP tools, enabling Claude Code to call them directly without spawning subprocesses
- Adds an optional HTTP webhook endpoint (`SHEPHERD_WEBHOOK_PORT`, default 3000) that receives GitHub PR events and forwards them to the connected session as MCP `notifications/message` wrapped in `<github-webhook-activity>` tags — the same format Claude Code's PR activity event system already handles
- Adds `shepherd_subscribe_pr` / `shepherd_unsubscribe_pr` tools so the agent can control which PRs trigger notifications in the current session

## New files

| File | Purpose |
|------|---------|
| `src/mcp-index.mts` | Entry point; reads `SHEPHERD_WEBHOOK_PORT` + `GITHUB_WEBHOOK_SECRET` env vars |
| `src/mcp/server.mts` | MCP server setup, tool registration, webhook→notification bridge |
| `src/mcp/subscriptions.mts` | In-memory `Set<prNumber>` — which PRs forward events to this session |
| `src/mcp/webhook.mts` | HTTP server; validates `X-Hub-Signature-256`; extracts PR number from payload |
| `src/mcp/tools.mts` | Dispatcher + `buildToolList()` combining both tool-list files |
| `src/mcp/tool-list-pr.mts` | Tool definitions: check, resolve_fetch, resolve_mutate, commit_suggestion, iterate |
| `src/mcp/tool-list-ops.mts` | Tool definitions: monitor, status, log_file, subscribe_pr, unsubscribe_pr |
| `src/mcp/tool-handlers.mts` | Handler implementations delegating to existing `run*()` functions |
| `src/mcp/tool-coerce.mts` | Input coercion helpers (optNum, reqStr, optStringArray, etc.) |
| `docs/mcp-server.md` | Full setup + tool reference documentation |

## Modified files

- `package.json` — adds `@modelcontextprotocol/sdk ^1.29.0` dep; adds `pr-shepherd-mcp` bin entry
- `scripts/build.mjs` — writes `bin/pr-shepherd-mcp` shebang wrapper + chmod + node_modules/.bin symlink
- `README.md` — adds "MCP Server" section with quick-start config snippet

## Design notes

- **Separate binary**: `pr-shepherd-mcp` is a clean entry point that doesn't call `setupLog()` (which would interfere with the MCP stdio transport by patching `process.stdout`)
- **Tool output**: all tools return `--format=text` output as MCP `TextContent`, identical to what the CLI emits
- **Webhook disabled by default opt-out**: set `SHEPHERD_WEBHOOK_PORT=0` to skip the HTTP server entirely
- **Existing CLI unchanged**: no shared mutable state between the CLI and MCP paths; all 802 existing tests still pass

## Test plan

- [x] `npm run build` produces `bin/pr-shepherd-mcp`
- [x] MCP handshake + ListTools returns all 10 tools
- [x] `SHEPHERD_WEBHOOK_PORT=0` starts without HTTP server
- [x] `npm run lint` / `npm run typecheck` / `npm run format:check` all pass
- [x] `npm test` — 802 tests pass, no regressions

https://claude.ai/code/session_016zr21ZuUx6kjymkK2uQjat

---
_Generated by [Claude Code](https://claude.ai/code/session_016zr21ZuUx6kjymkK2uQjat)_

## Shepherd Journal

**Iteration 1 (2026-04-27) — addressed review feedback from @copilot-pull-request-reviewer and @jonathanong**

Applied:
- [PRRT_kwDOSGizTs5965-9](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149346942) (`reqNumArray` empty-after-filter): changed both `reqNumArray` and `optStringArray` to throw on wrong-type elements rather than filtering them out.
- [PRRT_kwDOSGizTs5965_U](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149346982) (docs notification type): updated `docs/mcp-server.md` to say "MCP logging notification" and corrected the "Per-connection → Per-process" scope claim.
- [PRRT_kwDOSGizTs5965_l](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149347006) (`shepherd_resolve_mutate` no-op): added explicit guard in `handleResolveMutate` — returns MCP error when all three ID lists are empty; also guards `dismissReviewIds` without `dismissMessage`.
- [PRRT_kwDOSGizTs5965_s](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149347021) (path filter): webhook now rejects non-`/` / non-`/webhook` paths with 404.
- [PRRT_kwDOSGizTs5965_4](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149347042) (body size limit): added 5 MB cap; responds 413 and destroys the request if exceeded.
- [PRRT_kwDOSGizTs5966AC](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149347060) (`onEvent` try/catch): wrapped `buildPayload` + `onEvent` in try/catch; logs to stderr on error, always responds 204.
- [PRRT_kwDOSGizTs597DK8](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149397881) (webhook fails open): added loud stderr WARNING at startup when `GITHUB_WEBHOOK_SECRET` is unset; changed missing/invalid signature status to 401.
- [PRRT_kwDOSGizTs597DXt](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149398515) (SIGINT/SIGTERM): handlers now `await webhookServer.stop()` and call `process.exit(0)`.
- [PRRT_kwDOSGizTs597Do2](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149399665) (bind failure): `start()` now catches EADDRINUSE, logs to stderr, and continues with webhooks disabled instead of crashing the entire MCP server.
- [PRRT_kwDOSGizTs597D1Y](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149401161) (subscription scope docs): fixed "Per-connection" → "Per-process" in the docs table.
- [PRRT_kwDOSGizTs597D5m](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149401473) (`repoFullName` sentinel): made `repoFullName` optional on `WebhookPayload`; omit the `repo:` line when absent.
- [PRRT_kwDOSGizTs597ECM](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149402565) / [PRRT_kwDOSGizTs597EGD](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149402897): subscribe/unsubscribe responses now echo only the affected PR number, not the full subscription list.

Deferred (design-level, not addressed in this iteration):
- [PRRT_kwDOSGizTs597DSF](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149398515) (`notifications/message` undocumented): this is a Claude Code host behavior. The docs have been updated to remove the circular "same format handled by…" claim. Whether `level: "info"` logging notifications reach the session context is a host implementation detail — needs verification against Claude Code internals.
- [PRRT_kwDOSGizTs597DgC](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149399861) (`buildPayload` strips context): surfacing the raw event body is a larger design change. Current 6-field summary keeps notification size minimal; a follow-up could add event-type-specific fields (e.g., review comment body for `pull_request_review_comment` events).
- [PRRT_kwDOSGizTs597Dul](https://github.com/jonathanong/pr-shepherd/pull/145#discussion_r3149401161) (subscription per-connection clearing): `StdioServerTransport` doesn't expose an `onclose` hook in the current SDK version. Deferred until the SDK exposes transport lifecycle events.