### PR TITLE
[codex] make pr-shepherd goals autonomous

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example Workflow:
 
 `pr-shepherd` optimizes token management, rate limits, and agentic orchestration by moving **ALL** deterministic logic and prompts to code via a CLI tool, enshrining what would be a large skill or command prompt (of which the agent would inevitably make mistakes) into the code and returning a clear, actionable prompt.
 
-The CLI adapts monitor instructions to the calling agent. Claude Code gets `/loop` bootstrap instructions. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`; it gets a reusable `npx pr-shepherd <PR>` command and one-shot iterate instructions because Codex does not provide `/loop` scheduling in this workflow.
+The CLI adapts monitor instructions to the calling agent. Claude Code gets `/loop` bootstrap instructions. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`; it gets a reusable `npx pr-shepherd <PR>` command and explicit goal-friendly iterate instructions because Codex does not provide `/loop` scheduling in this workflow.
 
 At a high level, to start the monitor, the skill/command invokes a CLI that returns a prompt to be ingested by the agent _(schematic — paraphrased for brevity; actual output is more detailed)_:
 
@@ -127,7 +127,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. In Claude Code, `/pr-shepherd:monitor` uses `/loop` and continues working when your rate limit window is reset. In Codex, rerun the reusable `npx pr-shepherd <PR>` command when you want another check.
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. In Claude Code, `/pr-shepherd:monitor` uses `/loop` and continues working when your rate limit window is reset. In Codex, keep an active goal cycling the reusable `npx pr-shepherd <PR>` command every `watch.interval` (default 4m) until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 - Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
@@ -146,7 +146,7 @@ Recommendations:
 
 In Claude Code, creates a cron loop that fires every 4 minutes, checks CI and review comments, fixes issues, and marks the PR ready for review when clean. The loop cancels automatically when the PR is merged or closed.
 
-In Codex, run `npx pr-shepherd monitor <PR>` once to emit the one-shot prompt, then follow that prompt. Its reusable follow-up command is `npx pr-shepherd <PR>`.
+In Codex, run `npx pr-shepherd monitor <PR>` once to emit the goal-friendly recurrence prompt, then follow that prompt. Its reusable follow-up command is `npx pr-shepherd <PR>`.
 
 Claude Code:
 
@@ -162,7 +162,7 @@ Codex:
 ```sh
 npx pr-shepherd monitor                  # bootstrap from current branch, then follow its instructions
 npx pr-shepherd monitor 42               # bootstrap PR #42, then follow its instructions
-npx pr-shepherd 42                       # subsequent one-shot check/action tick
+npx pr-shepherd 42                       # subsequent explicit check/action tick
 npx pr-shepherd 42 --ready-delay 15m
 npx pr-shepherd iterate 42               # legacy-compatible spelling
 ```
@@ -248,7 +248,7 @@ Follow the output's `## Instructions`. The monitor bootstrap runs one tick and p
 npx pr-shepherd 42
 ```
 
-Rerun that command whenever you want Codex to check the PR again. `npx pr-shepherd iterate 42` remains supported for existing workflows. There is no background `/loop` scheduler in Codex.
+For an active Codex goal, rerun that command every `watch.interval` (default 4m) until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `npx pr-shepherd iterate 42` remains supported for existing workflows. There is no background `/loop` scheduler in Codex.
 
 ### Without the plugin
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -6,7 +6,7 @@ Each default `pr-shepherd` invocation returns exactly one iterate action. The le
 
 The default output format is Markdown — what you see when running `npx pr-shepherd <PR>`, and what the monitor SKILL reads each cron tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
-Instruction wording is agent-aware. Claude-compatible output refers to the next cron fire and `/loop cancel`. Codex output is selected with `AGENT=codex` or `CODEX_CI=1`; it replaces those lines with reusable-prompt guidance such as rerunning `npx pr-shepherd <PR>` later. The action data and section structure are otherwise the same.
+Instruction wording is agent-aware. Claude-compatible output refers to the next cron fire and `/loop cancel`. Codex output is selected with `AGENT=codex` or `CODEX_CI=1`; it replaces those lines with active-goal guidance such as waiting about the configured interval (`watch.interval`, default 4m) and rerunning `npx pr-shepherd <PR>`. The action data and section structure are otherwise the same.
 
 Pass `--verbose` to get more debug state. In JSON mode, the output starts from the full `IterateResult` shape (all fields, including `baseBranch`, `checks`, `shouldCancel`) and then applies the same agent-aware instruction projection as lean JSON: non-`fix_code` actions get a top-level `instructions` array, and Codex output may rewrite `fix.instructions` and simple-action instructions. In Markdown mode, `--verbose` restores the full header summary line (all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, `shouldCancel` always shown, and `[COOLDOWN]` no longer suppresses the base/summary block) — but Markdown is structurally different from JSON and does not guarantee field-for-field parity (array fields like `baseBranch` or `checks` are not added to Markdown for actions that do not normally render them). Lean mode is the default because most fields are `false`/`0`/`[]` on a typical healthy tick and add context noise without value.
 
@@ -70,7 +70,7 @@ SKIP: CI still starting — waiting for first check to appear
 1. End this iteration — the next cron fire will recheck once CI starts reporting.
 ```
 
-Codex variant: `End this iteration — rerun \`npx pr-shepherd 42\` after CI starts reporting.`
+Codex variant: `Continue the active Codex goal — wait about the configured interval (4m), then rerun \`npx pr-shepherd 42\` after CI starts reporting.`
 
 `status`, `merge`, `state`, and `repo` are not emitted in default mode — they carry UNKNOWN/empty placeholders because the early return happens before any GitHub sweep. Pass `--verbose` to see all fields.
 
@@ -103,7 +103,7 @@ WAIT: 3 passing, 2 in-progress — 120s until auto-cancel
 1. End this iteration — the next cron fire will recheck.
 ```
 
-Codex variant: the body omits `until auto-cancel`, and the instruction is `End this iteration — rerun \`npx pr-shepherd 42\` later to recheck.`
+Codex variant: the body omits `until auto-cancel`, and the instruction is `Continue the active Codex goal — wait about the configured interval (4m), then rerun \`npx pr-shepherd 42\` to recheck.`
 
 When the current command includes a ready-delay override, Codex rerun guidance preserves it: `npx pr-shepherd 42 --ready-delay 15m`.
 
@@ -138,7 +138,7 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review — end this iteration.
 ```
 
-Codex variant: the same instruction with an added reminder to rerun `npx pr-shepherd 42` later to recheck.
+Codex variant: the same instruction with added active-goal guidance to continue until the ready-delay completes, wait about the configured interval (4m), and rerun `npx pr-shepherd 42` to recheck.
 
 **What the monitor does:** Follow `## Instructions` — end the iteration and continue monitoring on the next cron fire.
 
@@ -315,7 +315,7 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 - A first-look summaries step is appended when `firstLookSummaries` is non-empty — it tells the agent these summaries are being seen for the first time and their IDs are already in the resolve command's `--minimize-comment-ids`.
 - An edited-items step is appended when `editedSummaries` is non-empty or any first-look thread/comment carries `edited: true` — it tells the agent to read the updated body but **not** include these IDs in any mutation flag.
 - The final "iteration" step has three variants: `Stop this iteration — CI needs time to run on the new push before the next tick.` when a push occurred; `Stop this iteration before the next tick.` when only GitHub mutations were made (no push); `End this iteration.` when no push or mutations occurred.
-- In Codex output, the two "next tick" variants are rewritten to say to rerun `npx pr-shepherd <PR>` later.
+- In Codex output, the "next tick" variants are rewritten to tell Codex to continue the active goal, wait about the configured interval (`watch.interval`, default 4m), and rerun `npx pr-shepherd <PR>`.
 
 The JSON payload exposes the same data under `fix.{threads, resolutionOnlyThreads, actionableComments, reviewSummaryIds, firstLookSummaries, editedSummaries, surfacedApprovals, checks, changesRequestedReviews, resolveCommand, instructions, mode, firstLookThreads, firstLookComments, inProgressRunIds}` — where `fix.mode === "rebase-and-push"` is the type discriminator — plus top-level `baseBranch` (on `IterateResultBase`, not under `fix`) and `cancelled`. `fix.inProgressRunIds` contains the GitHub Actions run IDs the agent must cancel before applying fixes (mirrors `## In-progress runs` in the Markdown output); it is an empty array when there are no in-progress GitHub Actions run IDs to cancel (external status checks or already-cancelled runs are excluded) or when no push is expected this iteration. `resolutionOnlyThreads` contains unresolved outdated/minimized review threads routed to `--resolve-thread-ids` without causing a push or `--require-sha`. `reviewSummaryIds` contains the IDs routed to `--minimize-comment-ids` for review-level minimization: this includes review summaries (both first-look and already-seen), and may also include APPROVED review IDs when approval minimization is enabled. `firstLookSummaries` carries the full `Review` objects for bodies seen this iteration for the first time. `editedSummaries` carries the full `Review` objects for summaries whose body changed since last seen — these IDs are **not** in `reviewSummaryIds`. Both `firstLookSummaries` and `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `editedSummaries` and `surfacedApprovals` are informational only. In lean JSON mode, `fix.*` arrays that are empty are omitted; `cancelled` is omitted when empty. Pass `--verbose` to include all fields. `firstLookThreads` and `firstLookComments` are informational unless the same thread appears in `resolutionOnlyThreads`.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -242,7 +242,7 @@ WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
 1. End this iteration — the next cron fire will recheck.
 ```
 
-When Codex output is selected, the `[WAIT]` body omits the `until auto-cancel` countdown and the instruction points to the reusable one-shot command instead. For example: ``End this iteration — rerun `npx pr-shepherd 42` later to recheck.`` If the current command used `--ready-delay`, the rerun command includes the same flag.
+When Codex output is selected, the `[WAIT]` body omits the `until auto-cancel` countdown and the instruction tells Codex to keep the active goal running with the reusable command. For example: ``Continue the active Codex goal — wait about the configured interval (4m), then rerun `npx pr-shepherd 42` to recheck.`` If the current command used `--ready-delay`, the rerun command includes the same flag.
 
 Example for `[FIX_CODE]` (richest action):
 
@@ -301,7 +301,7 @@ Exit codes: `0` wait/cooldown/mark_ready · `1` fix_code · `2` cancel · `3` es
 
 Bootstrap command used by the Claude `/pr-shepherd:monitor` skill and by Codex directly. Reads `watch.interval` from config and emits the monitor prompt body plus a short `Loop args` line (the interval).
 
-By default, output targets Claude Code and tells the monitor skill how to reuse an existing `/loop` or start a new one. When Codex is detected (`AGENT=codex` or `CODEX_CI=1`), output omits Cron and `/loop` instructions and instead tells Codex to run one iterate tick, then rerun the reusable `npx pr-shepherd <PR>` prompt later.
+By default, output targets Claude Code and tells the monitor skill how to reuse an existing `/loop` or start a new one. When Codex is detected (`AGENT=codex` or `CODEX_CI=1`), output omits Cron and `/loop` instructions and instead tells Codex to run explicit iterate ticks every `watch.interval` (default 4m) until a terminal condition.
 
 ```sh
 npx pr-shepherd monitor        # infer PR from current branch
@@ -329,7 +329,7 @@ Loop args: `4m`
 2. Otherwise, invoke the `/loop` skill via the Skill tool. Build the `args` parameter as: only the value inside the backticks on the `Loop args` line above (the interval — not the `Loop args:` label), then a blank line, then the full `## Loop prompt` body.
 ```
 
-Codex output includes the same PR, tag, interval, prompt body, and `## Instructions` shape, but the instructions say to run the loop prompt once and rerun `npx pr-shepherd 42` later instead of creating or cancelling a `/loop`.
+Codex output includes the same PR, tag, interval, prompt body, and `## Instructions` shape, but the instructions say to run the loop prompt once and keep cycling with `npx pr-shepherd 42` every `Loop args` interval instead of creating or cancelling a `/loop`.
 
 The loop interval comes from `watch.interval` in `.pr-shepherdrc.yml` or the built-in default. Use `--format=json` to inspect the raw values programmatically.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -18,13 +18,13 @@ If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking 
 export AGENT=codex
 ```
 
-Run `npx pr-shepherd monitor <PR>` once to bootstrap the workflow. Follow the output's `## Instructions`, then rerun the emitted `npx pr-shepherd <PR>` command whenever you want another one-shot check. Codex does not provide the Claude `/loop` scheduler in this workflow.
+Run `npx pr-shepherd monitor <PR>` once to bootstrap the workflow. Follow the output's `## Instructions`, then keep an active Codex goal cycling the emitted `npx pr-shepherd <PR>` command every `watch.interval` (default 4m) until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). Codex does not provide the Claude `/loop` scheduler in this workflow.
 
 ## `/pr-shepherd:monitor`
 
 Start continuous CI monitoring for a PR in Claude Code. Runs `npx pr-shepherd monitor <PR>` to get a pre-built `/loop` bootstrap block (interval and the recurring iterate prompt), then creates the cron job. The loop fires at the configured interval, calls `pr-shepherd <PR>`, and follows the `## Instructions` in the output. The loop cancels automatically after the PR is merged/closed or after the configured ready-delay.
 
-In Codex, run the CLI directly instead of the Claude slash command. `npx pr-shepherd monitor <PR>` emits one-shot iterate instructions instead of `/loop` setup. After the bootstrap step, rerun the emitted `npx pr-shepherd <PR>` command later to check again.
+In Codex, run the CLI directly instead of the Claude slash command. `npx pr-shepherd monitor <PR>` emits explicit iterate instructions instead of `/loop` setup. After the bootstrap step, rerun the emitted `npx pr-shepherd <PR>` command every `watch.interval` while the goal remains active.
 
 Claude Code:
 
@@ -38,7 +38,7 @@ Codex:
 ```sh
 npx pr-shepherd monitor        # bootstrap from current branch, then follow its instructions
 npx pr-shepherd monitor 42     # bootstrap PR #42, then follow its instructions
-npx pr-shepherd 42             # subsequent one-shot tick
+npx pr-shepherd 42             # subsequent explicit tick
 ```
 
 The polling interval and ready-delay come from `watch.interval` and `watch.readyDelayMinutes` in `.pr-shepherdrc.yml` (defaults: 4 minutes and 10 minutes). The 4-minute default is intentional — it keeps Claude's prompt cache warm (5-minute TTL).

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -6,7 +6,7 @@
 
 The `/pr-shepherd:monitor <PR>` slash command starts a Claude Code cron loop that polls PR status at the configured interval (default `4m`, set via `watch.interval`). This document explains how all the pieces fit together.
 
-Codex does not provide `/loop` scheduling in this workflow. When `pr-shepherd` detects Codex (`AGENT=codex` or `CODEX_CI=1`), `monitor` output tells Codex to run one iterate tick and rerun the reusable `npx pr-shepherd <PR>` prompt later.
+Codex does not provide `/loop` scheduling in this workflow. When `pr-shepherd` detects Codex (`AGENT=codex` or `CODEX_CI=1`), `monitor` output tells Codex to run explicit iterate ticks with the reusable `npx pr-shepherd <PR>` command every `watch.interval` (default 4m) until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
 
 ## Lifecycle
 

--- a/src/cli-parser.iterate-codex.mock.test.mts
+++ b/src/cli-parser.iterate-codex.mock.test.mts
@@ -28,6 +28,7 @@ import { main } from "./cli-parser.mts";
 import { runIterate } from "./commands/iterate.mts";
 import { runStatus } from "./commands/status.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
+import { buildCodexRetryDelay } from "./cli/iterate-instructions.mts";
 
 const mockRunIterate = vi.mocked(runIterate);
 const mockRunStatus = vi.mocked(runStatus);
@@ -60,6 +61,11 @@ afterEach(() => {
 });
 
 describe("main — iterate Codex fix_code output", () => {
+  it("falls back to the default interval label for malformed interval config values", () => {
+    expect(buildCodexRetryDelay(4)).toBe("the configured interval (default 4m)");
+    expect(buildCodexRetryDelay("five minutes")).toBe("the configured interval (default 4m)");
+  });
+
   it("text rewrites next-tick final instruction to reusable iterate command", async () => {
     process.env.AGENT = "codex";
     const result = makeIterateResult("fix_code");
@@ -73,7 +79,7 @@ describe("main — iterate Codex fix_code output", () => {
     await main(["node", "shepherd", "iterate", "42", "--ready-delay", "15m"]);
     const out = getStdout();
     expect(out).toContain(
-      "2. Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd 42 --ready-delay 15m` later to recheck.",
+      "2. Continue the active Codex goal — CI needs time to run on the new push. Wait about the configured interval (4m), then rerun `npx pr-shepherd 42 --ready-delay 15m` to recheck.",
     );
     expect(out).not.toContain("before the next tick");
   });
@@ -90,7 +96,7 @@ describe("main — iterate Codex fix_code output", () => {
     await main(["node", "shepherd", "iterate", "42", "--format=json", "--ready-delay", "2h"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.fix.instructions).toEqual([
-      "Stop this iteration — CI needs time to run on the new push. Rerun `npx pr-shepherd 42 --ready-delay 2h` later to recheck.",
+      "Continue the active Codex goal — CI needs time to run on the new push. Wait about the configured interval (4m), then rerun `npx pr-shepherd 42 --ready-delay 2h` to recheck.",
     ]);
   });
 
@@ -104,7 +110,21 @@ describe("main — iterate Codex fix_code output", () => {
     await main(["node", "shepherd", "iterate", "42", "--format=json"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.fix.instructions).toEqual([
-      "Stop this iteration. Rerun `npx pr-shepherd 42` later to recheck.",
+      "Continue the active Codex goal — wait about the configured interval (4m), then rerun `npx pr-shepherd 42` to recheck.",
+    ]);
+  });
+
+  it("rewrites mutation-without-push final instruction for Codex", async () => {
+    process.env.AGENT = "codex";
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.instructions = ["Stop this iteration before the next tick."];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42", "--format=json"]);
+    const parsed = JSON.parse(getStdout().trimEnd());
+    expect(parsed.fix.instructions).toEqual([
+      "Continue the active Codex goal — wait about the configured interval (4m), then rerun `npx pr-shepherd 42` to recheck.",
     ]);
   });
 });

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -254,7 +254,7 @@ describe("main — iterate text format", () => {
       "WAIT: 6 passing, 1 in-progress — awaiting human review or branch protection",
     );
     expect(out).toContain(
-      "1. End this iteration — rerun `npx pr-shepherd 42 --ready-delay 15m` later to recheck.",
+      "1. Continue the active Codex goal — wait about the configured interval (4m), then rerun `npx pr-shepherd 42 --ready-delay 15m` to recheck.",
     );
     expect(out).not.toContain("next cron fire");
     expect(out).not.toContain("auto-cancel");
@@ -266,7 +266,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain(
-      "1. End this iteration — rerun `npx pr-shepherd 42` after CI starts reporting.",
+      "1. Continue the active Codex goal — wait about the configured interval (4m), then rerun `npx pr-shepherd 42` after CI starts reporting.",
     );
     expect(out).not.toContain("next cron fire");
   });
@@ -277,7 +277,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain(
-      "1. The CLI already marked the PR ready for review — end this iteration. Rerun `npx pr-shepherd 42` later to recheck.",
+      "1. The CLI already marked the PR ready for review. Continue the active Codex goal until the ready-delay completes — wait about the configured interval (4m), then rerun `npx pr-shepherd 42` to recheck.",
     );
   });
 
@@ -324,7 +324,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42", "--format", "json"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.instructions).toEqual([
-      "End this iteration — rerun `npx pr-shepherd 42` later to recheck.",
+      "Continue the active Codex goal — wait about the configured interval (4m), then rerun `npx pr-shepherd 42` to recheck.",
     ]);
   });
 

--- a/src/cli-parser.monitor.mock.test.mts
+++ b/src/cli-parser.monitor.mock.test.mts
@@ -92,7 +92,9 @@ describe("main — monitor", () => {
     expect(mockRunMonitor).toHaveBeenCalledWith(expect.objectContaining({ runtime: "codex" }));
     const out = getStdout();
     expect(out).toContain("Reusable command: `npx pr-shepherd 42`");
-    expect(out).toContain("Codex does not provide `/loop` scheduling");
+    expect(out).toContain(
+      "keep cycling with `npx pr-shepherd 42` about every configured interval (4m)",
+    );
     expect(out).not.toContain("Invoke the `/loop` skill");
   });
 
@@ -114,7 +116,9 @@ describe("main — monitor", () => {
     await main(["node", "shepherd", "monitor", "42", "--format=json"]);
     const parsed = JSON.parse(getStdout().trim());
     expect(parsed.reusableCommand).toBe("npx pr-shepherd 42");
-    expect(parsed.instructions.join("\n")).toContain("Codex does not provide `/loop` scheduling");
+    expect(parsed.instructions.join("\n")).toContain(
+      "keep cycling with `npx pr-shepherd 42` about every configured interval (4m)",
+    );
   });
 
   it("accepts --ready-delay and forwards it to runMonitor", async () => {

--- a/src/cli/fix-formatter.mts
+++ b/src/cli/fix-formatter.mts
@@ -15,10 +15,11 @@ import type { IterateResultFixCode } from "../types.mts";
 export function formatFixCodeResult(
   header: string,
   result: IterateResultFixCode,
-  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string },
+  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string; retryInterval?: string },
 ): string {
   const runtime = opts?.runtime ?? "claude";
   const readyDelaySuffix = opts?.readyDelaySuffix;
+  const retryInterval = opts?.retryInterval;
   const sections: string[] = [header];
 
   if (result.fix.threads.length > 0) {
@@ -147,7 +148,13 @@ export function formatFixCodeResult(
   sections.push("## Instructions");
   sections.push(
     numberInstructions(
-      adaptFixCodeInstructions(result.fix.instructions, result.pr, runtime, readyDelaySuffix),
+      adaptFixCodeInstructions(
+        result.fix.instructions,
+        result.pr,
+        runtime,
+        readyDelaySuffix,
+        retryInterval,
+      ),
     ),
   );
 

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -98,17 +98,17 @@ export async function handleIterate(args: string[]): Promise<void> {
     noAutoCancelActionable,
   });
 
+  const projectionOpts = { runtime, readyDelaySuffix, retryInterval: cfg.watch.interval };
   if (globalOpts.format === "json") {
     const output = globalOpts.verbose
-      ? projectIterateVerbose(result, { runtime, readyDelaySuffix })
-      : projectIterateLean(result, { runtime, readyDelaySuffix });
+      ? projectIterateVerbose(result, projectionOpts)
+      : projectIterateLean(result, projectionOpts);
     process.stdout.write(`${JSON.stringify(output)}\n`);
   } else {
     process.stdout.write(
       `${formatIterateResult(result, {
         verbose: globalOpts.verbose,
-        runtime,
-        readyDelaySuffix,
+        ...projectionOpts,
       })}\n`,
     );
   }

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -25,11 +25,17 @@ import {
  */
 export function formatIterateResult(
   result: IterateResult,
-  opts?: { verbose?: boolean; runtime?: AgentRuntime; readyDelaySuffix?: string },
+  opts?: {
+    verbose?: boolean;
+    runtime?: AgentRuntime;
+    readyDelaySuffix?: string;
+    retryInterval?: string;
+  },
 ): string {
   const verbose = opts?.verbose ?? false;
   const runtime = opts?.runtime ?? "claude";
   const readyDelaySuffix = opts?.readyDelaySuffix;
+  const retryInterval = opts?.retryInterval;
 
   const heading = `# PR #${result.pr} [${result.action.toUpperCase()}]`;
   const reviewDecisionSeg =
@@ -64,38 +70,38 @@ export function formatIterateResult(
       return joinSections([
         verbose ? header : heading,
         adaptIterateLog(result.log, runtime),
-        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix, retryInterval))}`,
       ]);
 
     case "wait":
       return joinSections([
         header,
         adaptIterateLog(result.log, runtime),
-        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix, retryInterval))}`,
       ]);
 
     case "mark_ready":
       return joinSections([
         header,
         adaptIterateLog(result.log, runtime),
-        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix, retryInterval))}`,
       ]);
 
     case "cancel":
       return joinSections([
         [`${heading} — ${result.reason}`, "", baseLine, summaryLine].join("\n"),
         adaptIterateLog(result.log, runtime),
-        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix, retryInterval))}`,
       ]);
 
     case "escalate":
       return joinSections([
         header,
         result.escalate.humanMessage,
-        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix))}`,
+        `## Instructions\n\n${numberInstructions(buildSimpleIterateInstructions(result, runtime, readyDelaySuffix, retryInterval))}`,
       ]);
 
     case "fix_code":
-      return formatFixCodeResult(header, result, { runtime, readyDelaySuffix });
+      return formatFixCodeResult(header, result, { runtime, readyDelaySuffix, retryInterval });
   }
 }

--- a/src/cli/iterate-instructions.mts
+++ b/src/cli/iterate-instructions.mts
@@ -6,29 +6,34 @@ import {
 } from "../commands/iterate/render.mts";
 import type { IterateResult } from "../types.mts";
 
+const DEFAULT_CODEX_RETRY_INTERVAL = "4m";
+const VALID_RETRY_INTERVAL = /^\d+[smhd]$/;
+
 export function buildSimpleIterateInstructions(
   result: Exclude<IterateResult, { action: "fix_code" }>,
   runtime: AgentRuntime,
   readyDelaySuffix?: string,
+  retryInterval?: string,
 ): string[] {
   const rerunCommand = buildCodexIterateCommand(result.pr, readyDelaySuffix);
+  const retryDelay = buildCodexRetryDelay(retryInterval);
   switch (result.action) {
     case "cooldown":
       return [
         runtime === "codex"
-          ? `End this iteration — rerun \`${rerunCommand}\` after CI starts reporting.`
+          ? `Continue the active Codex goal — wait about ${retryDelay}, then rerun \`${rerunCommand}\` after CI starts reporting.`
           : "End this iteration — the next cron fire will recheck once CI starts reporting.",
       ];
     case "wait":
       return [
         runtime === "codex"
-          ? `End this iteration — rerun \`${rerunCommand}\` later to recheck.`
+          ? `Continue the active Codex goal — wait about ${retryDelay}, then rerun \`${rerunCommand}\` to recheck.`
           : "End this iteration — the next cron fire will recheck.",
       ];
     case "mark_ready":
       return [
         runtime === "codex"
-          ? `The CLI already marked the PR ready for review — end this iteration. Rerun \`${rerunCommand}\` later to recheck.`
+          ? `The CLI already marked the PR ready for review. Continue the active Codex goal until the ready-delay completes — wait about ${retryDelay}, then rerun \`${rerunCommand}\` to recheck.`
           : "The CLI already marked the PR ready for review — end this iteration.",
       ];
     case "cancel":
@@ -53,18 +58,20 @@ export function adaptFixCodeInstructions(
   pr: number,
   runtime: AgentRuntime,
   readyDelaySuffix?: string,
+  retryInterval?: unknown,
 ): string[] {
   if (runtime !== "codex") return instructions;
   const rerunCommand = buildCodexIterateCommand(pr, readyDelaySuffix);
+  const retryDelay = buildCodexRetryDelay(retryInterval);
   return instructions.map((instruction) => {
     if (instruction === FIX_INSTRUCTION_STOP_AFTER_PUSH) {
-      return `Stop this iteration — CI needs time to run on the new push. Rerun \`${rerunCommand}\` later to recheck.`;
+      return `Continue the active Codex goal — CI needs time to run on the new push. Wait about ${retryDelay}, then rerun \`${rerunCommand}\` to recheck.`;
     }
-    if (instruction === FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK) {
-      return `Stop this iteration. Rerun \`${rerunCommand}\` later to recheck.`;
-    }
-    if (instruction === FIX_INSTRUCTION_END_ITERATION) {
-      return `Stop this iteration. Rerun \`${rerunCommand}\` later to recheck.`;
+    if (
+      instruction === FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK ||
+      instruction === FIX_INSTRUCTION_END_ITERATION
+    ) {
+      return `Continue the active Codex goal — wait about ${retryDelay}, then rerun \`${rerunCommand}\` to recheck.`;
     }
     return instruction;
   });
@@ -78,6 +85,13 @@ export function adaptIterateLog(log: string, runtime: AgentRuntime): string {
 export function buildCodexIterateCommand(pr: number, readyDelaySuffix?: string): string {
   const suffix = readyDelaySuffix?.trim();
   return `npx pr-shepherd ${pr}${suffix ? ` --ready-delay ${suffix}` : ""}`;
+}
+
+export function buildCodexRetryDelay(retryInterval?: unknown): string {
+  const interval = typeof retryInterval === "string" ? retryInterval.trim() : "";
+  return VALID_RETRY_INTERVAL.test(interval)
+    ? `the configured interval (${interval})`
+    : `the configured interval (default ${DEFAULT_CODEX_RETRY_INTERVAL})`;
 }
 
 export function numberInstructions(instructions: string[]): string {

--- a/src/cli/iterate-lean.mts
+++ b/src/cli/iterate-lean.mts
@@ -13,10 +13,13 @@ import {
  */
 export function projectIterateLean(
   result: IterateResult,
-  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string },
+  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string; retryInterval?: string },
 ): unknown {
   const runtime = opts?.runtime ?? "claude";
   const readyDelaySuffix = opts?.readyDelaySuffix;
+  const retryInterval = opts?.retryInterval;
+  const simpleInstructions = (r: Exclude<IterateResult, { action: "fix_code" }>) =>
+    buildSimpleIterateInstructions(r, runtime, readyDelaySuffix, retryInterval);
   const base: Record<string, unknown> = {
     action: result.action,
     pr: result.pr,
@@ -47,27 +50,27 @@ export function projectIterateLean(
       return {
         ...base,
         log: adaptIterateLog(result.log, runtime),
-        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+        instructions: simpleInstructions(result),
       };
     case "wait":
       return {
         ...base,
         log: adaptIterateLog(result.log, runtime),
-        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+        instructions: simpleInstructions(result),
       };
     case "cancel":
       return {
         ...base,
         reason: result.reason,
         log: adaptIterateLog(result.log, runtime),
-        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+        instructions: simpleInstructions(result),
       };
     case "mark_ready":
       // drop markedReady — always true, redundant with action discriminator
       return {
         ...base,
         log: adaptIterateLog(result.log, runtime),
-        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+        instructions: simpleInstructions(result),
       };
     case "fix_code":
       return {
@@ -115,6 +118,7 @@ export function projectIterateLean(
               result.pr,
               runtime,
               readyDelaySuffix,
+              retryInterval,
             ),
           }),
         },
@@ -140,17 +144,18 @@ export function projectIterateLean(
           suggestion: result.escalate.suggestion,
           humanMessage: result.escalate.humanMessage,
         },
-        instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+        instructions: simpleInstructions(result),
       };
   }
 }
 
 export function projectIterateVerbose(
   result: IterateResult,
-  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string },
+  opts?: { runtime?: AgentRuntime; readyDelaySuffix?: string; retryInterval?: string },
 ): unknown {
   const runtime = opts?.runtime ?? "claude";
   const readyDelaySuffix = opts?.readyDelaySuffix;
+  const retryInterval = opts?.retryInterval;
   if (result.action === "fix_code") {
     return {
       ...result,
@@ -161,6 +166,7 @@ export function projectIterateVerbose(
           result.pr,
           runtime,
           readyDelaySuffix,
+          retryInterval,
         ),
       },
     };
@@ -172,6 +178,6 @@ export function projectIterateVerbose(
   return {
     ...result,
     ...log,
-    instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix),
+    instructions: buildSimpleIterateInstructions(result, runtime, readyDelaySuffix, retryInterval),
   };
 }

--- a/src/commands/monitor.mock.test.mts
+++ b/src/commands/monitor.mock.test.mts
@@ -80,10 +80,12 @@ describe("runMonitor", () => {
   it("builds a Codex prompt without /loop or Cron instructions", async () => {
     const result = await runMonitor({ format: "text", prNumber: 42, runtime: "codex" });
     expect(result.loopPrompt).toContain("Codex recurrence rules");
+    expect(result.loopPrompt).toContain("wait about the configured interval (4m)");
+    expect(result.loopPrompt).toContain("Stop only when Shepherd emits `[CANCEL]`");
     expect(result.loopPrompt).toContain("npx pr-shepherd 42");
     expect(result.loopPrompt).not.toContain("CronList");
     expect(result.loopPrompt).not.toContain("CronDelete");
-    expect(result.loopPrompt).not.toContain("ScheduleWakeup");
+    expect(result.loopPrompt).toContain("Do not call `/loop`, `ScheduleWakeup`, `CronCreate`");
     expect(result.loopPrompt).not.toContain("Do NOT call `/loop`");
   });
 
@@ -139,7 +141,9 @@ describe("formatMonitorResult", () => {
     const md = formatMonitorResult(codexFixture, { runtime: "codex" });
     expect(md).toContain("Reusable command: `npx pr-shepherd 42`");
     expect(md).toContain("Run the `## Loop prompt` body once inline now.");
-    expect(md).toContain("Codex does not provide `/loop` scheduling");
+    expect(md).toContain(
+      "keep cycling with `npx pr-shepherd 42` about every configured interval (4m)",
+    );
     expect(md).not.toContain("Invoke the `/loop` skill");
     expect(md).not.toContain("CronList");
   });

--- a/src/commands/monitor.mts
+++ b/src/commands/monitor.mts
@@ -40,7 +40,13 @@ export async function runMonitor(opts: MonitorCommandOptions): Promise<MonitorRe
   const loopTag = `#pr-shepherd-loop:pr=${prNumber}:`;
   const loopArgs = interval;
   const reusableCommand = buildIterateCommand(prNumber, opts.readyDelaySuffix);
-  const loopPrompt = buildLoopPrompt(prNumber, loopTag, reusableCommand, opts.runtime ?? "claude");
+  const loopPrompt = buildLoopPrompt(
+    prNumber,
+    loopTag,
+    reusableCommand,
+    loopArgs,
+    opts.runtime ?? "claude",
+  );
 
   return {
     prNumber,
@@ -117,6 +123,7 @@ function buildLoopPrompt(
   prNumber: number,
   loopTag: string,
   iterateCmd: string,
+  loopArgs: string,
   runtime: AgentRuntime = "claude",
 ): string {
   if (runtime === "codex") {
@@ -124,8 +131,10 @@ function buildLoopPrompt(
       loopTag,
       "",
       "**IMPORTANT — Codex recurrence rules:**",
-      "- Run the command below once, follow its `## Instructions` exactly, then stop.",
-      "- Codex does not provide `/loop` scheduling in this workflow. To check again later, rerun the reusable command from the monitor output.",
+      "- Run the command below once and follow its `## Instructions` exactly.",
+      `- If the output tells you to continue the active Codex goal, wait about the configured interval (${loopArgs}) and rerun the reusable command from the monitor output.`,
+      "- Stop only when Shepherd emits `[CANCEL]` because the ready-delay completed or the PR was merged/closed, or when Shepherd emits `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).",
+      "- Do not call `/loop`, `ScheduleWakeup`, `CronCreate`, or `npx pr-shepherd monitor`; Codex recurrence is explicit `iterate` command cycles.",
       "",
       "Run in a single Bash call:",
       `  ${iterateCmd}`,
@@ -157,7 +166,7 @@ function buildMonitorInstructions(result: MonitorResult, runtime: AgentRuntime):
   if (runtime === "codex") {
     return [
       "Run the `## Loop prompt` body once inline now.",
-      `When you want to check this PR again later, run \`${result.reusableCommand}\`. Codex does not provide \`/loop\` scheduling, so no recurring monitor is created.`,
+      `For an active Codex goal, keep cycling with \`${result.reusableCommand}\` about every configured interval (${result.loopArgs}) until a terminal condition is reached. Codex does not create a \`/loop\` monitor.`,
     ];
   }
   return [


### PR DESCRIPTION
## Summary
- Make Codex-specific iterate instructions continue active `/goal` loops across wait, cooldown, mark-ready, and post-fix states.
- Keep Codex stop conditions focused on ready/merged/closed PRs, Shepherd escalation, or undiagnosable repeated CI failures.
- Update Codex monitor guidance, docs, and tests while leaving Claude `/loop` behavior unchanged.

## Validation
- `npx vitest run src/cli-parser.iterate.mock.test.mts src/cli-parser.iterate-codex.mock.test.mts src/cli-parser.monitor.mock.test.mts src/commands/monitor.mock.test.mts src/cli/iterate-lean.test.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`

## Notes
- Also updated local testing skill at `~/.codex/skills/pr-shepherd/SKILL.md`; that file is outside this repository and is not part of the PR diff.
