### PR TITLE
[codex] fix release plugin manifest formatting

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,12 +9,6 @@
   "homepage": "https://github.com/jonathanong/pr-shepherd",
   "repository": "https://github.com/jonathanong/pr-shepherd",
   "license": "MIT",
-  "keywords": [
-    "github",
-    "pull-request",
-    "ci",
-    "code-review",
-    "automation"
-  ],
+  "keywords": ["github", "pull-request", "ci", "code-review", "automation"],
   "skills": "./plugin/skills/"
 }

--- a/.github/scripts/sync-plugin-version.mjs
+++ b/.github/scripts/sync-plugin-version.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process'
 import { readFileSync, writeFileSync } from 'fs'
 
 const version = JSON.parse(readFileSync('package.json', 'utf8')).version
@@ -11,3 +12,6 @@ for (const pluginPath of pluginPaths) {
   plugin.version = version
   writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + '\n')
 }
+
+const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+execFileSync(npx, ['oxfmt', ...pluginPaths], { stdio: 'inherit' })

--- a/.github/scripts/sync-plugin-version.mjs
+++ b/.github/scripts/sync-plugin-version.mjs
@@ -14,4 +14,4 @@ for (const pluginPath of pluginPaths) {
 }
 
 const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx'
-execFileSync(npx, ['oxfmt', ...pluginPaths], { stdio: 'inherit' })
+execFileSync(npx, ['--no-install', 'oxfmt', ...pluginPaths], { stdio: 'inherit' })

--- a/plugins/pr-shepherd/.codex-plugin/plugin.json
+++ b/plugins/pr-shepherd/.codex-plugin/plugin.json
@@ -10,14 +10,7 @@
   "homepage": "https://github.com/jonathanong/pr-shepherd",
   "repository": "https://github.com/jonathanong/pr-shepherd",
   "license": "MIT",
-  "keywords": [
-    "github",
-    "pull-request",
-    "ci",
-    "code-review",
-    "automation",
-    "codex"
-  ],
+  "keywords": ["github", "pull-request", "ci", "code-review", "automation", "codex"],
   "skills": "../skills/",
   "interface": {
     "displayName": "pr-shepherd",
@@ -25,10 +18,7 @@
     "longDescription": "Use pr-shepherd from Codex to check pull requests, resolve review feedback, and keep explicit iterate cycles running until a PR is ready, merged, closed, or escalated.",
     "developerName": "Jonathan Ong",
     "category": "Coding",
-    "capabilities": [
-      "Interactive",
-      "Write"
-    ],
+    "capabilities": ["Interactive", "Write"],
     "websiteURL": "https://github.com/jonathanong/pr-shepherd",
     "privacyPolicyURL": "https://github.com/jonathanong/pr-shepherd",
     "termsOfServiceURL": "https://github.com/jonathanong/pr-shepherd",


### PR DESCRIPTION
## Summary
- Fixes the current CI failure by formatting the Codex plugin manifest that the release commit expanded with `JSON.stringify`.
- Updates the release version sync script to run `oxfmt` on both plugin manifests after rewriting versions, keeping future release commits formatter-clean.
- Formats the legacy Claude manifest as well so the sync script is idempotent across both files it owns.

## Root Cause
The failing job was the combined `lint / typecheck / test (24.x)` job, but it did not reach TypeScript. It failed at `npm run format:check` on `plugins/pr-shepherd/.codex-plugin/plugin.json`. The v0.13.0 release commit rewrote plugin manifests via `.github/scripts/sync-plugin-version.mjs`, which used `JSON.stringify(plugin, null, 2)`. That expanded short arrays, while `oxfmt` expects those arrays inline.

## Why It Passed Before
Before the v0.13.0 release commit, `plugins/pr-shepherd/.codex-plugin/plugin.json` was already in `oxfmt` format from the packaging PR. The release sync script then rewrote the file without running `oxfmt`, so the next CI run on `main` failed format check before typecheck could run.

## Validation
- `npm install`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test`
- `npm run build`
- pre-push hook: lint, typecheck, format:check
