### PR TITLE
[codex] add codex monitor output support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-shepherd",
-  "description": "Autonomous PR CI monitor and review-comment resolver for Claude Code",
+  "description": "Autonomous PR CI monitor and review-comment resolver for agentic coding tools",
   "version": "0.11.0",
   "author": {
     "name": "Jonathan Ong",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pr-shepherd
 
-Autonomous PR CI monitor and review-comment resolver for Claude Code.
+Autonomous PR CI monitor and review-comment resolver for agentic coding tools, including Claude Code and Codex.
 The goal is to have an agent take a plan to a human-reviewable PR autonomously.
 
 Example Workflow:
@@ -19,6 +19,8 @@ Example Workflow:
 ## How it works
 
 `pr-shepherd` optimizes token management, rate limits, and agentic orchestration by moving **ALL** deterministic logic and prompts to code via a CLI tool, enshrining what would be a large skill or command prompt (of which the agent would inevitably make mistakes) into the code and returning a clear, actionable prompt.
+
+The CLI adapts monitor instructions to the calling agent. Claude Code gets `/loop` bootstrap instructions. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`; it gets a reusable `npx pr-shepherd iterate <PR>` command and one-shot iterate instructions because Codex does not provide `/loop` scheduling in this workflow.
 
 At a high level, to start the monitor, the skill/command invokes a CLI that returns a prompt to be ingested by the agent _(schematic — paraphrased for brevity; actual output is more detailed)_:
 
@@ -125,7 +127,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. As it uses `/loop`, it will continue working when your rate limit window is reset. The loop cancels automatically when the PR is merged, closed, or after the ready-delay elapses.
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. In Claude Code, `/pr-shepherd:monitor` uses `/loop` and continues working when your rate limit window is reset. In Codex, rerun the reusable `npx pr-shepherd iterate <PR>` command when you want another check.
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 - Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
@@ -142,15 +144,26 @@ Recommendations:
 
 ### Monitor a PR
 
-Creates a cron loop that fires every 4 minutes, checks CI and review
-comments, fixes issues, and marks the PR ready for review when clean. The
-loop cancels automatically when the PR is merged or closed.
+In Claude Code, creates a cron loop that fires every 4 minutes, checks CI and review comments, fixes issues, and marks the PR ready for review when clean. The loop cancels automatically when the PR is merged or closed.
+
+In Codex, run `npx pr-shepherd monitor <PR>` once to emit the one-shot prompt, then follow that prompt. Its reusable follow-up command is `npx pr-shepherd iterate <PR>`.
+
+Claude Code:
 
 ```
 /pr-shepherd:monitor                     # infer PR from current branch
 /pr-shepherd:monitor 42
 /pr-shepherd:monitor 42 every 8m
 /pr-shepherd:monitor 42 --ready-delay 15m
+```
+
+Codex:
+
+```sh
+npx pr-shepherd monitor                  # bootstrap from current branch, then follow its instructions
+npx pr-shepherd monitor 42               # bootstrap PR #42, then follow its instructions
+npx pr-shepherd iterate 42               # subsequent one-shot check/action tick
+npx pr-shepherd iterate 42 --ready-delay 15m
 ```
 
 ### Check a PR
@@ -208,6 +221,34 @@ claude /plugin install pr-shepherd
 
 This repo ships two `marketplace.json` files that serve different install flows: the root `marketplace.json` resolves the plugin from the npm registry (used by the `claude /plugin marketplace add` command above); `.claude-plugin/marketplace.json` is the owner-level registry manifest that resolves the plugin from the local plugin directory (used when Claude Code installs from a local or git-based source). Both files are needed to support these two install paths.
 
+### For Codex
+
+Codex does not use the Claude plugin or `/pr-shepherd:*` slash commands. Install the CLI where Codex will run it, then call `npx pr-shepherd` directly:
+
+```bash
+npm install --save-dev pr-shepherd
+```
+
+If your Codex environment does not already set `CODEX_CI=1`, set `AGENT=codex` so `pr-shepherd` emits Codex-compatible instructions instead of Claude `/loop` instructions:
+
+```bash
+export AGENT=codex
+```
+
+Then start a PR monitor from Codex:
+
+```bash
+npx pr-shepherd monitor 42
+```
+
+Follow the output's `## Instructions`. The monitor bootstrap runs one tick and prints the reusable follow-up command, usually:
+
+```bash
+npx pr-shepherd iterate 42
+```
+
+Rerun that `iterate` command whenever you want Codex to check the PR again. There is no background `/loop` scheduler in Codex.
+
 ### Without the plugin
 
 See [docs/custom-commands.md](docs/custom-commands.md) for a project-local slash command that wraps the CLI without the plugin.
@@ -234,7 +275,7 @@ actions:
   autoMarkReady: false # disable to stay draft until you manually promote
 ```
 
-Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_STATE_DIR` (override loop-state and log base dir), `PR_SHEPHERD_LOG_DISABLED=1` (disable the per-worktree debug log).
+Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`), `PR_SHEPHERD_STATE_DIR` (override loop-state and log base dir), `PR_SHEPHERD_LOG_DISABLED=1` (disable the per-worktree debug log), `AGENT=codex` or `CODEX_CI=1` (emit Codex-compatible monitor instructions).
 
 See [docs/configuration.md](docs/configuration.md) for full semantics and deprecated-key migration.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,22 +2,22 @@
 
 Quick entry point. For a command overview see [`../README.md`](../README.md).
 
-| Document                                 | What it covers                                                    |
-| ---------------------------------------- | ----------------------------------------------------------------- |
-| [cli-usage.md](cli-usage.md)             | CLI command reference and flags                                   |
-| [skills.md](skills.md)                   | Claude Code skill usage (`/pr-shepherd:*`)                        |
-| [configuration.md](configuration.md)     | `.pr-shepherdrc.yml` reference                                    |
-| [custom-commands.md](custom-commands.md) | Project-local slash command that wraps the CLI without the plugin |
-| [forking.md](forking.md)                 | How to fork and customize pr-shepherd                             |
-| [flow.md](flow.md)                       | End-to-end mermaid flow diagram                                   |
-| [architecture.md](architecture.md)       | Module map, dependency rules, where to put new code               |
-| [iterate-flow.md](iterate-flow.md)       | Full 8-step dispatch walkthrough inside `iterate`                 |
-| [actions.md](actions.md)                 | Every action: trigger, side-effects, prescriptive output fields   |
-| [watch-loop.md](watch-loop.md)           | How the monitor skill + `/loop` + `iterate` interact              |
-| [ready-delay.md](ready-delay.md)         | Loop-state files: ready-since, fix-attempts, iterate-stall        |
-| [graphql.md](graphql.md)                 | Batch query, pagination strategy, REST fallbacks                  |
-| [checks.md](checks.md)                   | Classify → triage → `failedStep`, `jobName`, event filtering      |
-| [comments.md](comments.md)               | Threads vs comments, outdated detection, push-before-resolve      |
-| [merge-status.md](merge-status.md)       | `deriveMergeStatus` rules, edge cases                             |
-| [extending.md](extending.md)             | Recipes: add an action, classifier, mutation                      |
-| [debugging.md](debugging.md)             | Failure modes, how to replay an iteration                         |
+| Document                                 | What it covers                                                             |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| [cli-usage.md](cli-usage.md)             | CLI command reference and flags                                            |
+| [skills.md](skills.md)                   | Claude Code skill usage and Codex-compatible CLI output (`/pr-shepherd:*`) |
+| [configuration.md](configuration.md)     | `.pr-shepherdrc.yml` reference                                             |
+| [custom-commands.md](custom-commands.md) | Project-local slash command that wraps the CLI without the plugin          |
+| [forking.md](forking.md)                 | How to fork and customize pr-shepherd                                      |
+| [flow.md](flow.md)                       | End-to-end mermaid flow diagram                                            |
+| [architecture.md](architecture.md)       | Module map, dependency rules, where to put new code                        |
+| [iterate-flow.md](iterate-flow.md)       | Full 8-step dispatch walkthrough inside `iterate`                          |
+| [actions.md](actions.md)                 | Every action: trigger, side-effects, prescriptive output fields            |
+| [watch-loop.md](watch-loop.md)           | How the monitor skill + `/loop` + `iterate` interact                       |
+| [ready-delay.md](ready-delay.md)         | Loop-state files: ready-since, fix-attempts, iterate-stall                 |
+| [graphql.md](graphql.md)                 | Batch query, pagination strategy, REST fallbacks                           |
+| [checks.md](checks.md)                   | Classify → triage → `failedStep`, `jobName`, event filtering               |
+| [comments.md](comments.md)               | Threads vs comments, outdated detection, push-before-resolve               |
+| [merge-status.md](merge-status.md)       | `deriveMergeStatus` rules, edge cases                                      |
+| [extending.md](extending.md)             | Recipes: add an action, classifier, mutation                               |
+| [debugging.md](debugging.md)             | Failure modes, how to replay an iteration                                  |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -6,7 +6,9 @@ Each iteration of `shepherd iterate` returns exactly one action. See [docs/itera
 
 The default output format is Markdown — what you see when running `npx pr-shepherd iterate <PR>`, and what the monitor SKILL reads each cron tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
-Pass `--verbose` to get more debug state. In JSON mode, the full `IterateResult` is returned (all fields, including `baseBranch`, `checks`, `shouldCancel`). In Markdown mode, `--verbose` restores the full header summary line (all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, `shouldCancel` always shown, and `[COOLDOWN]` no longer suppresses the base/summary block) — but Markdown is structurally different from JSON and does not guarantee field-for-field parity (array fields like `baseBranch` or `checks` are not added to Markdown for actions that do not normally render them). Lean mode is the default because most fields are `false`/`0`/`[]` on a typical healthy tick and add context noise without value.
+Instruction wording is agent-aware. Claude-compatible output refers to the next cron fire and `/loop cancel`. Codex output is selected with `AGENT=codex` or `CODEX_CI=1`; it replaces those lines with reusable-prompt guidance such as rerunning `npx pr-shepherd iterate <PR>` later. The action data and section structure are otherwise the same.
+
+Pass `--verbose` to get more debug state. In JSON mode, the output starts from the full `IterateResult` shape (all fields, including `baseBranch`, `checks`, `shouldCancel`) and then applies the same agent-aware instruction projection as lean JSON: non-`fix_code` actions get a top-level `instructions` array, and Codex output may rewrite `fix.instructions` and simple-action instructions. In Markdown mode, `--verbose` restores the full header summary line (all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, `shouldCancel` always shown, and `[COOLDOWN]` no longer suppresses the base/summary block) — but Markdown is structurally different from JSON and does not guarantee field-for-field parity (array fields like `baseBranch` or `checks` are not added to Markdown for actions that do not normally render them). Lean mode is the default because most fields are `false`/`0`/`[]` on a typical healthy tick and add context noise without value.
 
 **Output shape (every action, default lean format):**
 
@@ -68,6 +70,8 @@ SKIP: CI still starting — waiting for first check to appear
 1. End this iteration — the next cron fire will recheck once CI starts reporting.
 ```
 
+Codex variant: `End this iteration — rerun \`npx pr-shepherd iterate 42\` after CI starts reporting.`
+
 `status`, `merge`, `state`, and `repo` are not emitted in default mode — they carry UNKNOWN/empty placeholders because the early return happens before any GitHub sweep. Pass `--verbose` to see all fields.
 
 **What the monitor does:** Follow `## Instructions` — end the iteration and wait for the next cron fire.
@@ -98,6 +102,10 @@ WAIT: 3 passing, 2 in-progress — 120s until auto-cancel
 
 1. End this iteration — the next cron fire will recheck.
 ```
+
+Codex variant: the body omits `until auto-cancel`, and the instruction is `End this iteration — rerun \`npx pr-shepherd iterate 42\` later to recheck.`
+
+When the current command includes a ready-delay override, Codex rerun guidance preserves it: `npx pr-shepherd iterate 42 --ready-delay 15m`.
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
@@ -130,6 +138,8 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review — end this iteration.
 ```
 
+Codex variant: the same instruction with an added reminder to rerun `npx pr-shepherd iterate 42` later to recheck.
+
 **What the monitor does:** Follow `## Instructions` — end the iteration and continue monitoring on the next cron fire.
 
 ---
@@ -161,6 +171,8 @@ CANCEL: PR #42 is merged — stopping monitor
 1. Invoke `/loop cancel` via the Skill tool.
 2. Stop.
 ```
+
+Codex variant: `Stop — no recurring Codex monitor is running to cancel.` followed by `Stop.`
 
 Other heading variants: `# PR #42 [CANCEL] — closed`, `# PR #42 [CANCEL] — ready-delay-elapsed`.
 
@@ -302,6 +314,7 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 - A first-look summaries step is appended when `firstLookSummaries` is non-empty — it tells the agent these summaries are being seen for the first time and their IDs are already in the resolve command's `--minimize-comment-ids`.
 - An edited-items step is appended when `editedSummaries` is non-empty or any first-look thread/comment carries `edited: true` — it tells the agent to read the updated body but **not** include these IDs in any mutation flag.
 - The final "iteration" step has three variants: `Stop this iteration — CI needs time to run on the new push before the next tick.` when a push occurred; `Stop this iteration before the next tick.` when only GitHub mutations were made (no push); `End this iteration.` when no push or mutations occurred.
+- In Codex output, the two "next tick" variants are rewritten to say to rerun `npx pr-shepherd iterate <PR>` later.
 
 The JSON payload exposes the same data under `fix.{threads, actionableComments, reviewSummaryIds, firstLookSummaries, editedSummaries, surfacedApprovals, checks, changesRequestedReviews, resolveCommand, instructions, mode, firstLookThreads, firstLookComments, inProgressRunIds}` — where `fix.mode === "rebase-and-push"` is the type discriminator — plus top-level `baseBranch` (on `IterateResultBase`, not under `fix`) and `cancelled`. `fix.inProgressRunIds` contains the GitHub Actions run IDs the agent must cancel before applying fixes (mirrors `## In-progress runs` in the Markdown output); it is an empty array when there are no in-progress GitHub Actions run IDs to cancel (external status checks or already-cancelled runs are excluded) or when no push is expected this iteration. `reviewSummaryIds` contains the IDs routed to `--minimize-comment-ids` for review-level minimization: this includes review summaries (both first-look and already-seen), and may also include APPROVED review IDs when approval minimization is enabled. `firstLookSummaries` carries the full `Review` objects for bodies seen this iteration for the first time. `editedSummaries` carries the full `Review` objects for summaries whose body changed since last seen — these IDs are **not** in `reviewSummaryIds`. Both `firstLookSummaries` and `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `editedSummaries` and `surfacedApprovals` are informational only. In lean JSON mode, `fix.*` arrays that are empty are omitted; `cancelled` is omitted when empty. Pass `--verbose` to include all fields. `firstLookThreads` and `firstLookComments` are informational — they carry `firstLookStatus`, optional `autoResolved` (outdated only), and optional `edited` (true when body changed since first acknowledgement) fields but must not be routed to resolve mutations.
 
@@ -463,6 +476,8 @@ After fixing manually, rerun `/pr-shepherd:monitor 42` to resume.
 1. Invoke `/loop cancel` via the Skill tool.
 2. Stop — the PR needs human direction before monitoring can resume.
 ```
+
+Codex variant: `Stop — no recurring Codex monitor is running to cancel.` followed by the same human-direction stop instruction.
 
 The block after the base-fields line (separated by a blank line) is `escalate.humanMessage` in JSON — ready to print verbatim.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -70,6 +70,8 @@ Base: main
 3. This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.
 ```
 
+In Codex output, the final instruction points to the reusable iterate command instead: `npx pr-shepherd iterate <PR>`.
+
 ### pr-shepherd resolve [PR]
 
 Two modes: **fetch** (default) auto-resolves outdated threads and returns actionable items; **mutate** resolves/minimizes/dismisses specific IDs after you push fixes.
@@ -238,6 +240,8 @@ WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
 1. End this iteration — the next cron fire will recheck.
 ```
 
+When Codex output is selected, the `[WAIT]` body omits the `until auto-cancel` countdown and the instruction points to the reusable one-shot command instead. For example: ``End this iteration — rerun `npx pr-shepherd iterate 42` later to recheck.`` If the current command used `--ready-delay`, the rerun command includes the same flag.
+
 Example for `[FIX_CODE]` (richest action):
 
 ```markdown
@@ -293,7 +297,9 @@ Exit codes: `0` wait/cooldown/mark_ready · `1` fix_code · `2` cancel · `3` es
 
 ### pr-shepherd monitor [PR]
 
-Bootstrap command for `/pr-shepherd:monitor`. Reads `watch.interval` from config and emits the loop prompt body (for inline single-iteration use) and a short `Loop args` line (the interval). The monitor skill invokes this command and follows its `## Instructions` to either run one iteration inline (if a loop already exists) or start a new `/loop`.
+Bootstrap command used by the Claude `/pr-shepherd:monitor` skill and by Codex directly. Reads `watch.interval` from config and emits the monitor prompt body plus a short `Loop args` line (the interval).
+
+By default, output targets Claude Code and tells the monitor skill how to reuse an existing `/loop` or start a new one. When Codex is detected (`AGENT=codex` or `CODEX_CI=1`), output omits Cron and `/loop` instructions and instead tells Codex to run one `iterate` tick, then rerun the reusable `npx pr-shepherd iterate <PR>` prompt later.
 
 ```sh
 npx pr-shepherd monitor        # infer PR from current branch
@@ -320,6 +326,8 @@ Loop args: `4m`
 1. Run `CronList`. If any job's prompt contains `#pr-shepherd-loop:pr=42:`, run the `## Loop prompt` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.
 2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
+
+Codex output includes the same PR, tag, interval, prompt body, and `## Instructions` shape, but the instructions say to run the loop prompt once and rerun `npx pr-shepherd iterate 42` later instead of creating or cancelling a `/loop`.
 
 The loop interval comes from `watch.interval` in `.pr-shepherdrc.yml` or the built-in default. Use `--format=json` to inspect the raw values programmatically.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,12 @@ actions:
 
 ---
 
+## Agent detection
+
+`pr-shepherd` uses the calling-agent environment only to choose instruction wording. `AGENT=codex` and `CODEX_CI=1` select Codex-compatible monitor output. Other environments keep the default Claude-compatible `/loop` instructions.
+
+---
+
 ## `iterate`
 
 ### `iterate.cooldownSeconds` — default `30`

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,15 +2,43 @@
 
 [← README](../README.md)
 
-Three Claude Code skills are included in the plugin.
+Three Claude Code skills are included in the plugin. The CLI can also emit Codex-compatible monitor instructions when called from Codex (`AGENT=codex` or `CODEX_CI=1`).
+
+## Codex setup
+
+Codex does not install or run the Claude plugin skills. Install the CLI in the repository where Codex will work:
+
+```sh
+npm install --save-dev pr-shepherd
+```
+
+If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking the CLI:
+
+```sh
+export AGENT=codex
+```
+
+Run `npx pr-shepherd monitor <PR>` once to bootstrap the workflow. Follow the output's `## Instructions`, then rerun the emitted `npx pr-shepherd iterate <PR>` command whenever you want another one-shot check. Codex does not provide the Claude `/loop` scheduler in this workflow.
 
 ## `/pr-shepherd:monitor`
 
-Start continuous CI monitoring for a PR. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd iterate`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
+Start continuous CI monitoring for a PR in Claude Code. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd iterate`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
+
+In Codex, run the CLI directly instead of the Claude slash command. `npx pr-shepherd monitor <PR>` emits one-shot iterate instructions instead of `/loop` setup. After the bootstrap step, rerun the emitted `npx pr-shepherd iterate <PR>` command later to check again.
+
+Claude Code:
 
 ```
 /pr-shepherd:monitor        # infer PR from current branch
 /pr-shepherd:monitor 42
+```
+
+Codex:
+
+```sh
+npx pr-shepherd monitor        # bootstrap from current branch, then follow its instructions
+npx pr-shepherd monitor 42     # bootstrap PR #42, then follow its instructions
+npx pr-shepherd iterate 42     # subsequent one-shot tick
 ```
 
 The polling interval and ready-delay come from `watch.interval` and `watch.readyDelayMinutes` in `.pr-shepherdrc.yml` (defaults: 4 minutes and 10 minutes). The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-minute TTL).

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -4,9 +4,13 @@
 
 ## Overview
 
-The `/pr-shepherd:monitor <PR>` slash command starts a cron loop that polls PR status at the configured interval (default `4m`, set via `watch.interval`). This document explains how all the pieces fit together.
+The `/pr-shepherd:monitor <PR>` slash command starts a Claude Code cron loop that polls PR status at the configured interval (default `4m`, set via `watch.interval`). This document explains how all the pieces fit together.
+
+Codex does not provide `/loop` scheduling in this workflow. When `pr-shepherd` detects Codex (`AGENT=codex` or `CODEX_CI=1`), `monitor` output tells Codex to run one `iterate` tick and rerun the reusable `npx pr-shepherd iterate <PR>` prompt later.
 
 ## Lifecycle
+
+Claude Code lifecycle:
 
 1. **User runs `/pr-shepherd:monitor <PR>`**
    - The skill runs `npx pr-shepherd monitor <PR>`, which reads `watch.*` config and emits a bootstrap Markdown block.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-shepherd",
   "version": "0.11.0",
-  "description": "Autonomous PR CI monitor and review-comment resolver for Claude Code",
+  "description": "Autonomous PR CI monitor and review-comment resolver for agentic coding tools",
   "license": "MIT",
   "author": "Jonathan Ong",
   "type": "module",
@@ -49,6 +49,7 @@
     "ci",
     "code-review",
     "automation",
+    "codex",
     "claude",
     "claude-code"
   ],

--- a/src/agent-runtime.mts
+++ b/src/agent-runtime.mts
@@ -1,0 +1,9 @@
+export type AgentRuntime = "claude" | "codex";
+
+export function detectAgentRuntime(
+  env: Partial<Record<"AGENT" | "CODEX_CI", string | undefined>> = process.env,
+): AgentRuntime {
+  if (env.AGENT?.trim().toLowerCase() === "codex") return "codex";
+  if (env.CODEX_CI === "1") return "codex";
+  return "claude";
+}

--- a/src/agent-runtime.test.mts
+++ b/src/agent-runtime.test.mts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { detectAgentRuntime } from "./agent-runtime.mts";
+
+describe("detectAgentRuntime", () => {
+  it("detects Codex from AGENT=codex", () => {
+    expect(detectAgentRuntime({ AGENT: "codex" })).toBe("codex");
+  });
+
+  it("detects Codex from mixed-case AGENT with whitespace", () => {
+    expect(detectAgentRuntime({ AGENT: " Codex " })).toBe("codex");
+  });
+
+  it("detects current Codex CLI from CODEX_CI=1", () => {
+    expect(detectAgentRuntime({ CODEX_CI: "1" })).toBe("codex");
+  });
+
+  it("defaults to Claude-compatible output", () => {
+    expect(detectAgentRuntime({})).toBe("claude");
+  });
+});

--- a/src/cli-parser.iterate-codex.mock.test.mts
+++ b/src/cli-parser.iterate-codex.mock.test.mts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
+vi.mock("./commands/resolve.mts", () => ({
+  runResolveFetch: vi.fn(),
+  runResolveMutate: vi.fn(),
+}));
+vi.mock("./commands/commit-suggestion.mts", () => ({
+  runCommitSuggestion: vi.fn(),
+}));
+vi.mock("./commands/iterate.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+  return { ...actual, runIterate: vi.fn() };
+});
+vi.mock("./commands/status.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/status.mts")>();
+  return {
+    ...actual,
+    runStatus: vi.fn(),
+    formatStatusTable: vi.fn().mockReturnValue("status table"),
+  };
+});
+vi.mock("./github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
+}));
+
+import { main } from "./cli-parser.mts";
+import { runIterate } from "./commands/iterate.mts";
+import { runStatus } from "./commands/status.mts";
+import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
+
+const mockRunIterate = vi.mocked(runIterate);
+const mockRunStatus = vi.mocked(runStatus);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stdoutSpy: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let stderrSpy: any;
+
+function getStdout(): string {
+  return stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  mockRunStatus.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+describe("main — iterate Codex fix_code output", () => {
+  it("text rewrites next-tick final instruction to reusable iterate command", async () => {
+    process.env.AGENT = "codex";
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.instructions = [
+      'Commit changed files: `git add <files> && git commit -m "<descriptive message>"`',
+      "Stop this iteration — CI needs time to run on the new push before the next tick.",
+    ];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42", "--ready-delay", "15m"]);
+    const out = getStdout();
+    expect(out).toContain(
+      "2. Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd iterate 42 --ready-delay 15m` later to recheck.",
+    );
+    expect(out).not.toContain("before the next tick");
+  });
+
+  it("json rewrites next-tick final instruction", async () => {
+    process.env.CODEX_CI = "1";
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.instructions = [
+      "Stop this iteration — CI needs time to run on the new push before the next tick.",
+    ];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42", "--format=json", "--ready-delay", "2h"]);
+    const parsed = JSON.parse(getStdout().trimEnd());
+    expect(parsed.fix.instructions).toEqual([
+      "Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd iterate 42 --ready-delay 2h` later to recheck.",
+    ]);
+  });
+
+  it("rewrites no-mutation final instruction for Codex", async () => {
+    process.env.AGENT = "codex";
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.instructions = ["End this iteration."];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42", "--format=json"]);
+    const parsed = JSON.parse(getStdout().trimEnd());
+    expect(parsed.fix.instructions).toEqual([
+      "Stop this iteration. Rerun `npx pr-shepherd iterate 42` later to recheck.",
+    ]);
+  });
+});

--- a/src/cli-parser.iterate-fix.mock.test.mts
+++ b/src/cli-parser.iterate-fix.mock.test.mts
@@ -44,6 +44,8 @@ function getStdout(): string {
 beforeEach(() => {
   vi.clearAllMocks();
   process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   mockRunStatus.mockResolvedValue([]);
@@ -51,6 +53,8 @@ beforeEach(() => {
 
 afterEach(() => {
   process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
   stdoutSpy.mockRestore();
   stderrSpy.mockRestore();
 });

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -41,9 +41,15 @@ function getStdout(): string {
   return stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
 }
 
+function getStderr(): string {
+  return stderrSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   mockRunStatus.mockResolvedValue([]);
@@ -51,6 +57,8 @@ beforeEach(() => {
 
 afterEach(() => {
   process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
   stdoutSpy.mockRestore();
   stderrSpy.mockRestore();
 });
@@ -84,6 +92,20 @@ describe("main — iterate", () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
     await main(["node", "shepherd", "iterate", "42", "--cooldown-seconds", "120"]);
     expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ cooldownSeconds: 120 }));
+  });
+
+  it("invalid --ready-delay exits before runIterate", async () => {
+    await main(["node", "shepherd", "iterate", "42", "--ready-delay", "notaduration"]);
+    expect(process.exitCode).toBe(1);
+    expect(mockRunIterate).not.toHaveBeenCalled();
+    expect(getStderr()).toContain("invalid --ready-delay");
+  });
+
+  it("--ready-delay without a value exits before runIterate", async () => {
+    await main(["node", "shepherd", "iterate", "42", "--ready-delay", "--format=json"]);
+    expect(process.exitCode).toBe(1);
+    expect(mockRunIterate).not.toHaveBeenCalled();
+    expect(getStderr()).toContain("--ready-delay requires a value");
   });
 });
 
@@ -169,6 +191,66 @@ describe("main — iterate text format", () => {
     expect(out).toContain("2. Stop — the PR needs human direction");
   });
 
+  it("codex wait: instructions point to reusable iterate command instead of next cron fire", async () => {
+    process.env.AGENT = "codex";
+    const result = makeIterateResult("wait");
+    if (result.action !== "wait") throw new Error("unreachable");
+    result.log =
+      "WAIT: 6 passing, 1 in-progress — awaiting human review or branch protection — 600s until auto-cancel";
+    mockRunIterate.mockResolvedValue(result);
+    await main(["node", "shepherd", "iterate", "42", "--ready-delay", "15m"]);
+    const out = getStdout();
+    expect(out).toContain(
+      "WAIT: 6 passing, 1 in-progress — awaiting human review or branch protection",
+    );
+    expect(out).toContain(
+      "1. End this iteration — rerun `npx pr-shepherd iterate 42 --ready-delay 15m` later to recheck.",
+    );
+    expect(out).not.toContain("next cron fire");
+    expect(out).not.toContain("auto-cancel");
+  });
+
+  it("codex cooldown: instructions point to reusable iterate command", async () => {
+    process.env.AGENT = "codex";
+    mockRunIterate.mockResolvedValue(makeIterateResult("cooldown"));
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain(
+      "1. End this iteration — rerun `npx pr-shepherd iterate 42` after CI starts reporting.",
+    );
+    expect(out).not.toContain("next cron fire");
+  });
+
+  it("codex mark_ready: instructions point to reusable iterate command", async () => {
+    process.env.AGENT = "codex";
+    mockRunIterate.mockResolvedValue(makeIterateResult("mark_ready"));
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain(
+      "1. The CLI already marked the PR ready for review — end this iteration. Rerun `npx pr-shepherd iterate 42` later to recheck.",
+    );
+  });
+
+  it("codex cancel: instructions do not invoke /loop cancel", async () => {
+    process.env.AGENT = "codex";
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain("1. Stop — no recurring Codex monitor is running to cancel.");
+    expect(out).toContain("2. Stop.");
+    expect(out).not.toContain("Invoke `/loop cancel`");
+  });
+
+  it("codex escalate: instructions do not invoke /loop cancel", async () => {
+    process.env.CODEX_CI = "1";
+    mockRunIterate.mockResolvedValue(makeIterateResult("escalate"));
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain("1. Stop — no recurring Codex monitor is running to cancel.");
+    expect(out).toContain("2. Stop — the PR needs human direction");
+    expect(out).not.toContain("Invoke `/loop cancel`");
+  });
+
   it("## Checks section is absent when checks is empty (cooldown keeps no-checks invariant)", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("cooldown")); // checks: []
     await main(["node", "shepherd", "iterate", "42"]);
@@ -183,6 +265,17 @@ describe("main — iterate text format", () => {
     const parsed = JSON.parse(out);
     expect(parsed.action).toBe("wait");
     expect(parsed.pr).toBe(42);
+    expect(parsed.instructions).toEqual(["End this iteration — the next cron fire will recheck."]);
+  });
+
+  it("codex json format: emits Codex-specific instructions", async () => {
+    process.env.CODEX_CI = "1";
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+    await main(["node", "shepherd", "iterate", "42", "--format", "json"]);
+    const parsed = JSON.parse(getStdout().trimEnd());
+    expect(parsed.instructions).toEqual([
+      "End this iteration — rerun `npx pr-shepherd iterate 42` later to recheck.",
+    ]);
   });
 
   it("cancel json: emits reason field so consumers can branch without parsing log", async () => {

--- a/src/cli-parser.monitor.mock.test.mts
+++ b/src/cli-parser.monitor.mock.test.mts
@@ -47,12 +47,15 @@ const MONITOR_RESULT = {
   prNumber: 42,
   loopTag: "#pr-shepherd-loop:pr=42:",
   loopArgs: "4m",
+  reusableCommand: "npx pr-shepherd iterate 42",
   loopPrompt: "#pr-shepherd-loop:pr=42:\nBODY",
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   mockRunStatus.mockResolvedValue([]);
@@ -61,6 +64,8 @@ beforeEach(() => {
 
 afterEach(() => {
   process.exitCode = undefined;
+  delete process.env.AGENT;
+  delete process.env.CODEX_CI;
   stdoutSpy.mockRestore();
   stderrSpy.mockRestore();
 });
@@ -69,18 +74,47 @@ describe("main — monitor", () => {
   it("dispatches to runMonitor and emits formatted output", async () => {
     await main(["node", "shepherd", "monitor", "42"]);
     expect(mockRunMonitor).toHaveBeenCalledTimes(1);
-    expect(mockRunMonitor).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 42 }));
+    expect(mockRunMonitor).toHaveBeenCalledWith(
+      expect.objectContaining({ prNumber: 42, runtime: "claude" }),
+    );
     const out = getStdout();
     expect(out).toContain("# PR #42 [MONITOR]");
+  });
+
+  it("uses Codex monitor output when AGENT=codex", async () => {
+    process.env.AGENT = "codex";
+    mockRunMonitor.mockResolvedValue({
+      ...MONITOR_RESULT,
+      loopPrompt:
+        "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — Codex recurrence rules:**\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42",
+    });
+    await main(["node", "shepherd", "monitor", "42"]);
+    expect(mockRunMonitor).toHaveBeenCalledWith(expect.objectContaining({ runtime: "codex" }));
+    const out = getStdout();
+    expect(out).toContain("Reusable command: `npx pr-shepherd iterate 42`");
+    expect(out).toContain("Codex does not provide `/loop` scheduling");
+    expect(out).not.toContain("Invoke the `/loop` skill");
   });
 
   it("emits JSON when --format=json", async () => {
     await main(["node", "shepherd", "monitor", "42", "--format=json"]);
     const out = getStdout();
-    const parsed = JSON.parse(out.trim()) as typeof MONITOR_RESULT;
+    const parsed = JSON.parse(out.trim());
     expect(parsed.prNumber).toBe(42);
     expect(parsed.loopTag).toBe("#pr-shepherd-loop:pr=42:");
     expect(parsed.loopArgs).toBe("4m");
+    expect(parsed.reusableCommand).toBeUndefined();
+    expect(
+      parsed.instructions.some((inst: string) => inst.includes("invoke the `/loop` skill")),
+    ).toBe(true);
+  });
+
+  it("emits Codex JSON instructions when CODEX_CI=1", async () => {
+    process.env.CODEX_CI = "1";
+    await main(["node", "shepherd", "monitor", "42", "--format=json"]);
+    const parsed = JSON.parse(getStdout().trim());
+    expect(parsed.reusableCommand).toBe("npx pr-shepherd iterate 42");
+    expect(parsed.instructions.join("\n")).toContain("Codex does not provide `/loop` scheduling");
   });
 
   it("accepts --ready-delay and forwards it to runMonitor", async () => {

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -33,6 +33,7 @@ import {
   handleStatus,
 } from "./cli/handlers.mts";
 import { setupLog } from "./log/setup.mts";
+import { detectAgentRuntime } from "./agent-runtime.mts";
 
 // ---------------------------------------------------------------------------
 // Entry
@@ -99,9 +100,13 @@ function readVersion(): string {
 
 async function handleCheck(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts } = parseCommonArgs(args);
+  const runtime = detectAgentRuntime();
 
   const report = await runCheck({ ...globalOpts, prNumber, autoResolve: false });
-  const output = globalOpts.format === "json" ? formatJson(report) : formatText(report);
+  const output =
+    globalOpts.format === "json"
+      ? formatJson(report, { runtime })
+      : formatText(report, { runtime });
   process.stdout.write(`${output}\n`);
 
   process.exitCode = statusToExitCode(report.status);

--- a/src/cli/duration-flag.mts
+++ b/src/cli/duration-flag.mts
@@ -1,0 +1,29 @@
+export function validateDurationFlag(
+  command: string,
+  flag: string,
+  value: string | null,
+  presentAsSeparateArg: boolean,
+): string | undefined | null {
+  if (value === null) {
+    if (presentAsSeparateArg) {
+      process.stderr.write(`${command}: ${flag} requires a value (e.g. ${flag} 15m)\n`);
+      process.exitCode = 1;
+      return null;
+    }
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.startsWith("--")) {
+    process.stderr.write(`${command}: ${flag} requires a value (e.g. ${flag} 15m)\n`);
+    process.exitCode = 1;
+    return null;
+  }
+  if (!/^\d+(?:m|min|minutes?|h|hours?)?$/.test(trimmed)) {
+    process.stderr.write(
+      `${command}: invalid ${flag}: ${value}. Expected a duration like 5m, 2h, 10m, or 1h.\n`,
+    );
+    process.exitCode = 1;
+    return null;
+  }
+  return trimmed;
+}

--- a/src/cli/fix-formatter.mts
+++ b/src/cli/fix-formatter.mts
@@ -7,9 +7,17 @@ import {
   renderReviewBullet,
   renderFirstLookStatusTag,
 } from "./list-formatters.mts";
+import { adaptFixCodeInstructions, numberInstructions } from "./iterate-instructions.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
 import type { IterateResultFixCode } from "../types.mts";
 
-export function formatFixCodeResult(header: string, result: IterateResultFixCode): string {
+export function formatFixCodeResult(
+  header: string,
+  result: IterateResultFixCode,
+  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string },
+): string {
+  const runtime = opts?.runtime ?? "claude";
+  const readyDelaySuffix = opts?.readyDelaySuffix;
   const sections: string[] = [header];
 
   if (result.fix.threads.length > 0) {
@@ -129,7 +137,11 @@ export function formatFixCodeResult(header: string, result: IterateResultFixCode
   sections.push(postFixLines.join("\n"));
 
   sections.push("## Instructions");
-  sections.push(result.fix.instructions.map((inst, i) => `${i + 1}. ${inst}`).join("\n"));
+  sections.push(
+    numberInstructions(
+      adaptFixCodeInstructions(result.fix.instructions, result.pr, runtime, readyDelaySuffix),
+    ),
+  );
 
   return joinSections(sections);
 }

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -1,5 +1,5 @@
 export { formatIterateResult } from "./iterate-formatter.mts";
-export { projectIterateLean } from "./iterate-lean.mts";
+export { projectIterateLean, projectIterateVerbose } from "./iterate-lean.mts";
 
 import { safeFence } from "./fence.mts";
 import {

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -1,9 +1,10 @@
 import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
 import { runIterate } from "../commands/iterate.mts";
-import { runMonitor, formatMonitorResult } from "../commands/monitor.mts";
+import { runMonitor, formatMonitorResult, formatMonitorJson } from "../commands/monitor.mts";
 import { runStatus, formatStatusTable } from "../commands/status.mts";
 import { getRepoInfo } from "../github/client.mts";
 import { loadConfig } from "../config/load.mts";
+import { detectAgentRuntime } from "../agent-runtime.mts";
 import {
   parseCommonArgs,
   getFlag,
@@ -20,7 +21,9 @@ import {
   formatCommitSuggestionResult,
   formatIterateResult,
   projectIterateLean,
+  projectIterateVerbose,
 } from "./formatters.mts";
+import { validateDurationFlag } from "./duration-flag.mts";
 
 export async function handleCommitSuggestion(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
@@ -61,11 +64,19 @@ export async function handleCommitSuggestion(args: string[]): Promise<void> {
 
 export async function handleIterate(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
+  const runtime = detectAgentRuntime();
 
   const readyDelayStr = getFlag(extra, "--ready-delay");
+  const readyDelaySuffix = validateDurationFlag(
+    "pr-shepherd iterate",
+    "--ready-delay",
+    readyDelayStr,
+    hasFlag(extra, "--ready-delay"),
+  );
+  if (readyDelaySuffix === null) return;
   const cfg = loadConfig();
   const readyDelaySeconds =
-    parseDurationToMinutes(readyDelayStr ?? "", cfg.watch.readyDelayMinutes) * 60;
+    parseDurationToMinutes(readyDelaySuffix ?? "", cfg.watch.readyDelayMinutes) * 60;
   const cooldownSecondsStr = getFlag(extra, "--cooldown-seconds");
   const cooldownSeconds = cooldownSecondsStr
     ? parseIntStrict(cooldownSecondsStr, "--cooldown-seconds")
@@ -88,10 +99,18 @@ export async function handleIterate(args: string[]): Promise<void> {
   });
 
   if (globalOpts.format === "json") {
-    const output = globalOpts.verbose ? result : projectIterateLean(result);
+    const output = globalOpts.verbose
+      ? projectIterateVerbose(result, { runtime, readyDelaySuffix })
+      : projectIterateLean(result, { runtime, readyDelaySuffix });
     process.stdout.write(`${JSON.stringify(output)}\n`);
   } else {
-    process.stdout.write(`${formatIterateResult(result, { verbose: globalOpts.verbose })}\n`);
+    process.stdout.write(
+      `${formatIterateResult(result, {
+        verbose: globalOpts.verbose,
+        runtime,
+        readyDelaySuffix,
+      })}\n`,
+    );
   }
 
   process.exitCode = iterateActionToExitCode(result.action);
@@ -99,18 +118,16 @@ export async function handleIterate(args: string[]): Promise<void> {
 
 export async function handleMonitor(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
+  const runtime = detectAgentRuntime();
 
   const readyDelayStr = getFlag(extra, "--ready-delay");
-  if (
-    hasFlag(extra, "--ready-delay") &&
-    (readyDelayStr === null || readyDelayStr.startsWith("--"))
-  ) {
-    process.stderr.write(
-      "pr-shepherd monitor: --ready-delay requires a value (e.g. --ready-delay 15m)\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
+  const readyDelaySuffix = validateDurationFlag(
+    "pr-shepherd monitor",
+    "--ready-delay",
+    readyDelayStr,
+    hasFlag(extra, "--ready-delay"),
+  );
+  if (readyDelaySuffix === null) return;
   const remaining: string[] = [];
   for (let i = 0; i < extra.length; i++) {
     const a = extra[i]!;
@@ -139,7 +156,8 @@ export async function handleMonitor(args: string[]): Promise<void> {
     result = await runMonitor({
       ...globalOpts,
       prNumber,
-      readyDelaySuffix: readyDelayStr ?? undefined,
+      readyDelaySuffix: readyDelaySuffix ?? undefined,
+      runtime,
     });
   } catch (err) {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
@@ -149,8 +167,8 @@ export async function handleMonitor(args: string[]): Promise<void> {
 
   process.stdout.write(
     globalOpts.format === "json"
-      ? `${JSON.stringify(result, null, 2)}\n`
-      : `${formatMonitorResult(result)}\n`,
+      ? `${JSON.stringify(formatMonitorJson(result, { runtime }), null, 2)}\n`
+      : `${formatMonitorResult(result, { runtime })}\n`,
   );
 }
 

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -1,6 +1,12 @@
 import type { IterateResult } from "../types.mts";
 import { formatFixCodeResult } from "./fix-formatter.mts";
 import { joinSections } from "../util/markdown.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
+import {
+  adaptIterateLog,
+  buildSimpleIterateInstructions,
+  numberInstructions,
+} from "./iterate-instructions.mts";
 
 /**
  * Format an IterateResult as human-readable Markdown.
@@ -17,8 +23,13 @@ import { joinSections } from "../util/markdown.mts";
  *      unconditional: every action, every variant, always emits at least one step.
  *      The SKILL simply follows those steps; it does not need its own dispatch table.
  */
-export function formatIterateResult(result: IterateResult, opts?: { verbose?: boolean }): string {
+export function formatIterateResult(
+  result: IterateResult,
+  opts?: { verbose?: boolean; runtime?: AgentRuntime; readyDelaySuffix?: string },
+): string {
   const verbose = opts?.verbose ?? false;
+  const runtime = opts?.runtime ?? "claude";
+  const readyDelaySuffix = opts?.readyDelaySuffix;
 
   const heading = `# PR #${result.pr} [${result.action.toUpperCase()}]`;
   const reviewDecisionSeg =
@@ -52,39 +63,39 @@ export function formatIterateResult(result: IterateResult, opts?: { verbose?: bo
       // placeholders that add no value. Emit only heading + log + Instructions.
       return joinSections([
         verbose ? header : heading,
-        result.log,
-        "## Instructions\n\n1. End this iteration — the next cron fire will recheck once CI starts reporting.",
+        adaptIterateLog(result.log, runtime),
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
       ]);
 
     case "wait":
       return joinSections([
         header,
-        result.log,
-        "## Instructions\n\n1. End this iteration — the next cron fire will recheck.",
+        adaptIterateLog(result.log, runtime),
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
       ]);
 
     case "mark_ready":
       return joinSections([
         header,
-        result.log,
-        "## Instructions\n\n1. The CLI already marked the PR ready for review — end this iteration.",
+        adaptIterateLog(result.log, runtime),
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
       ]);
 
     case "cancel":
       return joinSections([
         [`${heading} — ${result.reason}`, "", baseLine, summaryLine].join("\n"),
-        result.log,
-        "## Instructions\n\n1. Invoke `/loop cancel` via the Skill tool.\n2. Stop.",
+        adaptIterateLog(result.log, runtime),
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
       ]);
 
     case "escalate":
       return joinSections([
         header,
         result.escalate.humanMessage,
-        "## Instructions\n\n1. Invoke `/loop cancel` via the Skill tool.\n2. Stop — the PR needs human direction before monitoring can resume.",
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
       ]);
 
     case "fix_code":
-      return formatFixCodeResult(header, result);
+      return formatFixCodeResult(header, result, { runtime, readyDelaySuffix });
   }
 }

--- a/src/cli/iterate-instructions.mts
+++ b/src/cli/iterate-instructions.mts
@@ -1,0 +1,85 @@
+import type { AgentRuntime } from "../agent-runtime.mts";
+import {
+  FIX_INSTRUCTION_END_ITERATION,
+  FIX_INSTRUCTION_STOP_AFTER_PUSH,
+  FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK,
+} from "../commands/iterate/render.mts";
+import type { IterateResult } from "../types.mts";
+
+export function buildSimpleIterateInstructions(
+  result: Exclude<IterateResult, { action: "fix_code" }>,
+  runtime: AgentRuntime,
+  readyDelaySuffix?: string,
+): string[] {
+  const rerunCommand = buildCodexIterateCommand(result.pr, readyDelaySuffix);
+  switch (result.action) {
+    case "cooldown":
+      return [
+        runtime === "codex"
+          ? `End this iteration — rerun \`${rerunCommand}\` after CI starts reporting.`
+          : "End this iteration — the next cron fire will recheck once CI starts reporting.",
+      ];
+    case "wait":
+      return [
+        runtime === "codex"
+          ? `End this iteration — rerun \`${rerunCommand}\` later to recheck.`
+          : "End this iteration — the next cron fire will recheck.",
+      ];
+    case "mark_ready":
+      return [
+        runtime === "codex"
+          ? `The CLI already marked the PR ready for review — end this iteration. Rerun \`${rerunCommand}\` later to recheck.`
+          : "The CLI already marked the PR ready for review — end this iteration.",
+      ];
+    case "cancel":
+      return [
+        runtime === "codex"
+          ? "Stop — no recurring Codex monitor is running to cancel."
+          : "Invoke `/loop cancel` via the Skill tool.",
+        "Stop.",
+      ];
+    case "escalate":
+      return [
+        runtime === "codex"
+          ? "Stop — no recurring Codex monitor is running to cancel."
+          : "Invoke `/loop cancel` via the Skill tool.",
+        "Stop — the PR needs human direction before monitoring can resume.",
+      ];
+  }
+}
+
+export function adaptFixCodeInstructions(
+  instructions: string[],
+  pr: number,
+  runtime: AgentRuntime,
+  readyDelaySuffix?: string,
+): string[] {
+  if (runtime !== "codex") return instructions;
+  const rerunCommand = buildCodexIterateCommand(pr, readyDelaySuffix);
+  return instructions.map((instruction) => {
+    if (instruction === FIX_INSTRUCTION_STOP_AFTER_PUSH) {
+      return `Stop this iteration — CI needs time to run on the new push. Rerun \`${rerunCommand}\` later to recheck.`;
+    }
+    if (instruction === FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK) {
+      return `Stop this iteration. Rerun \`${rerunCommand}\` later to recheck.`;
+    }
+    if (instruction === FIX_INSTRUCTION_END_ITERATION) {
+      return `Stop this iteration. Rerun \`${rerunCommand}\` later to recheck.`;
+    }
+    return instruction;
+  });
+}
+
+export function adaptIterateLog(log: string, runtime: AgentRuntime): string {
+  if (runtime !== "codex") return log;
+  return log.replace(/\s+—\s+\d+s until auto-cancel/g, "");
+}
+
+export function buildCodexIterateCommand(pr: number, readyDelaySuffix?: string): string {
+  const suffix = readyDelaySuffix?.trim();
+  return `npx pr-shepherd iterate ${pr}${suffix ? ` --ready-delay ${suffix}` : ""}`;
+}
+
+export function numberInstructions(instructions: string[]): string {
+  return instructions.map((instruction, i) => `${i + 1}. ${instruction}`).join("\n");
+}

--- a/src/cli/iterate-lean.mts
+++ b/src/cli/iterate-lean.mts
@@ -1,11 +1,22 @@
 import type { IterateResult } from "../types.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
+import {
+  adaptIterateLog,
+  adaptFixCodeInstructions,
+  buildSimpleIterateInstructions,
+} from "./iterate-instructions.mts";
 
 /**
  * Project an IterateResult to a lean JSON shape for the default (non-verbose) output.
  * Omits fields that are the trivial default (false, 0, empty) or state-gated fields
  * outside the state where they are meaningful.
  */
-export function projectIterateLean(result: IterateResult): unknown {
+export function projectIterateLean(
+  result: IterateResult,
+  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string },
+): unknown {
+  const runtime = opts?.runtime ?? "claude";
+  const readyDelaySuffix = opts?.readyDelaySuffix;
   const base: Record<string, unknown> = {
     action: result.action,
     pr: result.pr,
@@ -33,14 +44,31 @@ export function projectIterateLean(result: IterateResult): unknown {
 
   switch (result.action) {
     case "cooldown":
-      return { ...base, log: result.log };
+      return {
+        ...base,
+        log: adaptIterateLog(result.log, runtime),
+        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+      };
     case "wait":
-      return { ...base, log: result.log };
+      return {
+        ...base,
+        log: adaptIterateLog(result.log, runtime),
+        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+      };
     case "cancel":
-      return { ...base, reason: result.reason, log: result.log };
+      return {
+        ...base,
+        reason: result.reason,
+        log: adaptIterateLog(result.log, runtime),
+        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+      };
     case "mark_ready":
       // drop markedReady — always true, redundant with action discriminator
-      return { ...base, log: result.log };
+      return {
+        ...base,
+        log: adaptIterateLog(result.log, runtime),
+        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+      };
     case "fix_code":
       return {
         ...base,
@@ -78,7 +106,14 @@ export function projectIterateLean(result: IterateResult): unknown {
             changesRequestedReviews: result.fix.changesRequestedReviews,
           }),
           resolveCommand: result.fix.resolveCommand,
-          ...(result.fix.instructions.length > 0 && { instructions: result.fix.instructions }),
+          ...(result.fix.instructions.length > 0 && {
+            instructions: adaptFixCodeInstructions(
+              result.fix.instructions,
+              result.pr,
+              runtime,
+              readyDelaySuffix,
+            ),
+          }),
         },
       };
     case "escalate":
@@ -102,6 +137,38 @@ export function projectIterateLean(result: IterateResult): unknown {
           suggestion: result.escalate.suggestion,
           humanMessage: result.escalate.humanMessage,
         },
+        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
       };
   }
+}
+
+export function projectIterateVerbose(
+  result: IterateResult,
+  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string },
+): unknown {
+  const runtime = opts?.runtime ?? "claude";
+  const readyDelaySuffix = opts?.readyDelaySuffix;
+  if (result.action === "fix_code") {
+    return {
+      ...result,
+      fix: {
+        ...result.fix,
+        instructions: adaptFixCodeInstructions(
+          result.fix.instructions,
+          result.pr,
+          runtime,
+          readyDelaySuffix,
+        ),
+      },
+    };
+  }
+  const log =
+    "log" in result && typeof result.log === "string"
+      ? { log: adaptIterateLog(result.log, runtime) }
+      : {};
+  return {
+    ...result,
+    ...log,
+    instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+  };
 }

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -1,2 +1,7 @@
 export { runIterate } from "./iterate/index.mts";
-export { renderResolveCommand } from "./iterate/render.mts";
+export {
+  FIX_INSTRUCTION_END_ITERATION,
+  FIX_INSTRUCTION_STOP_AFTER_PUSH,
+  FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK,
+  renderResolveCommand,
+} from "./iterate/render.mts";

--- a/src/commands/iterate/render.mts
+++ b/src/commands/iterate/render.mts
@@ -8,6 +8,11 @@ import type {
   FirstLookComment,
 } from "../../types.mts";
 
+export const FIX_INSTRUCTION_STOP_AFTER_PUSH =
+  "Stop this iteration — CI needs time to run on the new push before the next tick.";
+export const FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK = "Stop this iteration before the next tick.";
+export const FIX_INSTRUCTION_END_ITERATION = "End this iteration.";
+
 /**
  * Render a resolve command as a shell snippet. Wraps `$DISMISS_MESSAGE` and whitespace-bearing
  * argv entries in double quotes for placeholder substitution. Throws if argv contains `"`, `$`,
@@ -168,13 +173,11 @@ export function buildFixInstructions(
     );
   }
   if (needsPush) {
-    instructions.push(
-      `Stop this iteration — CI needs time to run on the new push before the next tick.`,
-    );
+    instructions.push(FIX_INSTRUCTION_STOP_AFTER_PUSH);
   } else if (resolveCommand.hasMutations) {
-    instructions.push(`Stop this iteration before the next tick.`);
+    instructions.push(FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK);
   } else {
-    instructions.push(`End this iteration.`);
+    instructions.push(FIX_INSTRUCTION_END_ITERATION);
   }
 
   return instructions;

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -28,6 +28,7 @@ describe("runMonitor", () => {
     expect(result.loopArgs).toBe("4m");
     expect(result.loopPrompt).toContain("#pr-shepherd-loop:pr=99:");
     expect(result.loopPrompt).toContain("npx pr-shepherd iterate 99");
+    expect(result.reusableCommand).toBe("npx pr-shepherd iterate 99");
     // loopArgs is a short one-liner — not the combined invocation string
     expect(result.loopArgs).not.toContain("npx pr-shepherd");
   });
@@ -65,6 +66,27 @@ describe("runMonitor", () => {
     expect(result.loopPrompt).toContain("--ready-delay 15m");
   });
 
+  it("includes --ready-delay in the reusable command when readyDelaySuffix is valid", async () => {
+    const result = await runMonitor({
+      format: "text",
+      prNumber: 42,
+      readyDelaySuffix: "15m",
+      runtime: "codex",
+    });
+    expect(result.reusableCommand).toBe("npx pr-shepherd iterate 42 --ready-delay 15m");
+    expect(result.loopPrompt).toContain("npx pr-shepherd iterate 42 --ready-delay 15m");
+  });
+
+  it("builds a Codex prompt without /loop or Cron instructions", async () => {
+    const result = await runMonitor({ format: "text", prNumber: 42, runtime: "codex" });
+    expect(result.loopPrompt).toContain("Codex recurrence rules");
+    expect(result.loopPrompt).toContain("npx pr-shepherd iterate 42");
+    expect(result.loopPrompt).not.toContain("CronList");
+    expect(result.loopPrompt).not.toContain("CronDelete");
+    expect(result.loopPrompt).not.toContain("ScheduleWakeup");
+    expect(result.loopPrompt).not.toContain("Do NOT call `/loop`");
+  });
+
   it("accepts hours suffix for readyDelaySuffix", async () => {
     const result = await runMonitor({ format: "text", prNumber: 42, readyDelaySuffix: "2h" });
     expect(result.loopPrompt).toContain("--ready-delay 2h");
@@ -94,6 +116,7 @@ describe("formatMonitorResult", () => {
     prNumber: 42,
     loopTag: "#pr-shepherd-loop:pr=42:",
     loopArgs: "4m",
+    reusableCommand: "npx pr-shepherd iterate 42",
     loopPrompt:
       "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — recurrence rules:**\n- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.\n- End the turn cleanly after completing the actions below. The cron job handles the next fire.\n\n**Self-dedup:** Run `CronList`. If more than one job contains `#pr-shepherd-loop:pr=42:`, keep the lowest job ID and `CronDelete` the rest (ignore errors — a concurrent runner may have already deleted them).\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42\n\nExit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #42 [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.\n\nThe output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
   };
@@ -105,6 +128,20 @@ describe("formatMonitorResult", () => {
     expect(md).toContain("Loop args: `4m`");
     expect(md).toContain("## Loop prompt");
     expect(md).toContain("## Instructions");
+  });
+
+  it("emits Codex reusable prompt and non-loop instructions", () => {
+    const codexFixture: MonitorResult = {
+      ...fixture,
+      loopPrompt:
+        "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — Codex recurrence rules:**\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42",
+    };
+    const md = formatMonitorResult(codexFixture, { runtime: "codex" });
+    expect(md).toContain("Reusable command: `npx pr-shepherd iterate 42`");
+    expect(md).toContain("Run the `## Loop prompt` body once inline now.");
+    expect(md).toContain("Codex does not provide `/loop` scheduling");
+    expect(md).not.toContain("Invoke the `/loop` skill");
+    expect(md).not.toContain("CronList");
   });
 
   it("does not emit a ```loop fenced block", () => {

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -1,9 +1,12 @@
 import { getCurrentPrNumber } from "../github/client.mts";
 import { loadConfig } from "../config/load.mts";
 import type { GlobalOptions } from "../types.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
+import { joinSections } from "../util/markdown.mts";
 
 export interface MonitorCommandOptions extends GlobalOptions {
   readyDelaySuffix?: string;
+  runtime?: AgentRuntime;
 }
 
 export interface MonitorResult {
@@ -13,6 +16,7 @@ export interface MonitorResult {
   loopArgs: string;
   /** The loop prompt body. To build /loop args: `${loopArgs}\n\n${loopPrompt}` */
   loopPrompt: string;
+  reusableCommand: string;
 }
 
 export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorResult> {
@@ -34,34 +38,59 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   // step 1 of formatMonitorResult's ## Instructions and the in-prompt Self-dedup
   // block depend on this exact string — don't change the format.
   const loopTag = `#pr-shepherd-loop:pr=${prNumber}:`;
-  const loopPrompt = buildLoopPrompt(prNumber, loopTag, opts.readyDelaySuffix);
   const loopArgs = interval;
+  const reusableCommand = buildIterateCommand(prNumber, opts.readyDelaySuffix);
+  const loopPrompt = buildLoopPrompt(prNumber, loopTag, reusableCommand, opts.runtime ?? "claude");
 
-  return { prNumber, loopTag, loopArgs, loopPrompt };
+  return {
+    prNumber,
+    loopTag,
+    loopArgs,
+    loopPrompt,
+    reusableCommand,
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Formatters
 // ---------------------------------------------------------------------------
 
-export function formatMonitorResult(result: MonitorResult): string {
+export function formatMonitorResult(
+  result: MonitorResult,
+  opts?: { runtime?: AgentRuntime },
+): string {
   const { prNumber, loopTag, loopArgs, loopPrompt } = result;
+  const runtime = opts?.runtime ?? "claude";
 
-  return [
-    `# PR #${prNumber} [MONITOR]`,
-    "",
-    `Loop tag: \`${loopTag}\``,
-    `Loop args: \`${loopArgs}\``,
-    "",
+  const sections = [
+    [
+      `# PR #${prNumber} [MONITOR]`,
+      "",
+      `Loop tag: \`${loopTag}\``,
+      `Loop args: \`${loopArgs}\``,
+    ].join("\n"),
+    runtime === "codex" ? `Reusable command: \`${result.reusableCommand}\`` : null,
     "## Loop prompt",
-    "",
     loopPrompt,
-    "",
     "## Instructions",
-    "",
-    `1. Run \`CronList\`. If any job's prompt contains \`${loopTag}\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
-    `2. Otherwise, invoke the \`/loop\` skill via the Skill tool. Build the \`args\` parameter as: only the value inside the backticks on the \`Loop args\` line above (the interval — not the \`Loop args:\` label), then a blank line, then the full \`## Loop prompt\` body.`,
-  ].join("\n");
+    buildMonitorInstructions(result, runtime)
+      .map((inst, i) => `${i + 1}. ${inst}`)
+      .join("\n"),
+  ];
+  return joinSections(sections);
+}
+
+export function formatMonitorJson(
+  result: MonitorResult,
+  opts?: { runtime?: AgentRuntime },
+): Record<string, unknown> {
+  const runtime = opts?.runtime ?? "claude";
+  const { reusableCommand, ...base } = result;
+  return {
+    ...base,
+    ...(runtime === "codex" && { reusableCommand }),
+    instructions: buildMonitorInstructions(result, runtime),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -79,9 +108,33 @@ function validateReadyDelaySuffix(readyDelaySuffix?: string): string | undefined
   return trimmed;
 }
 
-function buildLoopPrompt(prNumber: number, loopTag: string, readyDelaySuffix?: string): string {
+function buildIterateCommand(prNumber: number, readyDelaySuffix?: string): string {
   const validatedDelay = validateReadyDelaySuffix(readyDelaySuffix);
-  const iterateCmd = `npx pr-shepherd iterate ${prNumber}${validatedDelay ? ` --ready-delay ${validatedDelay}` : ""}`;
+  return `npx pr-shepherd iterate ${prNumber}${validatedDelay ? ` --ready-delay ${validatedDelay}` : ""}`;
+}
+
+function buildLoopPrompt(
+  prNumber: number,
+  loopTag: string,
+  iterateCmd: string,
+  runtime: AgentRuntime = "claude",
+): string {
+  if (runtime === "codex") {
+    return [
+      loopTag,
+      "",
+      "**IMPORTANT — Codex recurrence rules:**",
+      "- Run the command below once, follow its `## Instructions` exactly, then stop.",
+      "- Codex does not provide `/loop` scheduling in this workflow. To check again later, rerun the reusable command from the monitor output.",
+      "",
+      "Run in a single Bash call:",
+      `  ${iterateCmd}`,
+      "",
+      `Exit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with \`# PR #${prNumber} [\`), report the first line of stderr and stop so the user can retry.`,
+      "",
+      "The output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
+    ].join("\n");
+  }
   return [
     loopTag,
     "",
@@ -98,4 +151,17 @@ function buildLoopPrompt(prNumber: number, loopTag: string, readyDelaySuffix?: s
     "",
     "The output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
   ].join("\n");
+}
+
+function buildMonitorInstructions(result: MonitorResult, runtime: AgentRuntime): string[] {
+  if (runtime === "codex") {
+    return [
+      "Run the `## Loop prompt` body once inline now.",
+      `When you want to check this PR again later, run \`${result.reusableCommand}\`. Codex does not provide \`/loop\` scheduling, so no recurring monitor is created.`,
+    ];
+  }
+  return [
+    `Run \`CronList\`. If any job's prompt contains \`${result.loopTag}\`, run the \`## Loop prompt\` body once inline (as if it were a cron tick) then stop — do not create a duplicate loop.`,
+    "Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.",
+  ];
 }

--- a/src/commands/ready-delay.mts
+++ b/src/commands/ready-delay.mts
@@ -33,7 +33,8 @@ export interface ReadyDelayState {
  *   - If `isReady == true`: start or continue the ready timer.
  *   - If `isReady == false`: reset the timer.
  *
- * When `shouldCancel == true`, the slash command should invoke `/loop cancel`.
+ * When `shouldCancel == true`, the formatter tells loop-capable agents to cancel
+ * the loop and tells one-shot agents to stop.
  */
 export async function updateReadyDelay(
   prNumber: number,

--- a/src/reporters/check-instructions.mts
+++ b/src/reporters/check-instructions.mts
@@ -1,11 +1,16 @@
 import type { ShepherdReport } from "../types.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
 
 /**
  * Build the numbered instruction steps for the agent to follow after a `check` run.
  * All rebase policy, CI budget policy, and ready-to-merge gating live here so the
  * skill stays a thin dispatcher and these rules co-evolve with the CLI data model.
  */
-export function buildCheckInstructions(report: ShepherdReport): string[] {
+export function buildCheckInstructions(
+  report: ShepherdReport,
+  opts?: { runtime?: AgentRuntime },
+): string[] {
+  const runtime = opts?.runtime ?? "claude";
   const { mergeStatus, checks, threads, comments, changesRequestedReviews, status } = report;
 
   const instructions: string[] = [];
@@ -68,7 +73,9 @@ export function buildCheckInstructions(report: ShepherdReport): string[] {
   // 5. Continuous monitoring pointer (suppressed only when truly ready to merge)
   if (!isReady) {
     instructions.push(
-      "This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.",
+      runtime === "codex"
+        ? `This is a one-shot check. For follow-up monitoring, run \`npx pr-shepherd iterate ${report.pr}\`.`
+        : "This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.",
     );
   }
 

--- a/src/reporters/check-instructions.test.mts
+++ b/src/reporters/check-instructions.test.mts
@@ -245,6 +245,14 @@ describe("buildCheckInstructions — monitoring pointer", () => {
     expect(steps[steps.length - 1]).toContain("/pr-shepherd:monitor");
   });
 
+  it("uses npx pr-shepherd iterate for Codex", () => {
+    const steps = buildCheckInstructions(makeReport({ status: "FAILING" }), {
+      runtime: "codex",
+    });
+    expect(steps[steps.length - 1]).toContain("npx pr-shepherd iterate");
+    expect(steps[steps.length - 1]).not.toContain("/pr-shepherd:monitor");
+  });
+
   it("omits the /pr-shepherd:monitor pointer when truly ready to merge (CLEAN + READY + no copilot)", () => {
     const steps = buildCheckInstructions(makeReport({ status: "READY" }));
     expect(steps.every((s) => !s.includes("/pr-shepherd:monitor"))).toBe(true);

--- a/src/reporters/json.mts
+++ b/src/reporters/json.mts
@@ -6,8 +6,9 @@
  */
 
 import type { ShepherdReport } from "../types.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
 import { buildCheckInstructions } from "./check-instructions.mts";
 
-export function formatJson(report: ShepherdReport): string {
-  return JSON.stringify({ ...report, instructions: buildCheckInstructions(report) }, null, 2);
+export function formatJson(report: ShepherdReport, opts?: { runtime?: AgentRuntime }): string {
+  return JSON.stringify({ ...report, instructions: buildCheckInstructions(report, opts) }, null, 2);
 }

--- a/src/reporters/json.test.mts
+++ b/src/reporters/json.test.mts
@@ -74,4 +74,11 @@ describe("formatJson", () => {
     const parsed = JSON.parse(output) as { instructions: string[] };
     expect(parsed.instructions.some((s) => s.includes("/pr-shepherd:monitor"))).toBe(true);
   });
+
+  it("instructions include reusable iterate command for Codex", () => {
+    const output = formatJson(makeReport({ status: "FAILING" }), { runtime: "codex" });
+    const parsed = JSON.parse(output) as { instructions: string[] };
+    expect(parsed.instructions.some((s) => s.includes("npx pr-shepherd iterate"))).toBe(true);
+    expect(parsed.instructions.every((s) => !s.includes("/pr-shepherd:monitor"))).toBe(true);
+  });
 });

--- a/src/reporters/text.mts
+++ b/src/reporters/text.mts
@@ -1,5 +1,6 @@
 import type { ShepherdReport, TriagedCheck } from "../types.mts";
 import { buildCheckInstructions } from "./check-instructions.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
 import {
   renderThreadBullet,
   renderCommentBullet,
@@ -8,7 +9,7 @@ import {
 } from "../cli/list-formatters.mts";
 import { joinSections } from "../util/markdown.mts";
 
-export function formatText(report: ShepherdReport): string {
+export function formatText(report: ShepherdReport, opts?: { runtime?: AgentRuntime }): string {
   const header = [
     `# PR #${report.pr} [CHECK] — ${report.repo}`,
     `Status: ${report.status}`,
@@ -161,7 +162,7 @@ export function formatText(report: ShepherdReport): string {
   const summaryLine = counts.join(", ") || "0 actionable — all threads resolved/minimized";
   const summarySection = `## Summary\n\n${summaryLine}`;
 
-  const instructions = buildCheckInstructions(report);
+  const instructions = buildCheckInstructions(report, opts);
   const instructionsSection = `## Instructions\n\n${instructions.map((step, i) => `${i + 1}. ${step}`).join("\n")}`;
 
   return joinSections([

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -432,6 +432,12 @@ describe("formatText — ## Instructions section", () => {
     const out = formatText(makeReport({ status: "FAILING" }));
     expect(out).toContain("/pr-shepherd:monitor");
   });
+
+  it("uses reusable iterate command for Codex", () => {
+    const out = formatText(makeReport({ status: "FAILING" }), { runtime: "codex" });
+    expect(out).toContain("npx pr-shepherd iterate");
+    expect(out).not.toContain("/pr-shepherd:monitor");
+  });
 });
 
 describe("formatText — baseBranch, reviewSummaries, approvedReviews", () => {


### PR DESCRIPTION
## Summary

Add agent-aware monitor and iterate output so pr-shepherd keeps Claude `/loop` behavior by default while emitting Codex-compatible one-shot instructions when run from Codex.

## Changes

- Detect Codex via `AGENT=codex` or current Codex CLI `CODEX_CI=1`.
- Emit reusable `/pr-shepherd:monitor <PR>` guidance for Codex monitor output instead of `/loop`/Cron instructions.
- Adapt iterate instructions for Codex so wait/cooldown/mark-ready/fix-code stop with rerun guidance, and cancel/escalate do not ask for `/loop cancel`.
- Keep JSON/text instruction parity and update docs/tests for the new behavior.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run build`