### PR TITLE
[codex] detect package runner in shepherd skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ State-machine actions (`fix_code`, `cancel`, `mark_ready`, `wait`, `escalate`) a
 
 ## Setup
 
-**Before any `npx pr-shepherd` or `/pr-shepherd:*` invocation in this worktree**, verify `bin/` and `node_modules/` exist. If either is missing, run:
+**Before any `npx pr-shepherd` or `/pr-shepherd:*` invocation in this worktree**, verify `bin/` and `node_modules/` exist. If either is missing, run this source checkout's package-manager install command. This checkout uses npm (`package-lock.json`), so run:
 
 ```bash
 npm install
@@ -48,7 +48,7 @@ Instead, emit a suggestion: build the patch / commit message / file list and ret
 
 ## Dogfooding
 
-During development, run the CLI from this repository root with `npx pr-shepherd` (after `npm install && npm run build`).
+During development, run the CLI from this repository root with `npx pr-shepherd` (after the source checkout's package-manager install command and build; currently `npm install && npm run build`).
 This ensures you are using the built local CLI from this checkout rather than any globally installed version.
 Use it from the same worktree/repository so it picks up the skills and configuration checked into this local checkout.
 

--- a/README.md
+++ b/README.md
@@ -265,18 +265,18 @@ If your Codex environment does not already set `CODEX_CI=1`, set `AGENT=codex` s
 export AGENT=codex
 ```
 
-Then start a PR monitor from Codex:
+Then start a PR monitor from Codex with the target repository's package runner:
 
 ```bash
-npx pr-shepherd monitor 42
+<runner> pr-shepherd monitor 42
 ```
 
-Use the target repository's package runner for the command. For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd monitor 42`.
+For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd monitor 42`. For npm repos, use `npx --no-install pr-shepherd monitor 42`.
 
 Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. The monitor bootstrap runs one tick and prints the reusable follow-up command, usually:
 
 ```bash
-npx pr-shepherd 42
+<runner> pr-shepherd 42
 ```
 
 For an active Codex goal, rerun that command every `watch.interval` (default 4m) until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `pr-shepherd iterate 42` remains supported for existing workflows. There is no background `/loop` scheduler in Codex.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ On each dynamic tick: fetch PR state in one GraphQL batch → classify CI, comme
 > **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. The skills invoke `pr-shepherd` through the repo package runner, so you also need the CLI available. If you're using `pr-shepherd` as development tooling for your repo, install it as a dev dependency so the selected runner resolves it without prompting:
 >
 > ```bash
+> pnpm add -D pr-shepherd      # pnpm repos
+> yarn add -D pr-shepherd      # yarn repos
 > npm install --save-dev pr-shepherd
 > ```
 >
@@ -250,6 +252,8 @@ After adding the marketplace, open the Codex plugin directory, choose the `jonat
 Install the CLI where Codex will run it:
 
 ```bash
+pnpm add -D pr-shepherd      # pnpm repos
+yarn add -D pr-shepherd      # yarn repos
 npm install --save-dev pr-shepherd
 ```
 
@@ -266,6 +270,8 @@ Then start a PR monitor from Codex:
 ```bash
 npx pr-shepherd monitor 42
 ```
+
+Use the target repository's package runner for the command. For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd monitor 42`.
 
 Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. The monitor bootstrap runs one tick and prints the reusable follow-up command, usually:
 

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -35,10 +35,10 @@ resolves `pr-shepherd ...` without prompting to install the package.
    ## Run the check
 
    Use the repository package runner selected by `packageManager` or lockfile
-   (`pnpm exec`, `yarn run`, or `npx`).
+   (for example, `pnpm exec`, `yarn run`, or `npx --no-install`).
 
    ```bash
-   pr-shepherd check <PR_NUMBER> --format=json
+   <runner> pr-shepherd check <PR_NUMBER> --format=json
    ```
 
    Parse the JSON and report:
@@ -60,6 +60,6 @@ For `monitor` and `resolve` custom commands, do **not** copy the
 frontmatter that is not valid for `.claude/commands/` files. Instead, create
 `.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
 using the same command-file structure as the `pr-check` example above, with
-the CLI invocation changed to `pr-shepherd monitor ...` or
-`pr-shepherd resolve ...` through the selected package runner. To drive the CLI without Claude at all, see
-[cli-usage.md](cli-usage.md).
+the CLI invocation changed to `<runner> pr-shepherd monitor ...` or
+`<runner> pr-shepherd resolve ...`. To drive the CLI without Claude at all,
+see [cli-usage.md](cli-usage.md).

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -5,8 +5,9 @@
 If you don't want the full plugin, create a project-local (or user-scope)
 slash command that wraps the CLI directly. This still requires `pr-shepherd`
 to be installed in the repository first (preferably as a dev dependency:
-`npm install --save-dev pr-shepherd`), so that `npx pr-shepherd ...` runs
-without prompting to install the package.
+`pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, or
+`npm install --save-dev pr-shepherd`), so that the repo package runner
+resolves `pr-shepherd ...` without prompting to install the package.
 
 1. **Create the command file:**
    - Project-scope: `.claude/commands/pr-check.md`
@@ -33,8 +34,11 @@ without prompting to install the package.
 
    ## Run the check
 
+   Use the repository package runner selected by `packageManager` or lockfile
+   (`pnpm exec`, `yarn run`, or `npx`).
+
    ```bash
-   npx pr-shepherd check <PR_NUMBER> --format=json
+   pr-shepherd check <PR_NUMBER> --format=json
    ```
 
    Parse the JSON and report:
@@ -56,6 +60,6 @@ For `monitor` and `resolve` custom commands, do **not** copy the
 frontmatter that is not valid for `.claude/commands/` files. Instead, create
 `.claude/commands/pr-monitor.md` and/or `.claude/commands/pr-resolve.md`
 using the same command-file structure as the `pr-check` example above, with
-the CLI invocation changed to `npx pr-shepherd monitor ...` or
-`npx pr-shepherd resolve ...`. To drive the CLI without Claude at all, see
+the CLI invocation changed to `pr-shepherd monitor ...` or
+`pr-shepherd resolve ...` through the selected package runner. To drive the CLI without Claude at all, see
 [cli-usage.md](cli-usage.md).

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -32,6 +32,8 @@ After adding the marketplace, open the Codex plugin directory, choose the `jonat
 Then install the CLI in the repository where Codex will work:
 
 ```sh
+pnpm add -D pr-shepherd      # pnpm repos
+yarn add -D pr-shepherd      # yarn repos
 npm install --save-dev pr-shepherd
 ```
 
@@ -43,7 +45,7 @@ export AGENT=codex
 
 Run `pr-shepherd monitor <PR>` once through the repo package runner to bootstrap the workflow. Follow the output's `## Instructions`, then keep an active Codex goal cycling the emitted command every `watch.interval` (default 4m) until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). Codex does not provide the Claude `/loop` scheduler in this workflow.
 
-The examples below use `npx pr-shepherd` as the default spelling. The actual runner depends on `cli.runner` in `.pr-shepherdrc.yml` (default `auto`, which detects pnpm/yarn from `packageManager` or lockfiles). Skills invoke the CLI through the detected runner; the CLI then emits follow-up commands using the same runner.
+The examples below use `npx pr-shepherd` as the default spelling. The actual runner depends on `cli.runner` in `.pr-shepherdrc.yml` (default `auto`, which detects pnpm/yarn from `packageManager` or lockfiles). Skills invoke the CLI through the detected runner; the CLI then emits follow-up commands using the same runner. For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd ...`.
 
 The Codex plugin skill handles PR-number discovery, one-off check/resolve commands, and open-ended goal setup. It still delegates policy and state transitions to the CLI output's own `## Instructions` section.
 

--- a/plugin/skills/check/SKILL.md
+++ b/plugin/skills/check/SKILL.md
@@ -26,10 +26,10 @@ allowed-tools: ["Bash"]
 
 3. **Run the check and follow instructions:**
    Use the repository package runner selected by `packageManager` or lockfile
-   (`pnpm exec`, `yarn run`, or `npx`).
+   (for example, `pnpm exec`, `yarn run`, or `npx --no-install`).
 
    ```bash
-   pr-shepherd check <N>
+   <runner> pr-shepherd check <N>
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/check/SKILL.md
+++ b/plugin/skills/check/SKILL.md
@@ -25,9 +25,11 @@ allowed-tools: ["Bash"]
    If `MERGED`, output: `PR #N is already merged. Nothing to check.` and skip.
 
 3. **Run the check and follow instructions:**
+   Use the repository package runner selected by `packageManager` or lockfile
+   (`pnpm exec`, `yarn run`, or `npx`).
 
    ```bash
-   npx pr-shepherd check <N>
+   pr-shepherd check <N>
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -31,10 +31,10 @@ allowed-tools:
 
 2. **Run the bootstrap command and follow its instructions:**
    Use the repository package runner selected by `packageManager` or lockfile
-   (`pnpm exec`, `yarn run`, or `npx`).
+   (for example, `pnpm exec`, `yarn run`, or `npx --no-install`).
 
    ```bash
-   pr-shepherd monitor <PR_NUMBER>
+   <runner> pr-shepherd monitor <PR_NUMBER>
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/monitor/SKILL.md
+++ b/plugin/skills/monitor/SKILL.md
@@ -30,9 +30,11 @@ allowed-tools:
    - If no PR found, report an error and stop.
 
 2. **Run the bootstrap command and follow its instructions:**
+   Use the repository package runner selected by `packageManager` or lockfile
+   (`pnpm exec`, `yarn run`, or `npx`).
 
    ```bash
-   npx pr-shepherd monitor <PR_NUMBER>
+   pr-shepherd monitor <PR_NUMBER>
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -29,10 +29,10 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
 
 3. **Fetch and follow instructions:**
    Use the repository package runner selected by `packageManager` or lockfile
-   (`pnpm exec`, `yarn run`, or `npx`).
+   (for example, `pnpm exec`, `yarn run`, or `npx --no-install`).
 
    ```bash
-   pr-shepherd resolve <N> --fetch
+   <runner> pr-shepherd resolve <N> --fetch
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugin/skills/resolve/SKILL.md
+++ b/plugin/skills/resolve/SKILL.md
@@ -28,9 +28,11 @@ Resolve unresolved review threads and minimize PR comments on the current PR —
    If `MERGED`, invoke `/loop cancel` via the Skill tool, output a merged message, and stop.
 
 3. **Fetch and follow instructions:**
+   Use the repository package runner selected by `packageManager` or lockfile
+   (`pnpm exec`, `yarn run`, or `npx`).
 
    ```bash
-   npx pr-shepherd resolve <N> --fetch
+   pr-shepherd resolve <N> --fetch
    ```
 
    Print the full output. Follow the `## Instructions` section exactly.

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-shepherd
-description: 'Codex-only skill for checking, updating, monitoring, or resolving a GitHub pull request with pr-shepherd. Use for requests like "check this PR", "use pr-shepherd", "iterate PR #123", "resolve this PR''s comments", or "run pr-shepherd until this PR is ready". For open-ended requests, create a Codex goal and run explicit `npx --no-install pr-shepherd PR_NUMBER` cycles, picking a fresh sleep/timeout between 1 and 4 minutes before each rerun until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` including repeated unchanged CI failures.'
+description: 'Codex-only skill for checking, updating, monitoring, or resolving a GitHub pull request with pr-shepherd. Use for requests like "check this PR", "use pr-shepherd", "iterate PR #123", "resolve this PR''s comments", or "run pr-shepherd until this PR is ready". For open-ended requests, create a Codex goal and run explicit pr-shepherd cycles through the target repo package runner, picking a fresh sleep/timeout between 1 and 4 minutes before each rerun until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` including repeated unchanged CI failures.'
 ---
 
 # pr-shepherd
@@ -19,32 +19,37 @@ Codex-only workflow for getting actionable PR updates from `pr-shepherd`.
 2. Decide whether this is one cycle or an open-ended goal.
    - For one-off requests such as "check this PR", "run pr-shepherd once", or "resolve this PR's comments", run one explicit CLI command.
    - For requests such as "continue", "until ready", "until this PR is ready", or "keep iterating", create a Codex goal before the first recurring cycle with this objective:
-     `Run npx --no-install pr-shepherd PR_NUMBER cycles, picking a fresh sleep/timeout between 1 and 4 minutes before each rerun, until Shepherd emits [CANCEL] for ready-delay completion or PR #PR_NUMBER is merged/closed, or pr-shepherd escalates, including repeated unchanged CI failures.`
+     `Run pr-shepherd PR_NUMBER cycles through the target repo package runner, picking a fresh sleep/timeout between 1 and 4 minutes before each rerun, until Shepherd emits [CANCEL] for ready-delay completion or PR #PR_NUMBER is merged/closed, or pr-shepherd escalates, including repeated unchanged CI failures.`
 
-3. Verify the CLI is available.
-   - In the pr-shepherd source checkout, before any `npx --no-install pr-shepherd` invocation, verify `bin/` and `node_modules/` exist. If either is missing, run:
+3. Select the package runner from the target repository root.
+   - Prefer `package.json` `packageManager`: `pnpm@...` -> `pnpm exec`, `yarn@...` -> `yarn run`, `npm@...` -> `npx --no-install`.
+   - If `packageManager` is absent, use lockfiles: `pnpm-lock.yaml` -> `pnpm exec`, `yarn.lock` -> `yarn run`, `package-lock.json` or no signal -> `npx --no-install`.
+   - Example: in `~/filaments`, use `pnpm exec pr-shepherd ...` because the root package declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml`.
+
+4. Verify the CLI is available.
+   - Only when the target repository itself is the pr-shepherd source checkout, verify `bin/` and `node_modules/` exist before any local CLI invocation. If either is missing, run the source checkout's package-manager install command. This repository currently uses npm, so run:
      `npm install`
-   - In other repositories, use `npx --no-install pr-shepherd` so Codex does not install packages implicitly. If that fails because the package is missing, tell the user to install `pr-shepherd` in the target repo with `npm install --save-dev pr-shepherd`.
+   - In other repositories, run through the selected package runner so Codex does not install packages implicitly. If the package is missing, tell the user to install `pr-shepherd` with the matching dev-dependency command: `pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, or `npm install --save-dev pr-shepherd`.
 
-4. Run the appropriate command from the repository root.
+5. Run the appropriate command from the repository root.
    - For a status check:
-     `npx --no-install pr-shepherd check PR_NUMBER`
+     `<runner> pr-shepherd check PR_NUMBER`
    - For review comment resolution:
-     `npx --no-install pr-shepherd resolve PR_NUMBER --fetch`
+     `<runner> pr-shepherd resolve PR_NUMBER --fetch`
    - For a monitor bootstrap:
-     `npx --no-install pr-shepherd monitor PR_NUMBER`
+     `<runner> pr-shepherd monitor PR_NUMBER`
    - For the recurring explicit monitor tick:
-     `npx --no-install pr-shepherd PR_NUMBER`
-   - `npx --no-install pr-shepherd iterate PR_NUMBER` remains supported as a legacy alias, but use the default `pr-shepherd PR_NUMBER` form for recurring Codex cycles.
+     `<runner> pr-shepherd PR_NUMBER`
+   - `pr-shepherd iterate PR_NUMBER` remains supported as a legacy alias, but use the default `pr-shepherd PR_NUMBER` form for recurring Codex cycles.
 
-5. Print or summarize the important status, then follow the output's `## Instructions` exactly.
+6. Print or summarize the important status, then follow the output's `## Instructions` exactly.
 
-6. Do not call `/loop`, `ScheduleWakeup`, `CronCreate`, or `npx pr-shepherd monitor` for recurrence. Codex does explicit `pr-shepherd PR_NUMBER` cycles.
+7. Do not call `/loop`, `ScheduleWakeup`, `CronCreate`, or `pr-shepherd monitor` for recurrence. Codex does explicit `pr-shepherd PR_NUMBER` cycles.
 
-7. For open-ended goal requests, complete the CLI-provided instructions for the current cycle. If the output says to continue the active Codex goal, pick a fresh sleep/timeout between 1 and 4 minutes, wait that long, and run another explicit `pr-shepherd PR_NUMBER` cycle.
+8. For open-ended goal requests, complete the CLI-provided instructions for the current cycle. If the output says to continue the active Codex goal, pick a fresh sleep/timeout between 1 and 4 minutes, wait that long, and run another explicit `pr-shepherd PR_NUMBER` cycle through the same runner.
 
-8. Do not stop an open-ended goal only because the output is `[WAIT]`, `[COOLDOWN]`, `[MARK_READY]`, or a post-fix CI wait. These are nonterminal Codex recurrence states.
+9. Do not stop an open-ended goal only because the output is `[WAIT]`, `[COOLDOWN]`, `[MARK_READY]`, or a post-fix CI wait. These are nonterminal Codex recurrence states.
 
-9. Stop only when Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or when it emits `[ESCALATE]`, including `stall-timeout` for repeated unchanged CI failures. If a Codex goal is active, mark it complete only when one of those terminal conditions is actually satisfied.
+10. Stop only when Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or when it emits `[ESCALATE]`, including `stall-timeout` for repeated unchanged CI failures. If a Codex goal is active, mark it complete only when one of those terminal conditions is actually satisfied.
 
-10. If the output includes fixes, pushes, rebases, or resolve commands, perform only the instructed scoped actions. Do not resolve, minimize, or dismiss comments until the CLI-provided post-push and `--require-sha` instructions are satisfied.
+11. If the output includes fixes, pushes, rebases, or resolve commands, perform only the instructed scoped actions. Do not resolve, minimize, or dismiss comments until the CLI-provided post-push and `--require-sha` instructions are satisfied.


### PR DESCRIPTION
## Summary
- Make the Codex pr-shepherd skill select the target repo package runner before invoking or installing the CLI.
- Add pnpm/yarn/npm install guidance and a ~/filaments-style pnpm example to docs.
- Clarify that the pr-shepherd source checkout setup uses this repo's own package manager.

## Validation
- npm run format:check
- npm test
- npm run lint
- git push pre-push hook: lint, typecheck, format:check
