### PR TITLE
[codex] stop resolve mutations on rate limit

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -137,10 +137,8 @@ the IDs still pending:
 
 ```text
 Minimized comments (35): IC_1, IC_2, …
-Stopped: GitHub rate limit hit — API rate limit exceeded (retry after 60s, remaining 0/5000)
+Stopped: GitHub rate limit hit — API rate limit exceeded (retry after 60s, remaining 0/5000, reset at 2023-11-14T22:13:20.000Z)
 Not minimized due to rate limit (5): IC_36, IC_37, IC_38, IC_39, IC_40
-Errors:
-  rate limit: API rate limit exceeded
 ```
 
 Retry a later run with the pending IDs only. JSON output exposes the same data in

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -131,6 +131,22 @@ Minimized comments (1): IC_kwDOxyz
 Dismissed reviews (1): PRR_kwDO123
 ```
 
+Mutation batches are sent in groups of 10. If GitHub returns a primary or secondary
+rate-limit response, Shepherd stops immediately and reports both completed IDs and
+the IDs still pending:
+
+```text
+Minimized comments (35): IC_1, IC_2, …
+Stopped: GitHub rate limit hit — API rate limit exceeded (retry after 60s, remaining 0/5000)
+Not minimized due to rate limit (5): IC_36, IC_37, IC_38, IC_39, IC_40
+Errors:
+  rate limit: API rate limit exceeded
+```
+
+Retry a later run with the pending IDs only. JSON output exposes the same data in
+`rateLimit`, `unresolvedThreads`, `unminimizedComments`, and
+`undismissedReviews`.
+
 **Flags:**
 
 | Flag                     | Description                                                    |

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -71,6 +71,14 @@ All mutations live in `comments/resolve.mts`:
 
 Review summary IDs (`PRR_…` from `reviewSummaries`) go through `--minimize-comment-ids`, not `--dismiss-review-ids`. The `dismiss` path is reserved for CHANGES_REQUESTED reviews.
 
+Mutation mode batches resolve/minimize/dismiss operations in groups of 10. On a
+GitHub primary or secondary rate-limit response, Shepherd stops instead of
+continuing through later IDs. The mutate result keeps the successful arrays
+(`resolvedThreads`, `minimizedComments`, `dismissedReviews`) and adds pending
+arrays for IDs that still need another run (`unresolvedThreads`,
+`unminimizedComments`, `undismissedReviews`), plus `rateLimit` metadata when
+GitHub provided retry or reset details.
+
 ## Applying reviewer suggestions
 
 For review threads whose body contains a ` ```suggestion ` fenced block, `resolve --fetch` attaches a parsed `suggestion` field (`{ startLine, endLine, lines, author }`, where `lines: string[]` losslessly carries the replacement — `[]` means "delete these lines", `[""]` means "replace with one blank line") and emits `commitSuggestionsEnabled` mirroring `actions.commitSuggestions`. The agent can then invoke [`pr-shepherd commit-suggestion`](cli-usage.md#pr-shepherd-commit-suggestion-pr---thread-id-id---message) (singular) per thread — one thread at a time — to build a unified diff and produce the suggested commit message + body (with `Co-authored-by: <reviewer>` trailer). The CLI does not mutate the working tree or git history; the agent applies the patch, stages, commits, and resolves the thread using the `## Instructions` section in the output.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -68,6 +68,8 @@ rm $TMPDIR/pr-shepherd-state/acme-myrepo/42/ready-since.txt
 
 1. Pause or cancel the monitor loop if API budget is tight. Scheduling is dynamic and fixed to agent-chosen 1-4 minute waits, so there is no polling interval config to raise.
 2. Check `x-ratelimit-remaining` in the reporter JSON output to monitor consumption
+3. For `resolve` mutate output, retry only the IDs listed under `Not resolved`,
+   `Not minimized`, or `Not dismissed`; IDs listed as completed already succeeded.
 
 ---
 

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -233,7 +233,9 @@ describe("main — resolve", () => {
     expect(out).toContain("Minimized comments (2): c-1, c-2");
     expect(out).toContain("Stopped: GitHub rate limit hit");
     expect(out).toContain("retry after 60s");
+    expect(out).toContain("reset at 2023-11-14T22:13:20.000Z");
     expect(out).toContain("Not minimized due to rate limit (2): c-3, c-4");
+    expect(out).not.toContain("Errors:");
   });
 
   it("resolve mutate --format=json includes rate-limit stop and pending IDs", async () => {

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -211,6 +211,59 @@ describe("main — resolve", () => {
     expect(mockRunResolveMutate).toHaveBeenCalledTimes(1);
   });
 
+  it("formatMutateResult renders rate-limit stop and pending IDs", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      resolvedThreads: [],
+      minimizedComments: ["c-1", "c-2"],
+      dismissedReviews: [],
+      errors: ["rate limit: API rate limit exceeded"],
+      rateLimit: {
+        message: "API rate limit exceeded",
+        retryAfterSeconds: 60,
+        remaining: 0,
+        limit: 5000,
+        resetAt: 1700000000,
+      },
+      unminimizedComments: ["c-3", "c-4"],
+    });
+
+    await main(["node", "shepherd", "resolve", "42", "--minimize-comment-ids", "c-1,c-2,c-3,c-4"]);
+
+    const out = getStdout();
+    expect(out).toContain("Minimized comments (2): c-1, c-2");
+    expect(out).toContain("Stopped: GitHub rate limit hit");
+    expect(out).toContain("retry after 60s");
+    expect(out).toContain("Not minimized due to rate limit (2): c-3, c-4");
+  });
+
+  it("resolve mutate --format=json includes rate-limit stop and pending IDs", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      resolvedThreads: ["t-1"],
+      minimizedComments: [],
+      dismissedReviews: [],
+      errors: ["rate limit: secondary rate limit"],
+      rateLimit: { message: "secondary rate limit" },
+      unresolvedThreads: ["t-2"],
+    });
+
+    await main([
+      "node",
+      "shepherd",
+      "resolve",
+      "42",
+      "--resolve-thread-ids",
+      "t-1,t-2",
+      "--format=json",
+    ]);
+
+    const parsed = JSON.parse(getStdout()) as {
+      rateLimit: { message: string };
+      unresolvedThreads: string[];
+    };
+    expect(parsed.rateLimit.message).toBe("secondary rate limit");
+    expect(parsed.unresolvedThreads).toEqual(["t-2"]);
+  });
+
   it("formatFetchResult emits H1 heading, Markdown sections, and ## Instructions", async () => {
     mockRunResolveFetch.mockResolvedValue({
       prNumber: 42,

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -163,7 +163,9 @@ export function formatMutateResult(result: ResolveResult): string {
       result.rateLimit.remaining !== undefined && result.rateLimit.limit !== undefined
         ? `remaining ${result.rateLimit.remaining}/${result.rateLimit.limit}`
         : null,
-      result.rateLimit.resetAt !== undefined ? `reset ${result.rateLimit.resetAt}` : null,
+      result.rateLimit.resetAt !== undefined
+        ? `reset at ${new Date(result.rateLimit.resetAt * 1000).toISOString()}`
+        : null,
     ]
       .filter(Boolean)
       .join(", ");
@@ -183,6 +185,9 @@ export function formatMutateResult(result: ResolveResult): string {
     lines.push(
       `Not dismissed due to rate limit (${result.undismissedReviews.length}): ${result.undismissedReviews.join(", ")}`,
     );
-  if (result.errors.length) lines.push(`Errors:\n  ${result.errors.join("\n  ")}`);
+  const errors = result.rateLimit
+    ? result.errors.filter((e) => !e.startsWith("rate limit:"))
+    : result.errors;
+  if (errors.length) lines.push(`Errors:\n  ${errors.join("\n  ")}`);
   return lines.join("\n");
 }

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -155,6 +155,34 @@ export function formatMutateResult(result: ResolveResult): string {
     lines.push(
       `Dismissed reviews (${result.dismissedReviews.length}): ${result.dismissedReviews.join(", ")}`,
     );
+  if (result.rateLimit) {
+    const details = [
+      result.rateLimit.retryAfterSeconds !== undefined
+        ? `retry after ${result.rateLimit.retryAfterSeconds}s`
+        : null,
+      result.rateLimit.remaining !== undefined && result.rateLimit.limit !== undefined
+        ? `remaining ${result.rateLimit.remaining}/${result.rateLimit.limit}`
+        : null,
+      result.rateLimit.resetAt !== undefined ? `reset ${result.rateLimit.resetAt}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    lines.push(
+      `Stopped: GitHub rate limit hit — ${result.rateLimit.message}${details ? ` (${details})` : ""}`,
+    );
+  }
+  if (result.unresolvedThreads?.length)
+    lines.push(
+      `Not resolved due to rate limit (${result.unresolvedThreads.length}): ${result.unresolvedThreads.join(", ")}`,
+    );
+  if (result.unminimizedComments?.length)
+    lines.push(
+      `Not minimized due to rate limit (${result.unminimizedComments.length}): ${result.unminimizedComments.join(", ")}`,
+    );
+  if (result.undismissedReviews?.length)
+    lines.push(
+      `Not dismissed due to rate limit (${result.undismissedReviews.length}): ${result.undismissedReviews.join(", ")}`,
+    );
   if (result.errors.length) lines.push(`Errors:\n  ${result.errors.join("\n  ")}`);
   return lines.join("\n");
 }

--- a/src/comments/pending-ops.mts
+++ b/src/comments/pending-ops.mts
@@ -1,0 +1,35 @@
+import type { ResolveResult } from "./resolve.mts";
+
+export type ResolveMutationOp =
+  | { kind: "r"; id: string }
+  | { kind: "m"; id: string }
+  | { kind: "d"; id: string };
+
+export function setPendingOps(result: ResolveResult, ops: ResolveMutationOp[]): void {
+  const resolved = new Set(result.resolvedThreads);
+  const minimized = new Set(result.minimizedComments);
+  const dismissed = new Set(result.dismissedReviews);
+
+  const unresolvedThreads = ops
+    .filter(
+      (op): op is Extract<ResolveMutationOp, { kind: "r" }> =>
+        op.kind === "r" && !resolved.has(op.id),
+    )
+    .map((op) => op.id);
+  const unminimizedComments = ops
+    .filter(
+      (op): op is Extract<ResolveMutationOp, { kind: "m" }> =>
+        op.kind === "m" && !minimized.has(op.id),
+    )
+    .map((op) => op.id);
+  const undismissedReviews = ops
+    .filter(
+      (op): op is Extract<ResolveMutationOp, { kind: "d" }> =>
+        op.kind === "d" && !dismissed.has(op.id),
+    )
+    .map((op) => op.id);
+
+  if (unresolvedThreads.length > 0) result.unresolvedThreads = unresolvedThreads;
+  if (unminimizedComments.length > 0) result.unminimizedComments = unminimizedComments;
+  if (undismissedReviews.length > 0) result.undismissedReviews = undismissedReviews;
+}

--- a/src/comments/pending-ops.test.mts
+++ b/src/comments/pending-ops.test.mts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { setPendingOps, type ResolveMutationOp } from "./pending-ops.mts";
+import type { ResolveResult } from "./resolve.mts";
+
+function makeResult(overrides: Partial<ResolveResult> = {}): ResolveResult {
+  return {
+    resolvedThreads: [],
+    minimizedComments: [],
+    dismissedReviews: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe("setPendingOps", () => {
+  it("records unresolved, unminimized, and undismissed IDs not already completed", () => {
+    const result = makeResult({
+      resolvedThreads: ["t-done"],
+      minimizedComments: ["c-done"],
+      dismissedReviews: ["r-done"],
+    });
+    const ops: ResolveMutationOp[] = [
+      { kind: "r", id: "t-done" },
+      { kind: "r", id: "t-pending" },
+      { kind: "m", id: "c-done" },
+      { kind: "m", id: "c-pending" },
+      { kind: "d", id: "r-done" },
+      { kind: "d", id: "r-pending" },
+    ];
+
+    setPendingOps(result, ops);
+
+    expect(result.unresolvedThreads).toEqual(["t-pending"]);
+    expect(result.unminimizedComments).toEqual(["c-pending"]);
+    expect(result.undismissedReviews).toEqual(["r-pending"]);
+  });
+
+  it("omits pending arrays when all IDs already completed", () => {
+    const result = makeResult({
+      resolvedThreads: ["t-done"],
+      minimizedComments: ["c-done"],
+      dismissedReviews: ["r-done"],
+    });
+
+    setPendingOps(result, [
+      { kind: "r", id: "t-done" },
+      { kind: "m", id: "c-done" },
+      { kind: "d", id: "r-done" },
+    ]);
+
+    expect(result.unresolvedThreads).toBeUndefined();
+    expect(result.unminimizedComments).toBeUndefined();
+    expect(result.undismissedReviews).toBeUndefined();
+  });
+});

--- a/src/comments/rate-limit.mts
+++ b/src/comments/rate-limit.mts
@@ -16,9 +16,11 @@ export function rateLimitFromError(
     retryAfterSeconds?: unknown;
   };
   const message = err instanceof Error ? err.message : fallbackMessage;
+  const status = finiteNumber(maybe.status);
+  const hasRateLimitStatus = status === 403 || status === 429;
   if (
     !isRateLimitMessage(message) &&
-    maybe.retryAfterSeconds === undefined &&
+    !(hasRateLimitStatus && maybe.retryAfterSeconds !== undefined) &&
     maybe.rateLimit?.remaining !== 0
   )
     return null;

--- a/src/comments/rate-limit.mts
+++ b/src/comments/rate-limit.mts
@@ -16,7 +16,12 @@ export function rateLimitFromError(
     retryAfterSeconds?: unknown;
   };
   const message = err instanceof Error ? err.message : fallbackMessage;
-  if (!isRateLimitMessage(message) && maybe.status !== 403 && maybe.status !== 429) return null;
+  if (
+    !isRateLimitMessage(message) &&
+    maybe.retryAfterSeconds === undefined &&
+    maybe.rateLimit?.remaining !== 0
+  )
+    return null;
   return buildRateLimitStop(message, {
     rateLimit: maybe.rateLimit,
     retryAfterSeconds: maybe.retryAfterSeconds,
@@ -62,6 +67,6 @@ function finiteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function isRateLimitMessage(message: string): boolean {
+export function isRateLimitMessage(message: string): boolean {
   return /rate limit|rate-limit|secondary limit|secondary rate/i.test(message);
 }

--- a/src/comments/rate-limit.mts
+++ b/src/comments/rate-limit.mts
@@ -1,0 +1,67 @@
+export interface ResolveRateLimitStop {
+  message: string;
+  retryAfterSeconds?: number;
+  limit?: number;
+  remaining?: number;
+  resetAt?: number;
+}
+
+export function rateLimitFromError(
+  err: unknown,
+  fallbackMessage: string,
+): ResolveRateLimitStop | null {
+  const maybe = err as {
+    status?: unknown;
+    rateLimit?: { remaining?: unknown; limit?: unknown; resetAt?: unknown };
+    retryAfterSeconds?: unknown;
+  };
+  const message = err instanceof Error ? err.message : fallbackMessage;
+  if (!isRateLimitMessage(message) && maybe.status !== 403 && maybe.status !== 429) return null;
+  return buildRateLimitStop(message, {
+    rateLimit: maybe.rateLimit,
+    retryAfterSeconds: maybe.retryAfterSeconds,
+  });
+}
+
+export function rateLimitFromGraphQlResult(
+  messages: string[],
+  meta: {
+    rateLimit?: { remaining?: unknown; limit?: unknown; resetAt?: unknown };
+    retryAfterSeconds?: unknown;
+    stopOnZeroRemaining?: boolean;
+  },
+): ResolveRateLimitStop | undefined {
+  const message = messages.find(isRateLimitMessage);
+  if (message) return buildRateLimitStop(message, meta);
+  if (meta.stopOnZeroRemaining === true && meta.rateLimit?.remaining === 0) {
+    return buildRateLimitStop("GitHub GraphQL rate limit remaining is 0", meta);
+  }
+  return undefined;
+}
+
+function buildRateLimitStop(
+  message: string,
+  meta: {
+    rateLimit?: { remaining?: unknown; limit?: unknown; resetAt?: unknown };
+    retryAfterSeconds?: unknown;
+  },
+): ResolveRateLimitStop {
+  const stop: ResolveRateLimitStop = { message };
+  const retryAfterSeconds = finiteNumber(meta.retryAfterSeconds);
+  const remaining = finiteNumber(meta.rateLimit?.remaining);
+  const limit = finiteNumber(meta.rateLimit?.limit);
+  const resetAt = finiteNumber(meta.rateLimit?.resetAt);
+  if (retryAfterSeconds !== undefined) stop.retryAfterSeconds = retryAfterSeconds;
+  if (limit !== undefined) stop.limit = limit;
+  if (remaining !== undefined) stop.remaining = remaining;
+  if (resetAt !== undefined) stop.resetAt = resetAt;
+  return stop;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRateLimitMessage(message: string): boolean {
+  return /rate limit|rate-limit|secondary limit|secondary rate/i.test(message);
+}

--- a/src/comments/resolve.mock.test.mts
+++ b/src/comments/resolve.mock.test.mts
@@ -83,6 +83,23 @@ describe("applyResolveOptions — mutations", () => {
     expect(result.errors[0]).toContain("server unavailable");
   });
 
+  it("does not classify non-rate-limit 403 errors as retryable rate limits", async () => {
+    mockGraphql.mockRejectedValueOnce(
+      Object.assign(new Error("Resource not accessible by integration"), { status: 403 }),
+    );
+
+    const result = await applyResolveOptions(1, REPO, {
+      minimizeCommentIds: ["c-bad", "c-later"],
+    });
+
+    expect(result.rateLimit).toBeUndefined();
+    expect(result.unminimizedComments).toBeUndefined();
+    expect(result.errors).toEqual([
+      "c-bad: Resource not accessible by integration",
+      "c-later: Resource not accessible by integration",
+    ]);
+  });
+
   it("stops on a thrown rate limit and reports unattempted IDs", async () => {
     const ids = Array.from({ length: 25 }, (_, i) => `c-${i}`);
     mockGraphql
@@ -149,6 +166,30 @@ describe("applyResolveOptions — mutations", () => {
     expect(result.minimizedComments).toEqual(ids.slice(0, 10));
     expect(result.unminimizedComments).toEqual(ids.slice(10));
     expect(result.rateLimit?.message).toContain("remaining is 0");
+  });
+
+  it("preserves current-batch alias failures when only headers show remaining zero", async () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `c-${i}`);
+    mockGraphql.mockResolvedValueOnce({
+      data: {
+        m0: { minimizedComment: { isMinimized: true } },
+        m1: null,
+        m2: { minimizedComment: { isMinimized: true } },
+        m3: { minimizedComment: { isMinimized: true } },
+        m4: { minimizedComment: { isMinimized: true } },
+        m5: { minimizedComment: { isMinimized: true } },
+        m6: { minimizedComment: { isMinimized: true } },
+        m7: { minimizedComment: { isMinimized: true } },
+        m8: { minimizedComment: { isMinimized: true } },
+        m9: { minimizedComment: { isMinimized: true } },
+      },
+      rateLimit: { remaining: 0, limit: 5000, resetAt: 1700000000 },
+    });
+
+    const result = await applyResolveOptions(1, REPO, { minimizeCommentIds: ids });
+
+    expect(result.errors).toContain("c-1: minimize returned null or comment not minimized");
+    expect(result.unminimizedComments).toEqual(["c-1", "c-10", "c-11"]);
   });
 
   it("records error when resolve alias returns non-resolved thread", async () => {

--- a/src/comments/resolve.mock.test.mts
+++ b/src/comments/resolve.mock.test.mts
@@ -5,14 +5,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ---------------------------------------------------------------------------
 
 vi.mock("../github/client.mts", () => ({
-  graphql: vi.fn(),
+  graphqlWithRateLimit: vi.fn(),
   getPrHeadSha: vi.fn(),
 }));
 
 import { applyResolveOptions, autoResolveOutdated } from "./resolve.mts";
-import { graphql, getPrHeadSha } from "../github/client.mts";
+import { graphqlWithRateLimit, getPrHeadSha } from "../github/client.mts";
 
-const mockGraphql = vi.mocked(graphql);
+const mockGraphql = vi.mocked(graphqlWithRateLimit);
 const mockGetPrHeadSha = vi.mocked(getPrHeadSha);
 
 const REPO = { owner: "owner", name: "repo" };
@@ -76,11 +76,79 @@ describe("applyResolveOptions — mutations", () => {
   });
 
   it("collects errors as 'id: message' without throwing", async () => {
-    mockGraphql.mockRejectedValueOnce(new Error("rate limited"));
+    mockGraphql.mockRejectedValueOnce(new Error("server unavailable"));
     const result = await applyResolveOptions(1, REPO, { resolveThreadIds: ["t-bad"] });
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("t-bad:");
-    expect(result.errors[0]).toContain("rate limited");
+    expect(result.errors[0]).toContain("server unavailable");
+  });
+
+  it("stops on a thrown rate limit and reports unattempted IDs", async () => {
+    const ids = Array.from({ length: 25 }, (_, i) => `c-${i}`);
+    mockGraphql
+      .mockImplementationOnce(async (doc) => makeBulkResponse(doc))
+      .mockRejectedValueOnce(
+        Object.assign(new Error("API rate limit exceeded"), {
+          status: 403,
+          retryAfterSeconds: 60,
+          rateLimit: { remaining: 0, limit: 5000, resetAt: 1700000000 },
+        }),
+      );
+
+    const result = await applyResolveOptions(1, REPO, { minimizeCommentIds: ids });
+
+    expect(mockGraphql).toHaveBeenCalledTimes(2);
+    expect(result.minimizedComments).toEqual(ids.slice(0, 10));
+    expect(result.unminimizedComments).toEqual(ids.slice(10));
+    expect(result.rateLimit).toMatchObject({
+      message: "API rate limit exceeded",
+      retryAfterSeconds: 60,
+      remaining: 0,
+      limit: 5000,
+      resetAt: 1700000000,
+    });
+  });
+
+  it("records partial successes from a GraphQL response before stopping on rate-limit errors", async () => {
+    const ids = Array.from({ length: 15 }, (_, i) => `c-${i}`);
+    mockGraphql.mockResolvedValueOnce({
+      data: {
+        m0: { minimizedComment: { isMinimized: true } },
+        m1: { minimizedComment: { isMinimized: true } },
+        m2: null,
+        m3: null,
+        m4: null,
+        m5: null,
+        m6: null,
+        m7: null,
+        m8: null,
+        m9: null,
+      },
+      errors: [{ message: "You have exceeded a secondary rate limit" }],
+      rateLimit: { remaining: 10, limit: 5000, resetAt: 1700000000 },
+    });
+
+    const result = await applyResolveOptions(1, REPO, { minimizeCommentIds: ids });
+
+    expect(mockGraphql).toHaveBeenCalledTimes(1);
+    expect(result.minimizedComments).toEqual(["c-0", "c-1"]);
+    expect(result.unminimizedComments).toEqual(ids.slice(2));
+    expect(result.errors).toContain("rate limit: You have exceeded a secondary rate limit");
+  });
+
+  it("stops before the next batch when remaining rate-limit budget reaches zero", async () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `c-${i}`);
+    mockGraphql.mockResolvedValueOnce({
+      ...makeBulkResponse("  m0:\n  m1:\n  m2:\n  m3:\n  m4:\n  m5:\n  m6:\n  m7:\n  m8:\n  m9:"),
+      rateLimit: { remaining: 0, limit: 5000, resetAt: 1700000000 },
+    });
+
+    const result = await applyResolveOptions(1, REPO, { minimizeCommentIds: ids });
+
+    expect(mockGraphql).toHaveBeenCalledTimes(1);
+    expect(result.minimizedComments).toEqual(ids.slice(0, 10));
+    expect(result.unminimizedComments).toEqual(ids.slice(10));
+    expect(result.rateLimit?.message).toContain("remaining is 0");
   });
 
   it("records error when resolve alias returns non-resolved thread", async () => {
@@ -122,30 +190,16 @@ describe("autoResolveOutdated", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("issues a single bulk graphql call when ids fit in one chunk", async () => {
-    const ids = Array.from({ length: 20 }, (_, i) => `t-${i}`);
+  it("splits mutations into 10-op graphql calls", async () => {
+    const ids = Array.from({ length: 25 }, (_, i) => `t-${i}`);
     await autoResolveOutdated(ids);
-    expect(mockGraphql).toHaveBeenCalledTimes(1);
+    expect(mockGraphql).toHaveBeenCalledTimes(3);
     const doc = mockGraphql.mock.calls[0]?.[0] as string;
     expect(doc).toContain("mutation BulkApply");
-    // All 20 IDs should appear inline.
-    for (const id of ids) {
+    for (const id of ids.slice(0, 10)) {
       expect(doc).toContain(id);
     }
-  });
-
-  it("splits into multiple graphql calls when ids exceed BULK_CHUNK_SIZE (50)", async () => {
-    const ids = Array.from({ length: 55 }, (_, i) => `t-${i}`);
-    await autoResolveOutdated(ids);
-    // 55 ids → chunk 1: t-0..t-49 (50 ops), chunk 2: t-50..t-54 (5 ops)
-    expect(mockGraphql).toHaveBeenCalledTimes(2);
-    const doc1 = mockGraphql.mock.calls[0]?.[0] as string;
-    const doc2 = mockGraphql.mock.calls[1]?.[0] as string;
-    expect(doc1).toContain("t-0");
-    expect(doc1).toContain("t-49");
-    expect(doc1).not.toContain("t-50");
-    expect(doc2).toContain("t-50");
-    expect(doc2).toContain("t-54");
+    expect(doc).not.toContain("t-10");
   });
 });
 

--- a/src/comments/resolve.mock.test.mts
+++ b/src/comments/resolve.mock.test.mts
@@ -100,6 +100,36 @@ describe("applyResolveOptions — mutations", () => {
     ]);
   });
 
+  it("does not classify retry-after alone as a rate-limit stop without rate-limit status", async () => {
+    mockGraphql.mockRejectedValueOnce(
+      Object.assign(new Error("Service unavailable"), {
+        status: 503,
+        retryAfterSeconds: 30,
+      }),
+    );
+
+    const result = await applyResolveOptions(1, REPO, { resolveThreadIds: ["t-1"] });
+
+    expect(result.rateLimit).toBeUndefined();
+    expect(result.unresolvedThreads).toBeUndefined();
+    expect(result.errors).toEqual(["t-1: Service unavailable"]);
+  });
+
+  it("classifies retry-after with a rate-limit status as a rate-limit stop", async () => {
+    mockGraphql.mockRejectedValueOnce(
+      Object.assign(new Error("Forbidden"), {
+        status: 403,
+        retryAfterSeconds: 30,
+      }),
+    );
+
+    const result = await applyResolveOptions(1, REPO, { resolveThreadIds: ["t-1", "t-2"] });
+
+    expect(result.rateLimit).toMatchObject({ message: "Forbidden", retryAfterSeconds: 30 });
+    expect(result.unresolvedThreads).toEqual(["t-1", "t-2"]);
+    expect(result.errors).toEqual(["rate limit: Forbidden"]);
+  });
+
   it("stops on a thrown rate limit and reports unattempted IDs", async () => {
     const ids = Array.from({ length: 25 }, (_, i) => `c-${i}`);
     mockGraphql

--- a/src/comments/resolve.mock.test.mts
+++ b/src/comments/resolve.mock.test.mts
@@ -133,7 +133,7 @@ describe("applyResolveOptions — mutations", () => {
     expect(mockGraphql).toHaveBeenCalledTimes(1);
     expect(result.minimizedComments).toEqual(["c-0", "c-1"]);
     expect(result.unminimizedComments).toEqual(ids.slice(2));
-    expect(result.errors).toContain("rate limit: You have exceeded a secondary rate limit");
+    expect(result.errors).toEqual(["rate limit: You have exceeded a secondary rate limit"]);
   });
 
   it("stops before the next batch when remaining rate-limit budget reaches zero", async () => {

--- a/src/comments/resolve.mts
+++ b/src/comments/resolve.mts
@@ -1,12 +1,22 @@
-import { graphql, getPrHeadSha, type RepoInfo } from "../github/client.mts";
+import { graphqlWithRateLimit, type RepoInfo } from "../github/client.mts";
 import type { ResolveOptions } from "../types.mts";
-import { loadConfig } from "../config/load.mts";
+import {
+  rateLimitFromError,
+  rateLimitFromGraphQlResult,
+  type ResolveRateLimitStop,
+} from "./rate-limit.mts";
+import { setPendingOps, type ResolveMutationOp } from "./pending-ops.mts";
+import { waitForSha } from "./sha-poll.mts";
 
 export interface ResolveResult {
   resolvedThreads: string[];
   minimizedComments: string[];
   dismissedReviews: string[];
   errors: string[];
+  rateLimit?: ResolveRateLimitStop;
+  unresolvedThreads?: string[];
+  unminimizedComments?: string[];
+  undismissedReviews?: string[];
 }
 
 export async function applyResolveOptions(
@@ -55,8 +65,8 @@ export async function autoResolveOutdated(
   return { resolved: result.resolvedThreads, errors: result.errors };
 }
 
-// Chunk at 50 so a single oversized list never fails the entire call.
-const BULK_CHUNK_SIZE = 50;
+// Keep mutation batches small so rate-limit stops leave a precise pending list.
+const BULK_CHUNK_SIZE = 10;
 
 function buildBulkMutation(
   resolveIds: string[],
@@ -94,8 +104,7 @@ async function bulkApply(
   dismissMessage: string,
   result: ResolveResult,
 ): Promise<void> {
-  type Op = { kind: "r"; id: string } | { kind: "m"; id: string } | { kind: "d"; id: string };
-  const allOps: Op[] = [
+  const allOps: ResolveMutationOp[] = [
     ...resolveIds.map((id) => ({ kind: "r" as const, id })),
     ...minimizeIds.map((id) => ({ kind: "m" as const, id })),
     ...dismissIds.map((id) => ({ kind: "d" as const, id })),
@@ -104,13 +113,18 @@ async function bulkApply(
   for (let i = 0; i < allOps.length; i += BULK_CHUNK_SIZE) {
     const chunk = allOps.slice(i, i + BULK_CHUNK_SIZE);
     // eslint-disable-next-line no-await-in-loop
-    await bulkApplyChunk(
+    const stopped = await bulkApplyChunk(
       chunk.filter((o) => o.kind === "r").map((o) => o.id),
       chunk.filter((o) => o.kind === "m").map((o) => o.id),
       chunk.filter((o) => o.kind === "d").map((o) => o.id),
       dismissMessage,
       result,
+      i + BULK_CHUNK_SIZE < allOps.length,
     );
+    if (stopped) {
+      setPendingOps(result, allOps.slice(i));
+      return;
+    }
   }
 }
 
@@ -120,21 +134,34 @@ async function bulkApplyChunk(
   dismissIds: string[],
   dismissMessage: string,
   result: ResolveResult,
-): Promise<void> {
-  if (resolveIds.length === 0 && minimizeIds.length === 0 && dismissIds.length === 0) return;
+  hasPendingAfter: boolean,
+): Promise<boolean> {
+  if (resolveIds.length === 0 && minimizeIds.length === 0 && dismissIds.length === 0) return false;
 
   const doc = buildBulkMutation(resolveIds, minimizeIds, dismissIds, dismissMessage);
 
   let data: Record<string, unknown>;
+  let rateLimitStop: ResolveRateLimitStop | undefined;
   try {
-    const resp = await graphql<Record<string, unknown>>(doc, {});
+    const resp = await graphqlWithRateLimit<Record<string, unknown>>(doc, {});
     data = resp.data;
+    rateLimitStop = rateLimitFromGraphQlResult(resp.errors?.map((e) => e.message) ?? [], {
+      rateLimit: resp.rateLimit,
+      retryAfterSeconds: resp.retryAfterSeconds,
+      stopOnZeroRemaining: hasPendingAfter,
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    const stop = rateLimitFromError(err, msg);
+    if (stop) {
+      result.errors.push(`rate limit: ${stop.message}`);
+      result.rateLimit = stop;
+      return true;
+    }
     for (const id of resolveIds) result.errors.push(`${id}: ${msg}`);
     for (const id of minimizeIds) result.errors.push(`${id}: ${msg}`);
     for (const id of dismissIds) result.errors.push(`${id}: ${msg}`);
-    return;
+    return false;
   }
 
   for (let i = 0; i < resolveIds.length; i++) {
@@ -154,33 +181,12 @@ async function bulkApplyChunk(
     if (d?.pullRequestReview != null) result.dismissedReviews.push(dismissIds[i]!);
     else result.errors.push(`${dismissIds[i]}: dismiss returned null`);
   }
-}
 
-async function waitForSha(pr: number, repo: RepoInfo, expectedSha: string): Promise<void> {
-  const { intervalMs: SHA_POLL_INTERVAL_MS, maxAttempts: SHA_POLL_MAX_ATTEMPTS } =
-    loadConfig().resolve.shaPoll;
-  for (let attempt = 0; attempt < SHA_POLL_MAX_ATTEMPTS; attempt++) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const currentSha = await getPrHeadSha(pr, repo.owner, repo.name);
-      if (currentSha === expectedSha) return;
-    } catch (err) {
-      if (attempt === SHA_POLL_MAX_ATTEMPTS - 1) throw err;
-    }
-
-    if (attempt < SHA_POLL_MAX_ATTEMPTS - 1) {
-      // eslint-disable-next-line no-await-in-loop
-      await sleep(SHA_POLL_INTERVAL_MS);
-    }
+  if (rateLimitStop) {
+    result.errors.push(`rate limit: ${rateLimitStop.message}`);
+    result.rateLimit = rateLimitStop;
+    return true;
   }
 
-  throw new Error(
-    `Timeout: GitHub PR #${pr} head SHA has not updated to ${expectedSha} after ${
-      ((SHA_POLL_MAX_ATTEMPTS - 1) * SHA_POLL_INTERVAL_MS) / 1000
-    }s. Push may still be in transit — retry shortly.`,
-  );
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return false;
 }

--- a/src/comments/resolve.mts
+++ b/src/comments/resolve.mts
@@ -167,19 +167,21 @@ async function bulkApplyChunk(
   for (let i = 0; i < resolveIds.length; i++) {
     const r = data[`r${i}`] as { thread?: { isResolved?: boolean } } | null | undefined;
     if (r?.thread?.isResolved === true) result.resolvedThreads.push(resolveIds[i]!);
-    else result.errors.push(`${resolveIds[i]}: resolve returned null or thread not resolved`);
+    else if (!rateLimitStop)
+      result.errors.push(`${resolveIds[i]}: resolve returned null or thread not resolved`);
   }
 
   for (let i = 0; i < minimizeIds.length; i++) {
     const m = data[`m${i}`] as { minimizedComment?: { isMinimized?: boolean } } | null | undefined;
     if (m?.minimizedComment?.isMinimized === true) result.minimizedComments.push(minimizeIds[i]!);
-    else result.errors.push(`${minimizeIds[i]}: minimize returned null or comment not minimized`);
+    else if (!rateLimitStop)
+      result.errors.push(`${minimizeIds[i]}: minimize returned null or comment not minimized`);
   }
 
   for (let i = 0; i < dismissIds.length; i++) {
     const d = data[`d${i}`] as { pullRequestReview?: { state?: string } } | null | undefined;
     if (d?.pullRequestReview != null) result.dismissedReviews.push(dismissIds[i]!);
-    else result.errors.push(`${dismissIds[i]}: dismiss returned null`);
+    else if (!rateLimitStop) result.errors.push(`${dismissIds[i]}: dismiss returned null`);
   }
 
   if (rateLimitStop) {

--- a/src/comments/resolve.mts
+++ b/src/comments/resolve.mts
@@ -1,6 +1,7 @@
 import { graphqlWithRateLimit, type RepoInfo } from "../github/client.mts";
 import type { ResolveOptions } from "../types.mts";
 import {
+  isRateLimitMessage,
   rateLimitFromError,
   rateLimitFromGraphQlResult,
   type ResolveRateLimitStop,
@@ -142,10 +143,13 @@ async function bulkApplyChunk(
 
   let data: Record<string, unknown>;
   let rateLimitStop: ResolveRateLimitStop | undefined;
+  let suppressCurrentChunkErrors = false;
   try {
     const resp = await graphqlWithRateLimit<Record<string, unknown>>(doc, {});
     data = resp.data;
-    rateLimitStop = rateLimitFromGraphQlResult(resp.errors?.map((e) => e.message) ?? [], {
+    const graphQlErrorMessages = resp.errors?.map((e) => e.message) ?? [];
+    suppressCurrentChunkErrors = graphQlErrorMessages.some(isRateLimitMessage);
+    rateLimitStop = rateLimitFromGraphQlResult(graphQlErrorMessages, {
       rateLimit: resp.rateLimit,
       retryAfterSeconds: resp.retryAfterSeconds,
       stopOnZeroRemaining: hasPendingAfter,
@@ -167,21 +171,22 @@ async function bulkApplyChunk(
   for (let i = 0; i < resolveIds.length; i++) {
     const r = data[`r${i}`] as { thread?: { isResolved?: boolean } } | null | undefined;
     if (r?.thread?.isResolved === true) result.resolvedThreads.push(resolveIds[i]!);
-    else if (!rateLimitStop)
+    else if (!suppressCurrentChunkErrors)
       result.errors.push(`${resolveIds[i]}: resolve returned null or thread not resolved`);
   }
 
   for (let i = 0; i < minimizeIds.length; i++) {
     const m = data[`m${i}`] as { minimizedComment?: { isMinimized?: boolean } } | null | undefined;
     if (m?.minimizedComment?.isMinimized === true) result.minimizedComments.push(minimizeIds[i]!);
-    else if (!rateLimitStop)
+    else if (!suppressCurrentChunkErrors)
       result.errors.push(`${minimizeIds[i]}: minimize returned null or comment not minimized`);
   }
 
   for (let i = 0; i < dismissIds.length; i++) {
     const d = data[`d${i}`] as { pullRequestReview?: { state?: string } } | null | undefined;
     if (d?.pullRequestReview != null) result.dismissedReviews.push(dismissIds[i]!);
-    else if (!rateLimitStop) result.errors.push(`${dismissIds[i]}: dismiss returned null`);
+    else if (!suppressCurrentChunkErrors)
+      result.errors.push(`${dismissIds[i]}: dismiss returned null`);
   }
 
   if (rateLimitStop) {

--- a/src/comments/sha-poll.mts
+++ b/src/comments/sha-poll.mts
@@ -1,0 +1,31 @@
+import { getPrHeadSha, type RepoInfo } from "../github/client.mts";
+import { loadConfig } from "../config/load.mts";
+
+export async function waitForSha(pr: number, repo: RepoInfo, expectedSha: string): Promise<void> {
+  const { intervalMs: SHA_POLL_INTERVAL_MS, maxAttempts: SHA_POLL_MAX_ATTEMPTS } =
+    loadConfig().resolve.shaPoll;
+  for (let attempt = 0; attempt < SHA_POLL_MAX_ATTEMPTS; attempt++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const currentSha = await getPrHeadSha(pr, repo.owner, repo.name);
+      if (currentSha === expectedSha) return;
+    } catch (err) {
+      if (attempt === SHA_POLL_MAX_ATTEMPTS - 1) throw err;
+    }
+
+    if (attempt < SHA_POLL_MAX_ATTEMPTS - 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(SHA_POLL_INTERVAL_MS);
+    }
+  }
+
+  throw new Error(
+    `Timeout: GitHub PR #${pr} head SHA has not updated to ${expectedSha} after ${
+      ((SHA_POLL_MAX_ATTEMPTS - 1) * SHA_POLL_INTERVAL_MS) / 1000
+    }s. Push may still be in transit — retry shortly.`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/comments/sha-poll.test.mts
+++ b/src/comments/sha-poll.test.mts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../github/client.mts", () => ({
+  getPrHeadSha: vi.fn(),
+}));
+
+import { waitForSha } from "./sha-poll.mts";
+import { getPrHeadSha } from "../github/client.mts";
+
+const mockGetPrHeadSha = vi.mocked(getPrHeadSha);
+const REPO = { owner: "owner", name: "repo" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("waitForSha", () => {
+  it("rethrows the last SHA lookup error", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetPrHeadSha.mockRejectedValue(new Error("GitHub unavailable"));
+      const settled = waitForSha(42, REPO, "expected-sha").catch((e: unknown) => e as Error);
+
+      await vi.runAllTimersAsync();
+
+      await expect(settled).resolves.toMatchObject({ message: "GitHub unavailable" });
+      expect(mockGetPrHeadSha).toHaveBeenCalledTimes(10);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/github/client.mts
+++ b/src/github/client.mts
@@ -8,11 +8,19 @@
 
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import { graphql as httpGraphql, rest, type RateLimitInfo, type GraphQlResult } from "./http.mts";
+import {
+  graphql as httpGraphql,
+  rest,
+  type RateLimitInfo,
+  type GraphQlResult,
+  type GitHubGraphQlError,
+  GitHubRequestError,
+} from "./http.mts";
 import { PR_NUMBER_BY_BRANCH_QUERY, GET_PR_HEAD_SHA_QUERY } from "./queries.mts";
 import type { MergeableState, MergeStateStatus } from "../types.mts";
 
-export type { RateLimitInfo, GraphQlResult };
+export type { RateLimitInfo, GraphQlResult, GitHubGraphQlError };
+export { GitHubRequestError };
 
 const execFile = promisify(execFileCb);
 

--- a/src/github/errors.mts
+++ b/src/github/errors.mts
@@ -1,0 +1,18 @@
+import type { RateLimitInfo } from "./http.mts";
+
+export class GitHubRequestError extends Error {
+  readonly status: number;
+  readonly rateLimit?: RateLimitInfo;
+  readonly retryAfterSeconds?: number;
+
+  constructor(
+    message: string,
+    opts: { status: number; rateLimit?: RateLimitInfo; retryAfterSeconds?: number },
+  ) {
+    super(message);
+    this.name = "GitHubRequestError";
+    this.status = opts.status;
+    this.rateLimit = opts.rateLimit;
+    this.retryAfterSeconds = opts.retryAfterSeconds;
+  }
+}

--- a/src/github/http.mock.test.mts
+++ b/src/github/http.mock.test.mts
@@ -25,7 +25,14 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import { graphql, graphqlWithRateLimit, rest, restText, _resetTokenCache } from "./http.mts";
+import {
+  GitHubRequestError,
+  graphql,
+  graphqlWithRateLimit,
+  rest,
+  restText,
+  _resetTokenCache,
+} from "./http.mts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -233,6 +240,43 @@ describe("graphqlWithRateLimit — header parsing", () => {
     });
     const result = await graphqlWithRateLimit("{ q }");
     expect(result.rateLimit).toEqual({ remaining: 42, limit: 5000, resetAt: 1700000000 });
+  });
+
+  it("returns retry-after and GraphQL errors on partial data", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "retry-after": "30" }),
+      json: () =>
+        Promise.resolve({
+          data: { m0: null },
+          errors: [{ message: "You have exceeded a secondary rate limit" }],
+        }),
+    });
+    const result = await graphqlWithRateLimit("{ q }");
+    expect(result.retryAfterSeconds).toBe(30);
+    expect(result.errors).toEqual([{ message: "You have exceeded a secondary rate limit" }]);
+  });
+
+  it("throws GitHubRequestError with rate-limit metadata on failed response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers({
+        "retry-after": "60",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-reset": "1700000000",
+      }),
+      text: () => Promise.resolve("API rate limit exceeded"),
+    });
+
+    await expect(graphqlWithRateLimit("{ q }")).rejects.toMatchObject({
+      name: "GitHubRequestError",
+      status: 403,
+      retryAfterSeconds: 60,
+      rateLimit: { remaining: 0, limit: 5000, resetAt: 1700000000 },
+    } satisfies Partial<GitHubRequestError>);
   });
 
   it("returns rateLimit: undefined when rate-limit headers are absent", async () => {

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -4,7 +4,7 @@ import { appendEntry, nextEntry } from "../log/log-file.mts";
 import { formatRequestEntry, formatResponseEntry } from "../log/session.mts";
 import { GitHubRequestError } from "./errors.mts";
 
-export { GitHubRequestError } from "./errors.mts";
+export { GitHubRequestError };
 
 const execFile = promisify(execFileCb);
 

--- a/src/github/http.mts
+++ b/src/github/http.mts
@@ -2,6 +2,9 @@ import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { appendEntry, nextEntry } from "../log/log-file.mts";
 import { formatRequestEntry, formatResponseEntry } from "../log/session.mts";
+import { GitHubRequestError } from "./errors.mts";
+
+export { GitHubRequestError } from "./errors.mts";
 
 const execFile = promisify(execFileCb);
 
@@ -13,9 +16,15 @@ export interface RateLimitInfo {
   resetAt: number;
 }
 
+export interface GitHubGraphQlError {
+  message: string;
+}
+
 export interface GraphQlResult<T = unknown> {
   data: T;
   rateLimit?: RateLimitInfo;
+  retryAfterSeconds?: number;
+  errors?: GitHubGraphQlError[];
 }
 
 // ---------------------------------------------------------------------------
@@ -113,7 +122,12 @@ async function requestWithTokenRetry(
 async function graphqlInner<T>(
   query: string,
   vars: Record<string, unknown>,
-): Promise<{ data: T; rateLimit: RateLimitInfo | null }> {
+): Promise<{
+  data: T;
+  rateLimit: RateLimitInfo | null;
+  retryAfterSeconds: number | undefined;
+  errors: GitHubGraphQlError[] | undefined;
+}> {
   const url = `${BASE_URL}/graphql`;
   const n = nextEntry();
   appendEntry(
@@ -151,6 +165,7 @@ async function graphqlInner<T>(
 
   const durationMs = Math.round(performance.now() - retryT0);
   const rateLimit = parseRateLimit(res.headers);
+  const retryAfterSeconds = parseRetryAfter(res.headers);
 
   if (!res.ok) {
     const body = await res.text();
@@ -166,10 +181,13 @@ async function graphqlInner<T>(
         attempt: attempt > 1 ? attempt : undefined,
       }),
     );
-    throw new Error(`GitHub GraphQL request failed: ${res.status} ${sanitizeBody(body)}`);
+    throw new GitHubRequestError(
+      `GitHub GraphQL request failed: ${res.status} ${sanitizeBody(body)}`,
+      { status: res.status, rateLimit: rateLimit ?? undefined, retryAfterSeconds },
+    );
   }
 
-  const parsed = (await res.json()) as { data: T | null; errors?: Array<{ message: string }> };
+  const parsed = (await res.json()) as { data: T | null; errors?: GitHubGraphQlError[] };
   appendEntry(
     formatResponseEntry({
       n,
@@ -184,15 +202,19 @@ async function graphqlInner<T>(
   );
 
   if (parsed.data == null) {
-    const messages = (parsed.errors ?? []).map((e: { message: string }) => e.message).join("; ");
-    throw new Error(`GitHub GraphQL error (no data): ${messages}`);
+    const messages = (parsed.errors ?? []).map((e) => e.message).join("; ");
+    throw new GitHubRequestError(`GitHub GraphQL error (no data): ${messages}`, {
+      status: res.status,
+      rateLimit: rateLimit ?? undefined,
+      retryAfterSeconds,
+    });
   }
   if (parsed.errors?.length) {
-    const messages = parsed.errors.map((e: { message: string }) => e.message).join("; ");
+    const messages = parsed.errors.map((e) => e.message).join("; ");
     process.stderr.write(`pr-shepherd: GraphQL non-fatal errors: ${messages}\n`);
   }
 
-  return { data: parsed.data, rateLimit };
+  return { data: parsed.data, rateLimit, retryAfterSeconds, errors: parsed.errors };
 }
 
 export async function graphql<T = unknown>(
@@ -207,8 +229,8 @@ export async function graphqlWithRateLimit<T = unknown>(
   query: string,
   vars: Record<string, unknown> = {},
 ): Promise<GraphQlResult<T>> {
-  const { data, rateLimit } = await graphqlInner<T>(query, vars);
-  return { data, rateLimit: rateLimit ?? undefined };
+  const { data, rateLimit, retryAfterSeconds, errors } = await graphqlInner<T>(query, vars);
+  return { data, rateLimit: rateLimit ?? undefined, retryAfterSeconds, errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -409,4 +431,10 @@ function parseRateLimit(headers: Headers): RateLimitInfo | null {
     return { remaining, limit, resetAt };
   }
   return null;
+}
+
+function parseRetryAfter(headers: Headers): number | undefined {
+  const raw = headers.get("retry-after");
+  const seconds = Number(raw);
+  return raw !== null && Number.isFinite(seconds) && seconds >= 0 ? seconds : undefined;
 }


### PR DESCRIPTION
## Summary
- Fixes #173 by batching resolve/minimize/dismiss mutations in groups of 10.
- Stops immediately on GitHub primary or secondary rate-limit responses and reports successful IDs plus pending IDs for retry.
- Surfaces GraphQL retry/rate-limit metadata in mutate JSON/text output and updates docs.

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
- npx pr-shepherd --version

## Notes
- `git push` also ran the pre-push lint/typecheck/format checks successfully.
