### PR TITLE
[codex] default pr-shepherd to iterate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example Workflow:
 
 `pr-shepherd` optimizes token management, rate limits, and agentic orchestration by moving **ALL** deterministic logic and prompts to code via a CLI tool, enshrining what would be a large skill or command prompt (of which the agent would inevitably make mistakes) into the code and returning a clear, actionable prompt.
 
-The CLI adapts monitor instructions to the calling agent. Claude Code gets `/loop` bootstrap instructions. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`; it gets a reusable `npx pr-shepherd iterate <PR>` command and one-shot iterate instructions because Codex does not provide `/loop` scheduling in this workflow.
+The CLI adapts monitor instructions to the calling agent. Claude Code gets `/loop` bootstrap instructions. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`; it gets a reusable `npx pr-shepherd <PR>` command and one-shot iterate instructions because Codex does not provide `/loop` scheduling in this workflow.
 
 At a high level, to start the monitor, the skill/command invokes a CLI that returns a prompt to be ingested by the agent _(schematic — paraphrased for brevity; actual output is more detailed)_:
 
@@ -42,7 +42,7 @@ Loop args: `4m`
 after completing the actions below. The cron job handles the next fire.
 
 Run in a single Bash call:
-  npx pr-shepherd iterate 123
+  npx pr-shepherd 123
 
 …(self-dedup guidance, error-handling instructions)…
 
@@ -52,10 +52,10 @@ Run in a single Bash call:
 2. Otherwise, invoke the /loop skill with Loop args and the full ## Loop prompt body.
 ```
 
-Each iteration calls `npx pr-shepherd iterate <PR>`, which provides actionable feedback directly to the agent:
+Each iteration calls `npx pr-shepherd <PR>`, which provides actionable feedback directly to the agent:
 
 ```
-> npx pr-shepherd iterate 123
+> npx pr-shepherd 123
 
 # PR #123 [FIX_CODE]
 
@@ -127,7 +127,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. In Claude Code, `/pr-shepherd:monitor` uses `/loop` and continues working when your rate limit window is reset. In Codex, rerun the reusable `npx pr-shepherd iterate <PR>` command when you want another check.
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. In Claude Code, `/pr-shepherd:monitor` uses `/loop` and continues working when your rate limit window is reset. In Codex, rerun the reusable `npx pr-shepherd <PR>` command when you want another check.
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 - Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
@@ -146,7 +146,7 @@ Recommendations:
 
 In Claude Code, creates a cron loop that fires every 4 minutes, checks CI and review comments, fixes issues, and marks the PR ready for review when clean. The loop cancels automatically when the PR is merged or closed.
 
-In Codex, run `npx pr-shepherd monitor <PR>` once to emit the one-shot prompt, then follow that prompt. Its reusable follow-up command is `npx pr-shepherd iterate <PR>`.
+In Codex, run `npx pr-shepherd monitor <PR>` once to emit the one-shot prompt, then follow that prompt. Its reusable follow-up command is `npx pr-shepherd <PR>`.
 
 Claude Code:
 
@@ -162,8 +162,9 @@ Codex:
 ```sh
 npx pr-shepherd monitor                  # bootstrap from current branch, then follow its instructions
 npx pr-shepherd monitor 42               # bootstrap PR #42, then follow its instructions
-npx pr-shepherd iterate 42               # subsequent one-shot check/action tick
-npx pr-shepherd iterate 42 --ready-delay 15m
+npx pr-shepherd 42                       # subsequent one-shot check/action tick
+npx pr-shepherd 42 --ready-delay 15m
+npx pr-shepherd iterate 42               # legacy-compatible spelling
 ```
 
 ### Check a PR
@@ -244,10 +245,10 @@ npx pr-shepherd monitor 42
 Follow the output's `## Instructions`. The monitor bootstrap runs one tick and prints the reusable follow-up command, usually:
 
 ```bash
-npx pr-shepherd iterate 42
+npx pr-shepherd 42
 ```
 
-Rerun that `iterate` command whenever you want Codex to check the PR again. There is no background `/loop` scheduler in Codex.
+Rerun that command whenever you want Codex to check the PR again. `npx pr-shepherd iterate 42` remains supported for existing workflows. There is no background `/loop` scheduler in Codex.
 
 ### Without the plugin
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -2,11 +2,11 @@
 
 [← README](../README.md)
 
-Each iteration of `shepherd iterate` returns exactly one action. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
+Each default `pr-shepherd` invocation returns exactly one iterate action. The legacy `pr-shepherd iterate` spelling is still supported. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
 
-The default output format is Markdown — what you see when running `npx pr-shepherd iterate <PR>`, and what the monitor SKILL reads each cron tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
+The default output format is Markdown — what you see when running `npx pr-shepherd <PR>`, and what the monitor SKILL reads each cron tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
-Instruction wording is agent-aware. Claude-compatible output refers to the next cron fire and `/loop cancel`. Codex output is selected with `AGENT=codex` or `CODEX_CI=1`; it replaces those lines with reusable-prompt guidance such as rerunning `npx pr-shepherd iterate <PR>` later. The action data and section structure are otherwise the same.
+Instruction wording is agent-aware. Claude-compatible output refers to the next cron fire and `/loop cancel`. Codex output is selected with `AGENT=codex` or `CODEX_CI=1`; it replaces those lines with reusable-prompt guidance such as rerunning `npx pr-shepherd <PR>` later. The action data and section structure are otherwise the same.
 
 Pass `--verbose` to get more debug state. In JSON mode, the output starts from the full `IterateResult` shape (all fields, including `baseBranch`, `checks`, `shouldCancel`) and then applies the same agent-aware instruction projection as lean JSON: non-`fix_code` actions get a top-level `instructions` array, and Codex output may rewrite `fix.instructions` and simple-action instructions. In Markdown mode, `--verbose` restores the full header summary line (all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, `shouldCancel` always shown, and `[COOLDOWN]` no longer suppresses the base/summary block) — but Markdown is structurally different from JSON and does not guarantee field-for-field parity (array fields like `baseBranch` or `checks` are not added to Markdown for actions that do not normally render them). Lean mode is the default because most fields are `false`/`0`/`[]` on a typical healthy tick and add context noise without value.
 
@@ -70,7 +70,7 @@ SKIP: CI still starting — waiting for first check to appear
 1. End this iteration — the next cron fire will recheck once CI starts reporting.
 ```
 
-Codex variant: `End this iteration — rerun \`npx pr-shepherd iterate 42\` after CI starts reporting.`
+Codex variant: `End this iteration — rerun \`npx pr-shepherd 42\` after CI starts reporting.`
 
 `status`, `merge`, `state`, and `repo` are not emitted in default mode — they carry UNKNOWN/empty placeholders because the early return happens before any GitHub sweep. Pass `--verbose` to see all fields.
 
@@ -103,9 +103,9 @@ WAIT: 3 passing, 2 in-progress — 120s until auto-cancel
 1. End this iteration — the next cron fire will recheck.
 ```
 
-Codex variant: the body omits `until auto-cancel`, and the instruction is `End this iteration — rerun \`npx pr-shepherd iterate 42\` later to recheck.`
+Codex variant: the body omits `until auto-cancel`, and the instruction is `End this iteration — rerun \`npx pr-shepherd 42\` later to recheck.`
 
-When the current command includes a ready-delay override, Codex rerun guidance preserves it: `npx pr-shepherd iterate 42 --ready-delay 15m`.
+When the current command includes a ready-delay override, Codex rerun guidance preserves it: `npx pr-shepherd 42 --ready-delay 15m`.
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
@@ -138,7 +138,7 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review — end this iteration.
 ```
 
-Codex variant: the same instruction with an added reminder to rerun `npx pr-shepherd iterate 42` later to recheck.
+Codex variant: the same instruction with an added reminder to rerun `npx pr-shepherd 42` later to recheck.
 
 **What the monitor does:** Follow `## Instructions` — end the iteration and continue monitoring on the next cron fire.
 
@@ -314,7 +314,7 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 - A first-look summaries step is appended when `firstLookSummaries` is non-empty — it tells the agent these summaries are being seen for the first time and their IDs are already in the resolve command's `--minimize-comment-ids`.
 - An edited-items step is appended when `editedSummaries` is non-empty or any first-look thread/comment carries `edited: true` — it tells the agent to read the updated body but **not** include these IDs in any mutation flag.
 - The final "iteration" step has three variants: `Stop this iteration — CI needs time to run on the new push before the next tick.` when a push occurred; `Stop this iteration before the next tick.` when only GitHub mutations were made (no push); `End this iteration.` when no push or mutations occurred.
-- In Codex output, the two "next tick" variants are rewritten to say to rerun `npx pr-shepherd iterate <PR>` later.
+- In Codex output, the two "next tick" variants are rewritten to say to rerun `npx pr-shepherd <PR>` later.
 
 The JSON payload exposes the same data under `fix.{threads, actionableComments, reviewSummaryIds, firstLookSummaries, editedSummaries, surfacedApprovals, checks, changesRequestedReviews, resolveCommand, instructions, mode, firstLookThreads, firstLookComments, inProgressRunIds}` — where `fix.mode === "rebase-and-push"` is the type discriminator — plus top-level `baseBranch` (on `IterateResultBase`, not under `fix`) and `cancelled`. `fix.inProgressRunIds` contains the GitHub Actions run IDs the agent must cancel before applying fixes (mirrors `## In-progress runs` in the Markdown output); it is an empty array when there are no in-progress GitHub Actions run IDs to cancel (external status checks or already-cancelled runs are excluded) or when no push is expected this iteration. `reviewSummaryIds` contains the IDs routed to `--minimize-comment-ids` for review-level minimization: this includes review summaries (both first-look and already-seen), and may also include APPROVED review IDs when approval minimization is enabled. `firstLookSummaries` carries the full `Review` objects for bodies seen this iteration for the first time. `editedSummaries` carries the full `Review` objects for summaries whose body changed since last seen — these IDs are **not** in `reviewSummaryIds`. Both `firstLookSummaries` and `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `editedSummaries` and `surfacedApprovals` are informational only. In lean JSON mode, `fix.*` arrays that are empty are omitted; `cancelled` is omitted when empty. Pass `--verbose` to include all fields. `firstLookThreads` and `firstLookComments` are informational — they carry `firstLookStatus`, optional `autoResolved` (outdated only), and optional `edited` (true when body changed since first acknowledgement) fields but must not be routed to resolve mutations.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -4,10 +4,11 @@
 
 ```
 pr-shepherd -v|--version
+pr-shepherd [PR] [--verbose] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd check [PR]
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
-pr-shepherd iterate [PR] [--verbose] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
+pr-shepherd iterate [PR] [--verbose] [--cooldown-seconds N] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # legacy-compatible spelling
 pr-shepherd monitor [PR]
 pr-shepherd status PR1 [PR2 …]
 pr-shepherd log-file
@@ -70,7 +71,7 @@ Base: main
 3. This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.
 ```
 
-In Codex output, the final instruction points to the reusable iterate command instead: `npx pr-shepherd iterate <PR>`.
+In Codex output, the final instruction points to the reusable default iterate command instead: `npx pr-shepherd <PR>`.
 
 ### pr-shepherd resolve [PR]
 
@@ -205,13 +206,14 @@ git push
 
 If a patch fails to apply (drift since the suggestion was written), apply the fix manually using the line range shown in the output.
 
-### pr-shepherd iterate [PR]
+### pr-shepherd [PR]
 
-One monitor tick: classifies current PR state and emits a single action. Used by the cron loop — the monitor skill calls this on each tick and follows the `## Instructions` section verbatim. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
+One monitor tick: classifies current PR state and emits a single action. Used by the cron loop — the monitor skill calls this on each tick and follows the `## Instructions` section verbatim. `pr-shepherd iterate [PR]` remains supported for backwards compatibility. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
 
 ```sh
-pr-shepherd iterate 42
-pr-shepherd iterate 42 --ready-delay 15m  # override ready-delay for this run
+pr-shepherd 42
+pr-shepherd 42 --ready-delay 15m          # override ready-delay for this run
+pr-shepherd iterate 42                    # legacy-compatible spelling
 ```
 
 **Flags:**
@@ -240,7 +242,7 @@ WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
 1. End this iteration — the next cron fire will recheck.
 ```
 
-When Codex output is selected, the `[WAIT]` body omits the `until auto-cancel` countdown and the instruction points to the reusable one-shot command instead. For example: ``End this iteration — rerun `npx pr-shepherd iterate 42` later to recheck.`` If the current command used `--ready-delay`, the rerun command includes the same flag.
+When Codex output is selected, the `[WAIT]` body omits the `until auto-cancel` countdown and the instruction points to the reusable one-shot command instead. For example: ``End this iteration — rerun `npx pr-shepherd 42` later to recheck.`` If the current command used `--ready-delay`, the rerun command includes the same flag.
 
 Example for `[FIX_CODE]` (richest action):
 
@@ -299,7 +301,7 @@ Exit codes: `0` wait/cooldown/mark_ready · `1` fix_code · `2` cancel · `3` es
 
 Bootstrap command used by the Claude `/pr-shepherd:monitor` skill and by Codex directly. Reads `watch.interval` from config and emits the monitor prompt body plus a short `Loop args` line (the interval).
 
-By default, output targets Claude Code and tells the monitor skill how to reuse an existing `/loop` or start a new one. When Codex is detected (`AGENT=codex` or `CODEX_CI=1`), output omits Cron and `/loop` instructions and instead tells Codex to run one `iterate` tick, then rerun the reusable `npx pr-shepherd iterate <PR>` prompt later.
+By default, output targets Claude Code and tells the monitor skill how to reuse an existing `/loop` or start a new one. When Codex is detected (`AGENT=codex` or `CODEX_CI=1`), output omits Cron and `/loop` instructions and instead tells Codex to run one iterate tick, then rerun the reusable `npx pr-shepherd <PR>` prompt later.
 
 ```sh
 npx pr-shepherd monitor        # infer PR from current branch
@@ -327,7 +329,7 @@ Loop args: `4m`
 2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
 
-Codex output includes the same PR, tag, interval, prompt body, and `## Instructions` shape, but the instructions say to run the loop prompt once and rerun `npx pr-shepherd iterate 42` later instead of creating or cancelling a `/loop`.
+Codex output includes the same PR, tag, interval, prompt body, and `## Instructions` shape, but the instructions say to run the loop prompt once and rerun `npx pr-shepherd 42` later instead of creating or cancelling a `/loop`.
 
 The loop interval comes from `watch.interval` in `.pr-shepherdrc.yml` or the built-in default. Use `--format=json` to inspect the raw values programmatically.
 

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -56,6 +56,6 @@ For `monitor` and `resolve` custom commands, do **not** copy the
 frontmatter that is not valid for `.claude/commands/` files. Instead, create
 `.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
 using the same command-file structure as the `pr-check` example above, with
-the CLI invocation changed to `npx pr-shepherd ...` or
+the CLI invocation changed to `npx pr-shepherd monitor ...` or
 `npx pr-shepherd resolve ...`. To drive the CLI without Claude at all, see
 [cli-usage.md](cli-usage.md).

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -56,6 +56,6 @@ For `monitor` and `resolve` custom commands, do **not** copy the
 frontmatter that is not valid for `.claude/commands/` files. Instead, create
 `.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
 using the same command-file structure as the `pr-check` example above, with
-the CLI invocation changed to `npx pr-shepherd iterate ...` or
+the CLI invocation changed to `npx pr-shepherd ...` or
 `npx pr-shepherd resolve ...`. To drive the CLI without Claude at all, see
 [cli-usage.md](cli-usage.md).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,7 +15,7 @@
 **Fix:** Verify the fix is deployed. Check the iterate output:
 
 ```bash
-pr-shepherd iterate <PR> --format=json
+pr-shepherd <PR> --format=json
 ```
 
 Should return `{"action":"cancel","state":"MERGED",...}`.
@@ -33,7 +33,7 @@ If it still returns `wait`, check that `report.mergeStatus.state` is being set c
 **Fix:** Wait a minute and retry:
 
 ```bash
-pr-shepherd iterate <PR> --format=json
+pr-shepherd <PR> --format=json
 ```
 
 ---
@@ -92,7 +92,7 @@ If `state` is `OPEN` and both `mergeable` and `mergeStateStatus` are `UNKNOWN` a
 To replay a single iteration with full output:
 
 ```bash
-pr-shepherd iterate <PR> --format=json
+pr-shepherd <PR> --format=json
 ```
 
 For human-readable output:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -18,13 +18,13 @@ If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking 
 export AGENT=codex
 ```
 
-Run `npx pr-shepherd monitor <PR>` once to bootstrap the workflow. Follow the output's `## Instructions`, then rerun the emitted `npx pr-shepherd iterate <PR>` command whenever you want another one-shot check. Codex does not provide the Claude `/loop` scheduler in this workflow.
+Run `npx pr-shepherd monitor <PR>` once to bootstrap the workflow. Follow the output's `## Instructions`, then rerun the emitted `npx pr-shepherd <PR>` command whenever you want another one-shot check. Codex does not provide the Claude `/loop` scheduler in this workflow.
 
 ## `/pr-shepherd:monitor`
 
-Start continuous CI monitoring for a PR in Claude Code. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd iterate`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
+Start continuous CI monitoring for a PR in Claude Code. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd <PR>`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
 
-In Codex, run the CLI directly instead of the Claude slash command. `npx pr-shepherd monitor <PR>` emits one-shot iterate instructions instead of `/loop` setup. After the bootstrap step, rerun the emitted `npx pr-shepherd iterate <PR>` command later to check again.
+In Codex, run the CLI directly instead of the Claude slash command. `npx pr-shepherd monitor <PR>` emits one-shot iterate instructions instead of `/loop` setup. After the bootstrap step, rerun the emitted `npx pr-shepherd <PR>` command later to check again.
 
 Claude Code:
 
@@ -38,7 +38,7 @@ Codex:
 ```sh
 npx pr-shepherd monitor        # bootstrap from current branch, then follow its instructions
 npx pr-shepherd monitor 42     # bootstrap PR #42, then follow its instructions
-npx pr-shepherd iterate 42     # subsequent one-shot tick
+npx pr-shepherd 42             # subsequent one-shot tick
 ```
 
 The polling interval and ready-delay come from `watch.interval` and `watch.readyDelayMinutes` in `.pr-shepherdrc.yml` (defaults: 4 minutes and 10 minutes). The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-minute TTL).

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -6,7 +6,7 @@
 
 The `/pr-shepherd:monitor <PR>` slash command starts a Claude Code cron loop that polls PR status at the configured interval (default `4m`, set via `watch.interval`). This document explains how all the pieces fit together.
 
-Codex does not provide `/loop` scheduling in this workflow. When `pr-shepherd` detects Codex (`AGENT=codex` or `CODEX_CI=1`), `monitor` output tells Codex to run one `iterate` tick and rerun the reusable `npx pr-shepherd iterate <PR>` prompt later.
+Codex does not provide `/loop` scheduling in this workflow. When `pr-shepherd` detects Codex (`AGENT=codex` or `CODEX_CI=1`), `monitor` output tells Codex to run one iterate tick and rerun the reusable `npx pr-shepherd <PR>` prompt later.
 
 ## Lifecycle
 
@@ -20,10 +20,10 @@ Claude Code lifecycle:
    - `/loop` schedules a tick at the interval from config (default `4m`, configurable via `watch.interval`).
    - The loop runs until the `cancel` action fires or the user cancels manually.
 
-3. **Each tick runs `shepherd iterate`**
+3. **Each tick runs `pr-shepherd`**
    - The cron prompt runs (single Bash invocation):
      ```bash
-     pr-shepherd iterate <PR>
+     pr-shepherd <PR>
      ```
    - Exit codes 0, 1, 2, and 3 are all valid (not errors).
 

--- a/src/cli-parser.iterate-codex.mock.test.mts
+++ b/src/cli-parser.iterate-codex.mock.test.mts
@@ -73,7 +73,7 @@ describe("main — iterate Codex fix_code output", () => {
     await main(["node", "shepherd", "iterate", "42", "--ready-delay", "15m"]);
     const out = getStdout();
     expect(out).toContain(
-      "2. Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd iterate 42 --ready-delay 15m` later to recheck.",
+      "2. Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd 42 --ready-delay 15m` later to recheck.",
     );
     expect(out).not.toContain("before the next tick");
   });
@@ -90,7 +90,7 @@ describe("main — iterate Codex fix_code output", () => {
     await main(["node", "shepherd", "iterate", "42", "--format=json", "--ready-delay", "2h"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.fix.instructions).toEqual([
-      "Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd iterate 42 --ready-delay 2h` later to recheck.",
+      "Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd 42 --ready-delay 2h` later to recheck.",
     ]);
   });
 
@@ -104,7 +104,7 @@ describe("main — iterate Codex fix_code output", () => {
     await main(["node", "shepherd", "iterate", "42", "--format=json"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.fix.instructions).toEqual([
-      "Stop this iteration. Rerun `npx pr-shepherd iterate 42` later to recheck.",
+      "Stop this iteration. Rerun `npx pr-shepherd 42` later to recheck.",
     ]);
   });
 });

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -68,6 +68,29 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("main — iterate", () => {
+  it("defaults to iterate when no subcommand is given", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+    await main(["node", "shepherd"]);
+    expect(mockRunIterate).toHaveBeenCalledTimes(1);
+    expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: undefined }));
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("defaults to iterate when the first argument is a PR number", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+    await main(["node", "shepherd", "42", "--format=json"]);
+    expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 42 }));
+    expect(JSON.parse(getStdout().trimEnd()).pr).toBe(42);
+  });
+
+  it("defaults to iterate when the first argument is an iterate flag", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+    await main(["node", "shepherd", "--ready-delay", "15m"]);
+    expect(mockRunIterate).toHaveBeenCalledWith(
+      expect.objectContaining({ readyDelaySeconds: 15 * 60 }),
+    );
+  });
+
   it("exits with iterateActionToExitCode(fix_code)=1", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("fix_code"));
     await main(["node", "shepherd", "iterate", "42"]);
@@ -204,7 +227,7 @@ describe("main — iterate text format", () => {
       "WAIT: 6 passing, 1 in-progress — awaiting human review or branch protection",
     );
     expect(out).toContain(
-      "1. End this iteration — rerun `npx pr-shepherd iterate 42 --ready-delay 15m` later to recheck.",
+      "1. End this iteration — rerun `npx pr-shepherd 42 --ready-delay 15m` later to recheck.",
     );
     expect(out).not.toContain("next cron fire");
     expect(out).not.toContain("auto-cancel");
@@ -216,7 +239,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain(
-      "1. End this iteration — rerun `npx pr-shepherd iterate 42` after CI starts reporting.",
+      "1. End this iteration — rerun `npx pr-shepherd 42` after CI starts reporting.",
     );
     expect(out).not.toContain("next cron fire");
   });
@@ -227,7 +250,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain(
-      "1. The CLI already marked the PR ready for review — end this iteration. Rerun `npx pr-shepherd iterate 42` later to recheck.",
+      "1. The CLI already marked the PR ready for review — end this iteration. Rerun `npx pr-shepherd 42` later to recheck.",
     );
   });
 
@@ -274,7 +297,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42", "--format", "json"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.instructions).toEqual([
-      "End this iteration — rerun `npx pr-shepherd iterate 42` later to recheck.",
+      "End this iteration — rerun `npx pr-shepherd 42` later to recheck.",
     ]);
   });
 

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -104,6 +104,13 @@ describe("main — iterate", () => {
     expect(getStderr()).toContain("Unknown subcommand: --formt");
   });
 
+  it("rejects missing values for value-taking default iterate flags", async () => {
+    await main(["node", "shepherd", "--cooldown-seconds"]);
+    expect(process.exitCode).toBe(1);
+    expect(mockRunIterate).not.toHaveBeenCalled();
+    expect(getStderr()).toContain("Unknown subcommand: --cooldown-seconds");
+  });
+
   it("rejects extra positional arguments in default iterate form", async () => {
     await main(["node", "shepherd", "42", "resolve"]);
     expect(process.exitCode).toBe(1);

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -83,12 +83,32 @@ describe("main — iterate", () => {
     expect(JSON.parse(getStdout().trimEnd()).pr).toBe(42);
   });
 
+  it("defaults to iterate when the first argument is a PR URL", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+    await main(["node", "shepherd", "https://github.com/owner/repo/pull/42"]);
+    expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 42 }));
+  });
+
   it("defaults to iterate when the first argument is an iterate flag", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
     await main(["node", "shepherd", "--ready-delay", "15m"]);
     expect(mockRunIterate).toHaveBeenCalledWith(
       expect.objectContaining({ readyDelaySeconds: 15 * 60 }),
     );
+  });
+
+  it("rejects unknown flag-first default invocations", async () => {
+    await main(["node", "shepherd", "--formt", "json"]);
+    expect(process.exitCode).toBe(1);
+    expect(mockRunIterate).not.toHaveBeenCalled();
+    expect(getStderr()).toContain("Unknown subcommand: --formt");
+  });
+
+  it("rejects extra positional arguments in default iterate form", async () => {
+    await main(["node", "shepherd", "42", "resolve"]);
+    expect(process.exitCode).toBe(1);
+    expect(mockRunIterate).not.toHaveBeenCalled();
+    expect(getStderr()).toContain("Unknown subcommand: resolve");
   });
 
   it("exits with iterateActionToExitCode(fix_code)=1", async () => {

--- a/src/cli-parser.monitor.mock.test.mts
+++ b/src/cli-parser.monitor.mock.test.mts
@@ -47,7 +47,7 @@ const MONITOR_RESULT = {
   prNumber: 42,
   loopTag: "#pr-shepherd-loop:pr=42:",
   loopArgs: "4m",
-  reusableCommand: "npx pr-shepherd iterate 42",
+  reusableCommand: "npx pr-shepherd 42",
   loopPrompt: "#pr-shepherd-loop:pr=42:\nBODY",
 };
 
@@ -86,12 +86,12 @@ describe("main — monitor", () => {
     mockRunMonitor.mockResolvedValue({
       ...MONITOR_RESULT,
       loopPrompt:
-        "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — Codex recurrence rules:**\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42",
+        "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — Codex recurrence rules:**\n\nRun in a single Bash call:\n  npx pr-shepherd 42",
     });
     await main(["node", "shepherd", "monitor", "42"]);
     expect(mockRunMonitor).toHaveBeenCalledWith(expect.objectContaining({ runtime: "codex" }));
     const out = getStdout();
-    expect(out).toContain("Reusable command: `npx pr-shepherd iterate 42`");
+    expect(out).toContain("Reusable command: `npx pr-shepherd 42`");
     expect(out).toContain("Codex does not provide `/loop` scheduling");
     expect(out).not.toContain("Invoke the `/loop` skill");
   });
@@ -113,7 +113,7 @@ describe("main — monitor", () => {
     process.env.CODEX_CI = "1";
     await main(["node", "shepherd", "monitor", "42", "--format=json"]);
     const parsed = JSON.parse(getStdout().trim());
-    expect(parsed.reusableCommand).toBe("npx pr-shepherd iterate 42");
+    expect(parsed.reusableCommand).toBe("npx pr-shepherd 42");
     expect(parsed.instructions.join("\n")).toContain("Codex does not provide `/loop` scheduling");
   });
 

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -3,6 +3,9 @@
  *
  * Usage:
  *   pr-shepherd --version
+ *   pr-shepherd [PR] [--format text|json] [--cooldown-seconds N] [--ready-delay Nm]
+ *                  [--stall-timeout <duration>] [--no-auto-mark-ready]
+ *                  [--no-auto-cancel-actionable]
  *   pr-shepherd check [PR] [--format text|json]
  *   pr-shepherd resolve [PR] [--fetch] [--resolve-thread-ids A,B] [--minimize-comment-ids X,Y]
  *                            [--dismiss-review-ids Q] [--message MSG] [--require-sha SHA]
@@ -58,6 +61,11 @@ export async function main(argv: string[]): Promise<void> {
   // Initialize the per-worktree log and install a stdout tee.
   await setupLog(argv);
 
+  if (isDefaultIterateInvocation(subcommand)) {
+    await handleIterate(args);
+    return;
+  }
+
   switch (subcommand) {
     case "check":
       await handleCheck(args.slice(1));
@@ -86,6 +94,10 @@ export async function main(argv: string[]): Promise<void> {
       process.exitCode = 1;
       return;
   }
+}
+
+function isDefaultIterateInvocation(subcommand: string | undefined): boolean {
+  return subcommand === undefined || subcommand.startsWith("--") || /^\d+$/.test(subcommand);
 }
 
 function readVersion(): string {

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -27,6 +27,7 @@ import { runLogFile } from "./commands/log-file.mts";
 import { formatJson } from "./reporters/json.mts";
 import { formatText } from "./reporters/text.mts";
 import { parseCommonArgs, getFlag, hasFlag, parseList } from "./cli/args.mts";
+import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./cli/default-iterate.mts";
 import { statusToExitCode } from "./cli/exit-codes.mts";
 import { formatFetchResult, formatMutateResult } from "./cli/formatters.mts";
 import {
@@ -62,6 +63,7 @@ export async function main(argv: string[]): Promise<void> {
   await setupLog(argv);
 
   if (isDefaultIterateInvocation(subcommand)) {
+    if (!validateDefaultIterateArgs(args)) return;
     await handleIterate(args);
     return;
   }
@@ -94,10 +96,6 @@ export async function main(argv: string[]): Promise<void> {
       process.exitCode = 1;
       return;
   }
-}
-
-function isDefaultIterateInvocation(subcommand: string | undefined): boolean {
-  return subcommand === undefined || subcommand.startsWith("--") || /^\d+$/.test(subcommand);
 }
 
 function readVersion(): string {

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -115,9 +115,9 @@ export function parseCommonArgs(args: string[]): ParsedArgs {
   }
 
   const prIndex = args.findIndex(
-    (a, index) => !skipForPrDetect.has(index) && !a.startsWith("--") && /^\d+$/.test(a),
+    (a, index) => !skipForPrDetect.has(index) && !a.startsWith("--") && parsePrNumber(a) !== null,
   );
-  const prNumber = prIndex !== -1 ? parseInt(args[prIndex]!, 10) : undefined;
+  const prNumber = prIndex !== -1 ? parsePrNumber(args[prIndex]!)! : undefined;
 
   // Remove consumed global-flag indices (and the PR number itself) from extra.
   if (prIndex !== -1) {
@@ -131,6 +131,15 @@ export function parseCommonArgs(args: string[]): ParsedArgs {
     global: { format, verbose },
     extra,
   };
+}
+
+export function parsePrNumber(value: string): number | null {
+  if (/^\d+$/.test(value)) return parseInt(value, 10);
+
+  const match = value.match(/^https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:[/?#].*)?$/);
+  if (match) return parseInt(match[1]!, 10);
+
+  return null;
 }
 
 /** Get the value of a flag like `--flag value` or `--flag=value`. */

--- a/src/cli/args.test.mts
+++ b/src/cli/args.test.mts
@@ -138,6 +138,11 @@ describe("parseCommonArgs — PR number detection", () => {
     expect(prNumber).toBe(42);
   });
 
+  it("extracts PR number from a GitHub pull request URL", () => {
+    const { prNumber } = parseCommonArgs(["https://github.com/owner/repo/pull/42"]);
+    expect(prNumber).toBe(42);
+  });
+
   it("does NOT treat unknown flag values as PR numbers", () => {
     const { prNumber } = parseCommonArgs(["--last-push-time", "100", "42"]);
     expect(prNumber).toBe(42);

--- a/src/cli/default-iterate.mts
+++ b/src/cli/default-iterate.mts
@@ -1,0 +1,65 @@
+import { parsePrNumber } from "./args.mts";
+
+const DEFAULT_ITERATE_FLAGS_WITH_VALUES = new Set([
+  "--format",
+  "--ready-delay",
+  "--cooldown-seconds",
+  "--stall-timeout",
+]);
+
+const DEFAULT_ITERATE_BOOLEAN_FLAGS = new Set([
+  "--verbose",
+  "--no-auto-mark-ready",
+  "--no-auto-cancel-actionable",
+]);
+
+export function isDefaultIterateInvocation(subcommand: string | undefined): boolean {
+  return (
+    subcommand === undefined ||
+    parsePrNumber(subcommand) !== null ||
+    isDefaultIterateFlag(subcommand)
+  );
+}
+
+export function validateDefaultIterateArgs(args: string[]): boolean {
+  let sawPr = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+
+    if (DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(arg)) {
+      if (i + 1 < args.length && !args[i + 1]!.startsWith("--")) i += 1;
+      continue;
+    }
+
+    const inlineFlag = arg.split("=", 1)[0]!;
+    if (DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(inlineFlag)) continue;
+
+    if (DEFAULT_ITERATE_BOOLEAN_FLAGS.has(arg)) continue;
+
+    if (parsePrNumber(arg) !== null && !sawPr) {
+      sawPr = true;
+      continue;
+    }
+
+    writeDefaultUsageError(arg);
+    return false;
+  }
+
+  return true;
+}
+
+function isDefaultIterateFlag(arg: string): boolean {
+  const name = arg.split("=", 1)[0]!;
+  return DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(name) || DEFAULT_ITERATE_BOOLEAN_FLAGS.has(arg);
+}
+
+function writeDefaultUsageError(arg: string): void {
+  process.stderr.write(`Unknown subcommand: ${arg}\n`);
+  process.stderr.write(
+    "Usage: pr-shepherd [PR] [options]\n" +
+      "       pr-shepherd <check|resolve|commit-suggestion|iterate|monitor|status|log-file> [options]\n" +
+      "       pr-shepherd --version | -v\n",
+  );
+  process.exitCode = 1;
+}

--- a/src/cli/default-iterate.mts
+++ b/src/cli/default-iterate.mts
@@ -28,7 +28,11 @@ export function validateDefaultIterateArgs(args: string[]): boolean {
     const arg = args[i]!;
 
     if (DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(arg)) {
-      if (i + 1 < args.length && !args[i + 1]!.startsWith("--")) i += 1;
+      if (i + 1 >= args.length || args[i + 1]!.startsWith("--")) {
+        writeDefaultUsageError(arg);
+        return false;
+      }
+      i += 1;
       continue;
     }
 

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -68,7 +68,7 @@ export async function handleIterate(args: string[]): Promise<void> {
 
   const readyDelayStr = getFlag(extra, "--ready-delay");
   const readyDelaySuffix = validateDurationFlag(
-    "pr-shepherd iterate",
+    "pr-shepherd",
     "--ready-delay",
     readyDelayStr,
     hasFlag(extra, "--ready-delay"),

--- a/src/cli/iterate-instructions.mts
+++ b/src/cli/iterate-instructions.mts
@@ -77,7 +77,7 @@ export function adaptIterateLog(log: string, runtime: AgentRuntime): string {
 
 export function buildCodexIterateCommand(pr: number, readyDelaySuffix?: string): string {
   const suffix = readyDelaySuffix?.trim();
-  return `npx pr-shepherd iterate ${pr}${suffix ? ` --ready-delay ${suffix}` : ""}`;
+  return `npx pr-shepherd ${pr}${suffix ? ` --ready-delay ${suffix}` : ""}`;
 }
 
 export function numberInstructions(instructions: string[]): string {

--- a/src/commands/__snapshots__/monitor.mock.test.mts.snap
+++ b/src/commands/__snapshots__/monitor.mock.test.mts.snap
@@ -17,7 +17,7 @@ Loop args: \`4m\`
 **Self-dedup:** Run \`CronList\`. If more than one job contains \`#pr-shepherd-loop:pr=42:\`, keep the lowest job ID and \`CronDelete\` the rest (ignore errors — a concurrent runner may have already deleted them).
 
 Run in a single Bash call:
-  npx pr-shepherd iterate 42
+  npx pr-shepherd 42
 
 Exit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with \`# PR #42 [\`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.
 

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -27,15 +27,15 @@ describe("runMonitor", () => {
     expect(result.loopTag).toBe("#pr-shepherd-loop:pr=99:");
     expect(result.loopArgs).toBe("4m");
     expect(result.loopPrompt).toContain("#pr-shepherd-loop:pr=99:");
-    expect(result.loopPrompt).toContain("npx pr-shepherd iterate 99");
-    expect(result.reusableCommand).toBe("npx pr-shepherd iterate 99");
+    expect(result.loopPrompt).toContain("npx pr-shepherd 99");
+    expect(result.reusableCommand).toBe("npx pr-shepherd 99");
     // loopArgs is a short one-liner — not the combined invocation string
     expect(result.loopArgs).not.toContain("npx pr-shepherd");
   });
 
   it("loopPrompt body is not doubled — key phrases appear exactly once", async () => {
     const result = await runMonitor({ format: "text", prNumber: 42 });
-    expect(result.loopPrompt.split("npx pr-shepherd iterate 42").length - 1).toBe(1);
+    expect(result.loopPrompt.split("npx pr-shepherd 42").length - 1).toBe(1);
     expect(result.loopPrompt.split("Self-dedup:").length - 1).toBe(1);
   });
 
@@ -73,14 +73,14 @@ describe("runMonitor", () => {
       readyDelaySuffix: "15m",
       runtime: "codex",
     });
-    expect(result.reusableCommand).toBe("npx pr-shepherd iterate 42 --ready-delay 15m");
-    expect(result.loopPrompt).toContain("npx pr-shepherd iterate 42 --ready-delay 15m");
+    expect(result.reusableCommand).toBe("npx pr-shepherd 42 --ready-delay 15m");
+    expect(result.loopPrompt).toContain("npx pr-shepherd 42 --ready-delay 15m");
   });
 
   it("builds a Codex prompt without /loop or Cron instructions", async () => {
     const result = await runMonitor({ format: "text", prNumber: 42, runtime: "codex" });
     expect(result.loopPrompt).toContain("Codex recurrence rules");
-    expect(result.loopPrompt).toContain("npx pr-shepherd iterate 42");
+    expect(result.loopPrompt).toContain("npx pr-shepherd 42");
     expect(result.loopPrompt).not.toContain("CronList");
     expect(result.loopPrompt).not.toContain("CronDelete");
     expect(result.loopPrompt).not.toContain("ScheduleWakeup");
@@ -116,9 +116,9 @@ describe("formatMonitorResult", () => {
     prNumber: 42,
     loopTag: "#pr-shepherd-loop:pr=42:",
     loopArgs: "4m",
-    reusableCommand: "npx pr-shepherd iterate 42",
+    reusableCommand: "npx pr-shepherd 42",
     loopPrompt:
-      "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — recurrence rules:**\n- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.\n- End the turn cleanly after completing the actions below. The cron job handles the next fire.\n\n**Self-dedup:** Run `CronList`. If more than one job contains `#pr-shepherd-loop:pr=42:`, keep the lowest job ID and `CronDelete` the rest (ignore errors — a concurrent runner may have already deleted them).\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42\n\nExit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #42 [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.\n\nThe output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
+      "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — recurrence rules:**\n- **Do NOT call `ScheduleWakeup` or `/loop`.** This session is fired by a recurring cron job. Either call creates a duplicate runner, causing concurrent git operations and `.git/index.lock` collisions.\n- End the turn cleanly after completing the actions below. The cron job handles the next fire.\n\n**Self-dedup:** Run `CronList`. If more than one job contains `#pr-shepherd-loop:pr=42:`, keep the lowest job ID and `CronDelete` the rest (ignore errors — a concurrent runner may have already deleted them).\n\nRun in a single Bash call:\n  npx pr-shepherd 42\n\nExit codes 0–3 are all valid. If the command crashes (non-zero exit, no markdown output starting with `# PR #42 [`), log the first line of stderr and continue — do not cancel the loop. The next cron fire will retry.\n\nThe output is Markdown. The first line is an H1 heading of the form `# PR #<N> [<ACTION>]`. Every output ends with a `## Instructions` section — follow those numbered steps exactly.",
   };
 
   it("emits MONITOR heading, loop tag, loop args, loop prompt, and instructions", () => {
@@ -134,10 +134,10 @@ describe("formatMonitorResult", () => {
     const codexFixture: MonitorResult = {
       ...fixture,
       loopPrompt:
-        "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — Codex recurrence rules:**\n\nRun in a single Bash call:\n  npx pr-shepherd iterate 42",
+        "#pr-shepherd-loop:pr=42:\n\n**IMPORTANT — Codex recurrence rules:**\n\nRun in a single Bash call:\n  npx pr-shepherd 42",
     };
     const md = formatMonitorResult(codexFixture, { runtime: "codex" });
-    expect(md).toContain("Reusable command: `npx pr-shepherd iterate 42`");
+    expect(md).toContain("Reusable command: `npx pr-shepherd 42`");
     expect(md).toContain("Run the `## Loop prompt` body once inline now.");
     expect(md).toContain("Codex does not provide `/loop` scheduling");
     expect(md).not.toContain("Invoke the `/loop` skill");
@@ -151,7 +151,7 @@ describe("formatMonitorResult", () => {
 
   it("key prompt phrases appear exactly once — no body duplication", () => {
     const md = formatMonitorResult(fixture);
-    expect(md.match(/npx pr-shepherd iterate 42/g)?.length).toBe(1);
+    expect(md.match(/npx pr-shepherd 42/g)?.length).toBe(1);
     expect(md.match(/Self-dedup:/g)?.length).toBe(1);
   });
 

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -110,7 +110,7 @@ function validateReadyDelaySuffix(readyDelaySuffix?: string): string | undefined
 
 function buildIterateCommand(prNumber: number, readyDelaySuffix?: string): string {
   const validatedDelay = validateReadyDelaySuffix(readyDelaySuffix);
-  return `npx pr-shepherd iterate ${prNumber}${validatedDelay ? ` --ready-delay ${validatedDelay}` : ""}`;
+  return `npx pr-shepherd ${prNumber}${validatedDelay ? ` --ready-delay ${validatedDelay}` : ""}`;
 }
 
 function buildLoopPrompt(

--- a/src/index.mts
+++ b/src/index.mts
@@ -3,6 +3,7 @@
  * pr-shepherd — unified GitHub PR status + auto-resolve CLI
  *
  * Usage:
+ *   pr-shepherd [PR]
  *   pr-shepherd check [PR]
  *   pr-shepherd resolve [PR]
  *   pr-shepherd iterate [PR]

--- a/src/reporters/check-instructions.mts
+++ b/src/reporters/check-instructions.mts
@@ -74,7 +74,7 @@ export function buildCheckInstructions(
   if (!isReady) {
     instructions.push(
       runtime === "codex"
-        ? `This is a one-shot check. For follow-up monitoring, run \`npx pr-shepherd iterate ${report.pr}\`.`
+        ? `This is a one-shot check. For follow-up monitoring, run \`npx pr-shepherd ${report.pr}\`.`
         : "This is a one-shot check. For continuous monitoring that acts on these signals automatically, use `/pr-shepherd:monitor`.",
     );
   }

--- a/src/reporters/check-instructions.test.mts
+++ b/src/reporters/check-instructions.test.mts
@@ -245,11 +245,11 @@ describe("buildCheckInstructions — monitoring pointer", () => {
     expect(steps[steps.length - 1]).toContain("/pr-shepherd:monitor");
   });
 
-  it("uses npx pr-shepherd iterate for Codex", () => {
+  it("uses the default npx pr-shepherd command for Codex", () => {
     const steps = buildCheckInstructions(makeReport({ status: "FAILING" }), {
       runtime: "codex",
     });
-    expect(steps[steps.length - 1]).toContain("npx pr-shepherd iterate");
+    expect(steps[steps.length - 1]).toContain("npx pr-shepherd 42");
     expect(steps[steps.length - 1]).not.toContain("/pr-shepherd:monitor");
   });
 

--- a/src/reporters/json.test.mts
+++ b/src/reporters/json.test.mts
@@ -78,7 +78,7 @@ describe("formatJson", () => {
   it("instructions include reusable iterate command for Codex", () => {
     const output = formatJson(makeReport({ status: "FAILING" }), { runtime: "codex" });
     const parsed = JSON.parse(output) as { instructions: string[] };
-    expect(parsed.instructions.some((s) => s.includes("npx pr-shepherd iterate"))).toBe(true);
+    expect(parsed.instructions.some((s) => s.includes("npx pr-shepherd 42"))).toBe(true);
     expect(parsed.instructions.every((s) => !s.includes("/pr-shepherd:monitor"))).toBe(true);
   });
 });

--- a/src/reporters/text.test.mts
+++ b/src/reporters/text.test.mts
@@ -435,7 +435,7 @@ describe("formatText — ## Instructions section", () => {
 
   it("uses reusable iterate command for Codex", () => {
     const out = formatText(makeReport({ status: "FAILING" }), { runtime: "codex" });
-    expect(out).toContain("npx pr-shepherd iterate");
+    expect(out).toContain("npx pr-shepherd 42");
     expect(out).not.toContain("/pr-shepherd:monitor");
   });
 });


### PR DESCRIPTION
## Summary
- Make bare `pr-shepherd` invocations dispatch to the existing iterate flow while keeping `pr-shepherd iterate` supported.
- Update generated Codex and monitor rerun commands to prefer `npx pr-shepherd <PR>`.
- Refresh CLI docs, README guidance, and tests for the new preferred command spelling.

## Validation
- `npx vitest run src/cli-parser.iterate.mock.test.mts src/cli-parser.iterate-codex.mock.test.mts src/cli-parser.monitor.mock.test.mts src/commands/monitor.mock.test.mts src/reporters/check-instructions.test.mts src/reporters/json.test.mts src/reporters/text.test.mts`
- `npm run typecheck`
- `npm run format:check`
- `npm test`
- pre-push hook: `npm run lint`, `npm run typecheck`, `npm run format:check`