### PR TITLE
fix: drop unsupported --max-turns/--expires flags from monitor Loop args

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ At a high level, to start the monitor, the skill/command invokes a CLI that retu
 
 # PR #123 [MONITOR]
 
-Loop tag: `# pr-shepherd-loop:pr=123`
+Loop tag: `#pr-shepherd-loop:pr=123:`
 Loop args: `4m`
 
 ## Loop prompt
 
-# pr-shepherd-loop:pr=123
+#pr-shepherd-loop:pr=123:
 
 **IMPORTANT — recurrence rules:** Do not call ScheduleWakeup or /loop. End the turn
 after completing the actions below. The cron job handles the next fire.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ At a high level, to start the monitor, the skill/command invokes a CLI that retu
 # PR #123 [MONITOR]
 
 Loop tag: `# pr-shepherd-loop:pr=123`
-Loop args: `4m --max-turns 50 --expires 8h`
+Loop args: `4m`
 
 ## Loop prompt
 
@@ -125,7 +125,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. As it uses `/loop`, it will continue working when your rate limit window is reset. There is a default timeout of 8 hours and 50 loops before exiting automatically.
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. As it uses `/loop`, it will continue working when your rate limit window is reset. The loop cancels automatically when the PR is merged, closed, or after the ready-delay elapses.
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -343,7 +343,7 @@ Loop args: `4m`
 ## Instructions
 
 1. Run `CronList`. If any job's prompt contains `#pr-shepherd-loop:pr=42:`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
-2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval/flags string — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
+2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
 
 The loop interval comes from `watch.interval` in `.pr-shepherdrc.yml` or the built-in default. Use `--format=json` to inspect the raw values programmatically.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -330,19 +330,19 @@ npx pr-shepherd monitor 42
 ```markdown
 # PR #42 [MONITOR]
 
-Loop tag: `# pr-shepherd-loop:pr=42`
+Loop tag: `#pr-shepherd-loop:pr=42:`
 Loop args: `4m`
 
 ## Loop prompt
 
-# pr-shepherd-loop:pr=42
+#pr-shepherd-loop:pr=42:
 
 **IMPORTANT — recurrence rules:**
 ...
 
 ## Instructions
 
-1. Run `CronList`. If any job's prompt contains `# pr-shepherd-loop:pr=42`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
+1. Run `CronList`. If any job's prompt contains `#pr-shepherd-loop:pr=42:`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
 2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval/flags string — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -318,7 +318,7 @@ Exit codes: `0` wait/cooldown/mark_ready · `1` fix_code · `2` cancel · `3` es
 
 ### pr-shepherd monitor [PR]
 
-Bootstrap command for `/pr-shepherd:monitor`. Reads `watch.{interval, maxTurns, expiresHours}` from config and emits the loop prompt body (for inline single-iteration use) and a short `Loop args` line (interval + flags). The monitor skill invokes this command and follows its `## Instructions` to either run one iteration inline (if a loop already exists) or start a new `/loop`.
+Bootstrap command for `/pr-shepherd:monitor`. Reads `watch.interval` from config and emits the loop prompt body (for inline single-iteration use) and a short `Loop args` line (the interval). The monitor skill invokes this command and follows its `## Instructions` to either run one iteration inline (if a loop already exists) or start a new `/loop`.
 
 ```sh
 npx pr-shepherd monitor        # infer PR from current branch
@@ -331,7 +331,7 @@ npx pr-shepherd monitor 42
 # PR #42 [MONITOR]
 
 Loop tag: `# pr-shepherd-loop:pr=42`
-Loop args: `4m --max-turns 50 --expires 8h`
+Loop args: `4m`
 
 ## Loop prompt
 
@@ -346,7 +346,7 @@ Loop args: `4m --max-turns 50 --expires 8h`
 2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval/flags string — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
 
-All loop parameters (`interval`, `maxTurns`, `expiresHours`) come from `.pr-shepherdrc.yml` or the built-in defaults (`watch.*` config keys). Use `--format=json` to inspect the raw values programmatically.
+The loop interval comes from `watch.interval` in `.pr-shepherdrc.yml` or the built-in default. Use `--format=json` to inspect the raw values programmatically.
 
 Exit code: `0`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,6 @@ iterate:
 watch:
   interval: 4m # /loop cadence
   readyDelayMinutes: 10 # settle window after PR first becomes READY
-  expiresHours: 8 # max loop lifetime
 
 resolve:
   shaPoll:
@@ -51,8 +50,6 @@ actions:
 | `iterate.minimizeApprovals`          | `false`                                   | Opt in to also minimize APPROVED-state reviews (also enables >50-approval pagination). All `COMMENTED` summaries are always minimized. |
 | `watch.interval`                     | `"4m"`                                    | Monitor tick interval (tuned to Claude's 5-min prompt-cache TTL)                                                                       |
 | `watch.readyDelayMinutes`            | `10`                                      | Settle window after READY before the monitor loop cancels                                                                              |
-| `watch.expiresHours`                 | `8`                                       | Max lifetime of a monitor cron job                                                                                                     |
-| `watch.maxTurns`                     | `50`                                      | Max monitor ticks per session                                                                                                          |
 | `resolve.shaPoll.intervalMs`         | `2000`                                    | Poll interval when waiting for `--require-sha` to land on GitHub                                                                       |
 | `resolve.shaPoll.maxAttempts`        | `10`                                      | Max `--require-sha` polls before giving up                                                                                             |
 | `resolve.fetchReviewSummaries`       | `true`                                    | Surface `COMMENTED` review summaries in `resolve --fetch` output                                                                       |
@@ -130,14 +127,6 @@ The default of 4 minutes is chosen to keep Claude's prompt cache warm — the ca
 After the PR first reaches READY status (all checks green, no open threads), shepherd continues to loop for this many minutes before cancelling the loop. This settle window gives reviewers time to request changes or for a Copilot review to finish.
 
 The ready-delay countdown resets if the PR drops out of READY state at any tick.
-
-### `watch.expiresHours` — default `8`
-
-Maximum lifetime of a monitor loop, expressed in hours. After this time the loop stops regardless of PR state. The `/loop` skill receives this as `--expires Nh`.
-
-### `watch.maxTurns` — default `50`
-
-Maximum number of iterations before the `/loop` skill stops. This is the `--max-turns` argument, which counts iterations, not turns of dialogue. With a 4-minute interval, 50 turns ≈ 3.3 hours.
 
 ---
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -5,7 +5,7 @@ flowchart TD
   U(["/pr-shepherd:monitor PR"]) --> SC["/pr-shepherd:monitor slash command"]
   SC -->|CronList| EX{Loop exists<br/>for this PR?}
   EX -->|yes| NOW[Run iterate once<br/>inline and act]
-  EX -->|no| CREATE[CronCreate:<br/>every 4m,<br/>maxTurns 50,<br/>expires 8h]
+  EX -->|no| CREATE[CronCreate:<br/>every 4m]
   CREATE --> CRON[(cron tick)]
   NOW --> ITER
   CRON --> ITER[pr-shepherd<br/>iterate PR]

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -34,10 +34,10 @@ In `marketplace.json`:
 
 ## 2. Rename the loop tag
 
-The monitor skill tags each cron job with `# pr-shepherd-loop:pr=<N>` so `CronList` can detect existing loops. Change this string in `skills/monitor/SKILL.md` to avoid conflicts with other installations:
+The monitor skill tags each cron job with `#pr-shepherd-loop:pr=<N>:` so `CronList` can detect existing loops. Change this string in `skills/monitor/SKILL.md` to avoid conflicts with other installations:
 
 ```
-# my-shepherd-loop:pr=<PR_NUMBER>
+#my-shepherd-loop:pr=<PR_NUMBER>:
 ```
 
 ## 3. Adjust CI check filtering

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,7 +6,7 @@ Three Claude Code skills are included in the plugin.
 
 ## `/pr-shepherd:monitor`
 
-Start continuous CI monitoring for a PR. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval, max-turns, expires, and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd iterate`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
+Start continuous CI monitoring for a PR. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd iterate`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
 
 ```
 /pr-shepherd:monitor        # infer PR from current branch
@@ -15,7 +15,7 @@ Start continuous CI monitoring for a PR. Runs `npx pr-shepherd monitor <PR>` to 
 
 The polling interval and ready-delay come from `watch.interval` and `watch.readyDelayMinutes` in `.pr-shepherdrc.yml` (defaults: 4 minutes and 10 minutes). The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-minute TTL).
 
-**Loop deduplication:** The CLI output's `## Instructions` handles dedup — the skill checks `CronList` for a job tagged `# pr-shepherd-loop:pr=<N>` and runs one iteration inline if one already exists, instead of creating a duplicate.
+**Loop deduplication:** The CLI output's `## Instructions` handles dedup — the skill checks `CronList` for a job tagged `#pr-shepherd-loop:pr=<N>:` and runs one iteration inline if one already exists, instead of creating a duplicate.
 
 ## `/pr-shepherd:check`
 

--- a/src/cli-parser.monitor.mock.test.mts
+++ b/src/cli-parser.monitor.mock.test.mts
@@ -46,7 +46,7 @@ function getStdout(): string {
 const MONITOR_RESULT = {
   prNumber: 42,
   loopTag: "#pr-shepherd-loop:pr=42:",
-  loopArgs: "4m --max-turns 50 --expires 8h",
+  loopArgs: "4m",
   loopPrompt: "#pr-shepherd-loop:pr=42:\nBODY",
 };
 
@@ -80,7 +80,7 @@ describe("main — monitor", () => {
     const parsed = JSON.parse(out.trim()) as typeof MONITOR_RESULT;
     expect(parsed.prNumber).toBe(42);
     expect(parsed.loopTag).toBe("#pr-shepherd-loop:pr=42:");
-    expect(parsed.loopArgs).toBe("4m --max-turns 50 --expires 8h");
+    expect(parsed.loopArgs).toBe("4m");
   });
 
   it("accepts --ready-delay and forwards it to runMonitor", async () => {

--- a/src/commands/__snapshots__/monitor.mock.test.mts.snap
+++ b/src/commands/__snapshots__/monitor.mock.test.mts.snap
@@ -26,5 +26,5 @@ The output is Markdown. The first line is an H1 heading of the form \`# PR #<N> 
 ## Instructions
 
 1. Run \`CronList\`. If any job's prompt contains \`#pr-shepherd-loop:pr=42:\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
-2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval/flags string — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body."
+2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body."
 `;

--- a/src/commands/__snapshots__/monitor.mock.test.mts.snap
+++ b/src/commands/__snapshots__/monitor.mock.test.mts.snap
@@ -4,7 +4,7 @@ exports[`formatMonitorResult > matches snapshot 1`] = `
 "# PR #42 [MONITOR]
 
 Loop tag: \`#pr-shepherd-loop:pr=42:\`
-Loop args: \`4m --max-turns 50 --expires 8h\`
+Loop args: \`4m\`
 
 ## Loop prompt
 

--- a/src/commands/iterate.base-checks.mock.test.mts
+++ b/src/commands/iterate.base-checks.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.classify.mock.test.mts
+++ b/src/commands/iterate.classify.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -142,7 +142,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.fix-code-actionable.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.fix-code-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.fix-code-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.fix-code-projection.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -144,7 +144,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.orchestrator.mock.test.mts
+++ b/src/commands/iterate.orchestrator.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.render-escalate-fields.mock.test.mts
+++ b/src/commands/iterate.render-escalate-fields.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.render-humanmessage.mock.test.mts
+++ b/src/commands/iterate.render-humanmessage.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.render-resolve-cmd.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.stall.mock.test.mts
+++ b/src/commands/iterate.stall.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/iterate.steps.mock.test.mts
+++ b/src/commands/iterate.steps.mock.test.mts
@@ -146,7 +146,7 @@ function defaultConfig() {
       stallTimeoutMinutes: 30,
       minimizeApprovals: false,
     },
-    watch: { interval: "4m", readyDelayMinutes: 10, expiresHours: 8, maxTurns: 50 },
+    watch: { interval: "4m", readyDelayMinutes: 10 },
     resolve: {
       concurrency: 4,
       shaPoll: { intervalMs: 2000, maxAttempts: 10 },

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -13,7 +13,7 @@ import { loadConfig } from "../config/load.mts";
 import type { PrShepherdConfig } from "../config/load.mts";
 
 const defaultConfig = {
-  watch: { interval: "4m", maxTurns: 50, expiresHours: 8, readyDelayMinutes: 10 },
+  watch: { interval: "4m", readyDelayMinutes: 10 },
 } as unknown as PrShepherdConfig;
 
 describe("runMonitor", () => {
@@ -25,7 +25,7 @@ describe("runMonitor", () => {
     const result = await runMonitor({ format: "text", prNumber: 99 });
     expect(result.prNumber).toBe(99);
     expect(result.loopTag).toBe("#pr-shepherd-loop:pr=99:");
-    expect(result.loopArgs).toBe("4m --max-turns 50 --expires 8h");
+    expect(result.loopArgs).toBe("4m");
     expect(result.loopPrompt).toContain("#pr-shepherd-loop:pr=99:");
     expect(result.loopPrompt).toContain("npx pr-shepherd iterate 99");
     // loopArgs is a short one-liner — not the combined invocation string
@@ -45,37 +45,19 @@ describe("runMonitor", () => {
 
   it("throws a clear error when interval is not a valid duration string", async () => {
     vi.mocked(loadConfig).mockReturnValue({
-      watch: { interval: "every 4 minutes", maxTurns: 50, expiresHours: 8, readyDelayMinutes: 10 },
+      watch: { interval: "every 4 minutes", readyDelayMinutes: 10 },
     } as unknown as PrShepherdConfig);
     await expect(runMonitor({ format: "text", prNumber: 42 })).rejects.toThrow(
       "watch.interval must be a duration string",
     );
   });
 
-  it("throws a clear error when expiresHours is not a positive integer", async () => {
+  it("respects config override for interval", async () => {
     vi.mocked(loadConfig).mockReturnValue({
-      watch: { interval: "4m", maxTurns: 50, expiresHours: "8h", readyDelayMinutes: 10 },
-    } as unknown as PrShepherdConfig);
-    await expect(runMonitor({ format: "text", prNumber: 42 })).rejects.toThrow(
-      "watch.expiresHours must be a positive integer",
-    );
-  });
-
-  it("throws a clear error when maxTurns is not a positive integer", async () => {
-    vi.mocked(loadConfig).mockReturnValue({
-      watch: { interval: "4m", maxTurns: 0, expiresHours: 8, readyDelayMinutes: 10 },
-    } as unknown as PrShepherdConfig);
-    await expect(runMonitor({ format: "text", prNumber: 42 })).rejects.toThrow(
-      "watch.maxTurns must be a positive integer",
-    );
-  });
-
-  it("respects config overrides for interval/maxTurns/expiresHours", async () => {
-    vi.mocked(loadConfig).mockReturnValue({
-      watch: { interval: "8m", maxTurns: 30, expiresHours: 4, readyDelayMinutes: 10 },
+      watch: { interval: "8m", readyDelayMinutes: 10 },
     } as unknown as PrShepherdConfig);
     const result = await runMonitor({ format: "text", prNumber: 42 });
-    expect(result.loopArgs).toMatch(/^8m --max-turns 30 --expires 4h/);
+    expect(result.loopArgs).toBe("8m");
   });
 
   it("includes --ready-delay in loop prompt when readyDelaySuffix is valid", async () => {
@@ -111,7 +93,7 @@ describe("formatMonitorResult", () => {
   const fixture: MonitorResult = {
     prNumber: 42,
     loopTag: "#pr-shepherd-loop:pr=42:",
-    loopArgs: "4m --max-turns 50 --expires 8h",
+    loopArgs: "4m",
     loopPrompt:
       "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — recurrence rules:**\n- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.\n- End the turn cleanly after completing the actions below. The cron job handles the next fire.\n\n**Self-dedup:** Run `CronList`. If more than one job contains `#pr-shepherd-loop:pr=42:`, keep the lowest job ID and `CronDelete` the rest (ignore errors — a concurrent runner may have already deleted them).\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42\n\nExit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #42 [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.\n\nThe output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
   };
@@ -120,7 +102,7 @@ describe("formatMonitorResult", () => {
     const md = formatMonitorResult(fixture);
     expect(md).toContain("# PR #42 [MONITOR]");
     expect(md).toContain("Loop tag: `#pr-shepherd-loop:pr=42:`");
-    expect(md).toContain("Loop args: `4m --max-turns 50 --expires 8h`");
+    expect(md).toContain("Loop args: `4m`");
     expect(md).toContain("## Loop prompt");
     expect(md).toContain("## Instructions");
   });

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -60,7 +60,7 @@ export function formatMonitorResult(result: MonitorResult): string {
     "## Instructions",
     "",
     `1. Run \`CronList\`. If any job's prompt contains \`${loopTag}\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
-    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval/flags string — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body.`,
+    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body.`,
   ].join("\n");
 }
 

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -9,7 +9,7 @@ export interface MonitorCommandOptions extends GlobalOptions {
 export interface MonitorResult {
   prNumber: number;
   loopTag: string;
-  /** The interval/flags line: "<interval> --max-turns N --expires Nh" */
+  /** The interval to pass to /loop (e.g. "4m"). */
   loopArgs: string;
   /** The loop prompt body. To build /loop args: `${loopArgs}\n\n${loopPrompt}` */
   loopPrompt: string;
@@ -22,20 +22,10 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
     throw new Error("No open PR found for current branch. Pass a PR number explicitly.");
   }
 
-  const { interval, maxTurns, expiresHours } = config.watch;
+  const { interval } = config.watch;
   if (typeof interval !== "string" || !/^\d+[smhd]$/.test(interval)) {
     throw new Error(
       `Invalid config: watch.interval must be a duration string like "4m" or "1h", got ${JSON.stringify(interval)}`,
-    );
-  }
-  if (!Number.isFinite(expiresHours) || expiresHours <= 0 || !Number.isInteger(expiresHours)) {
-    throw new Error(
-      `Invalid config: watch.expiresHours must be a positive integer, got ${JSON.stringify(expiresHours)}`,
-    );
-  }
-  if (!Number.isFinite(maxTurns) || maxTurns <= 0 || !Number.isInteger(maxTurns)) {
-    throw new Error(
-      `Invalid config: watch.maxTurns must be a positive integer, got ${JSON.stringify(maxTurns)}`,
     );
   }
   // No space after `#` — `# text` is a CommonMark ATX heading; `#text` is not.
@@ -45,7 +35,7 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   // block depend on this exact string — don't change the format.
   const loopTag = `#pr-shepherd-loop:pr=${prNumber}:`;
   const loopPrompt = buildLoopPrompt(prNumber, loopTag, opts.readyDelaySuffix);
-  const loopArgs = `${interval} --max-turns ${maxTurns} --expires ${expiresHours}h`;
+  const loopArgs = interval;
 
   return { prNumber, loopTag, loopArgs, loopPrompt };
 }

--- a/src/config.json
+++ b/src/config.json
@@ -7,9 +7,7 @@
   },
   "watch": {
     "interval": "4m",
-    "readyDelayMinutes": 10,
-    "expiresHours": 8,
-    "maxTurns": 50
+    "readyDelayMinutes": 10
   },
   "resolve": {
     "shaPoll": {

--- a/src/config/load.mts
+++ b/src/config/load.mts
@@ -19,8 +19,6 @@ export interface PrShepherdConfig {
   watch: {
     interval: string;
     readyDelayMinutes: number;
-    expiresHours: number;
-    maxTurns: number;
   };
   resolve: {
     shaPoll: {


### PR DESCRIPTION
## Summary

- `/loop` (Claude Code built-in) only parses a leading `^\d+[smhd]$` interval token — `--max-turns` and `--expires` are not real flags, and `CronCreate` has no such parameters
- Emitting these flags caused them to bleed into the cron prompt body as leading prose, producing improvised/undefined agent behavior (e.g. "loop-control flags consumed here (not passed to cron)")
- Removes `watch.expiresHours` and `watch.maxTurns` config keys; `Loop args` now contains only the interval (e.g. `4m`)
- Loops still cancel on PR merge/close or after the ready-delay; `/loop`'s built-in auto-expiry handles the lifetime backstop

## Test plan

- [ ] 814 tests pass (`npm test`)
- [ ] Typecheck, lint, format all clean
- [ ] `npx pr-shepherd monitor 251` emits `Loop args: \`4m\`` with no phantom flags
- [ ] Zero grep hits for `maxTurns|expiresHours|--max-turns|--expires` across source, tests, docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)