### PR TITLE
cleanup: remove monitor/check remnants, fix doc drift, tighten types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ When making changes, review [`docs/`](docs/) and [`README.md`](README.md) for im
 
 CLI output should only include information that is relevant or actionable in the current state. Omit fields and lines that add noise without value:
 
-- Do not emit a field, flag, or line when its value is the trivial default (false, null, 0, empty). For example: do not emit `copilotReviewInProgress` unless it is `true`.
+- Do not emit a field, flag, or line when its value is the trivial default (false, null, 0, empty). For example: do not emit `blockingBotReviewInProgress` unless it is `true`.
 - Do not emit time-bounded or state-specific fields outside the state where they are meaningful. For example: do not emit `remainingSeconds` unless the PR is in the final ready-delay countdown.
 - Do not repeat information the reader already has from an earlier line in the same output block.
 - Omit section headers and labels when the section would be empty.
@@ -145,8 +145,7 @@ so their bodies are never fetched. This remains future work.
 Implementation lives in `src/state/seen-comments.mts`. The call sites are
 `src/commands/resolve.mts` (surfaced in `resolve --fetch` output under
 `## First-look items`) and `src/commands/check.mts` (surfaced in iterate's
-`fix_code` output under `## Review summaries (first look — to be minimized)`
-and in `pr-shepherd check` text output under `## First-look items`).
+`fix_code` output under `## Review summaries (first look — to be minimized)`).
 
 ## Keep skills and loop prompts minimal
 
@@ -158,7 +157,7 @@ Skills (`plugin/skills/*/SKILL.md`) and `/loop` prompts should be thin dispatche
 4. Print the full output.
 5. Follow the output's own `## Instructions` section exactly.
 
-The canonical example is `plugin/skills/resolve/SKILL.md` — 37 lines, pure dispatcher, no policy.
+The canonical example is `plugin/skills/pr-shepherd/SKILL.md` — pure dispatcher, no policy.
 
 Everything else belongs in the CLI's Markdown `## Instructions` output, not in the skill:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ At a high level, the skill invokes `pr-shepherd <PR>` through the selected packa
 
 ## Review threads
 
-### `PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate.mts:42` (@alice)
+### `PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate/index.mts:42` (@alice)
 
 > The variable name is misleading.
 >

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example Workflow:
 2. Create a plan
 3. Accept the plan
 4. Switch to Auto Mode
-5. Prompt: `make a PR, then run /pr-shepherd:monitor`
+5. Prompt: `make a PR, then run /pr-shepherd:pr-shepherd`
 6. Agent makes a draft PR
 7. PR has passing CI -> draft is marked Ready for Review
 8. Review bots begin providing reviews
@@ -112,9 +112,9 @@ Recommendations:
 
 ## Usage
 
-### Monitor a PR
+### Iterate a PR to completion
 
-One-tick dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Loops by sleeping between 30 seconds and 4 minutes and rerunning the configured command until the CLI emits `[CANCEL]` or `[ESCALATE]`.
+One-tick dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section telling the agent to pick a fresh 30s–4m delay and rerun; the loop continues until `[CANCEL]` or `[ESCALATE]`.
 
 Claude Code (via `pr-shepherd` skill):
 
@@ -208,13 +208,13 @@ If your Codex environment does not already set `CODEX_CI=1`, set `AGENT=codex` s
 export AGENT=codex
 ```
 
-Then start a PR monitor from Codex with the target repository's package runner:
+Then iterate a PR from Codex with the target repository's package runner:
 
 ```bash
-<runner> pr-shepherd monitor 42
+<runner> pr-shepherd iterate 42
 ```
 
-For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd monitor 42`. For npm repos, use `npx --no-install pr-shepherd monitor 42`.
+For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd iterate 42`. For npm repos, use `npx --no-install pr-shepherd iterate 42`.
 
 Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. The skill runs one tick and the instructions tell you to pick a fresh sleep/timeout between 30 seconds and 4 minutes before the next rerun. Continue until Shepherd emits `[CANCEL]` or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `pr-shepherd iterate 42` remains supported for existing workflows.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Quick entry point. For a command overview see [`../README.md`](../README.md).
 | [architecture.md](architecture.md)       | Module map, dependency rules, where to put new code                        |
 | [iterate-flow.md](iterate-flow.md)       | Full 8-step dispatch walkthrough inside `iterate`                          |
 | [actions.md](actions.md)                 | Every action: trigger, side-effects, prescriptive output fields            |
-| [watch-loop.md](watch-loop.md)           | How the monitor skill + `/loop` + `iterate` interact                       |
+| [watch-loop.md](watch-loop.md)           | How the pr-shepherd skill and `iterate` interact                           |
 | [ready-delay.md](ready-delay.md)         | Loop-state files: ready-since, fix-attempts, iterate-stall                 |
 | [graphql.md](graphql.md)                 | Batch query, pagination strategy, REST fallbacks                           |
 | [checks.md](checks.md)                   | Classify → triage → `failedStep`, `jobName`, event filtering               |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -165,7 +165,7 @@ Actionable work needs a code fix, commit, and push.
 
 ## Review threads
 
-### `threadId=PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate.mts:42` (@alice)
+### `threadId=PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate/index.mts:42` (@alice)
 
 > The variable name is misleading.
 >

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -453,4 +453,3 @@ The block after the base-fields line (separated by a blank line) is `escalate.hu
 > **This action is no longer emitted by `iterate`.** Transient CI failure detection (timeout / cancelled) has been moved to the agent: the `fix_code` action now carries `failedStep`/`conclusion` for every failing check, and the `## Instructions` section tells the agent to run `gh run view <runId> --log-failed` and decide whether to rerun or apply a code fix. Current releases no longer include a `rerun_ci` action or `[RERUN_CI]` formatter output.
 
 **Trigger:** Previously emitted when one or more failing checks had `failureKind === "timeout"` or `"cancelled"` and no actionable work was found. Removed in favour of routing all failing checks through `fix_code` with raw log data.
-

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -4,13 +4,13 @@
 
 Each default `pr-shepherd` invocation returns exactly one iterate action. The legacy `pr-shepherd iterate` spelling is still supported. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
 
-The default output format is Markdown — what you see when running `pr-shepherd <PR>` through the selected package runner, and what the monitor SKILL reads each cron tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
+The default output format is Markdown — what you see when running `pr-shepherd <PR>` through the selected package runner, and what the iterate skill reads on each tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
 Instruction wording uses unified sleep guidance for all runtimes: pick a fresh sleep/timeout between 30 seconds and 4 minutes and rerun the configured pr-shepherd command. The action data and section structure are otherwise the same.
 
 Command examples use the default npm spelling (`npx pr-shepherd`). Repos can set `cli.runner` to `auto`, `npx`, `pnpm`, or `yarn`; generated text and JSON argv then use the selected runner (for example `pnpm exec pr-shepherd` or `yarn run pr-shepherd`) everywhere a pr-shepherd follow-up command is emitted.
 
-Pass `--verbose` to get more debug state. In JSON mode, the output starts from the full `IterateResult` shape (all fields, including `baseBranch`, `checks`, `shouldCancel`) and then applies the same instruction projection as lean JSON: non-`fix_code` actions get a top-level `instructions` array, and `fix.instructions` may be rewritten. In Markdown mode, `--verbose` restores the full header summary line (all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, `shouldCancel` always shown) — but Markdown is structurally different from JSON and does not guarantee field-for-field parity (array fields like `baseBranch` or `checks` are not added to Markdown for actions that do not normally render them). Lean mode is the default because most fields are `false`/`0`/`[]` on a typical healthy tick and add context noise without value.
+Pass `--verbose` to get more debug state. In JSON mode, the output starts from the full `IterateResult` shape (all fields, including `baseBranch`, `checks`, `shouldCancel`) and then applies the same instruction projection as lean JSON: non-`fix_code` actions get a top-level `instructions` array, and `fix.instructions` may be rewritten. In Markdown mode, `--verbose` restores the full header summary line (all four counts, `remainingSeconds`, `blockingBotReviewInProgress`, `isDraft`, `shouldCancel` always shown) — but Markdown is structurally different from JSON and does not guarantee field-for-field parity (array fields like `baseBranch` or `checks` are not added to Markdown for actions that do not normally render them). Lean mode is the default because most fields are `false`/`0`/`[]` on a typical healthy tick and add context noise without value.
 
 **Output shape (every action, default lean format):**
 
@@ -18,34 +18,33 @@ Pass `--verbose` to get more debug state. In JSON mode, the output starts from t
 # PR #<N> [ACTION]
 
 **status** `<…>` · **merge** `<…>` · **state** `<…>` · **repo** `<…>`
-**summary** <N> passing[, <N> skipped][, <N> filtered][, <N> inProgress][· **remainingSeconds** <N>][· **copilotReviewInProgress**][· **isDraft**]
+**summary** <N> passing[, <N> skipped][, <N> filtered][, <N> inProgress][· **remainingSeconds** <N>][· **blockingBotReviewInProgress**][· **isDraft**]
 
 <action-specific body>
 
 ## Instructions
 
-1. <numbered steps telling the monitor exactly what to do>
+1. <numbered steps telling the agent exactly what to do>
 ```
 
 Lean-mode rules for the summary line:
 
 - Zero counts (`skipped`, `filtered`, `inProgress`) are omitted.
 - `remainingSeconds` is shown only when the ready-delay timer is actively counting down (`status === "READY"` and `remainingSeconds > 0`).
-- `copilotReviewInProgress` and `isDraft` are shown only when `true`.
+- `blockingBotReviewInProgress` and `isDraft` are shown only when `true`.
 - `shouldCancel` is never shown (it is fully implied by `action === "cancel"`).
 
-`--verbose` restores the full summary line: all four counts, `remainingSeconds`, `copilotReviewInProgress`, `isDraft`, and `shouldCancel` always present.
+`--verbose` restores the full summary line: all four counts, `remainingSeconds`, `blockingBotReviewInProgress`, `isDraft`, and `shouldCancel` always present.
 
 **Note on `mergeStatus` in JSON lean mode.** The lean JSON projection (`--format=json`, default) emits `mergeStateStatus` (the raw GitHub value) but **omits the derived `mergeStatus` discriminator** (`CLEAN | BEHIND | CONFLICTS | BLOCKED | UNSTABLE | DRAFT | UNKNOWN`). Scripts that branch on `mergeStatus` must use `--verbose` to get the full `IterateResult`. `mergeStateStatus` is always present in both modes.
 
-Load-bearing conventions (the monitor SKILL depends on these):
+Load-bearing conventions (the iterate skill depends on these):
 
 1. Line 1 is always an H1 heading of the form `# PR #<N> [<ACTION>]`. The action tag identifies the output for logging and validation — behavior is driven by the `## Instructions` section, not by dispatching on the tag.
 2. Lines 3–4 carry the base fields (status, merge, state, repo, summary). In lean mode, fields at their trivial default are omitted; `--verbose` restores the full scalar header/summary line in Markdown. JSON verbose mode returns the complete `IterateResult` including fields not present in Markdown (e.g. `baseBranch`, `checks` on all actions); Markdown is structurally lossy relative to JSON and `--verbose` does not close that gap.
-3. Every action ends with a `## Instructions` section — numbered `1.`, `2.`, … — that tells the monitor exactly what to do. The monitor follows those steps; it does not need its own dispatch table.
-4. Under `[REBASE]`, the shell script is inside a ```bash fenced block — instruction 1 tells the monitor to extract and run it.
-5. Under `[FIX_CODE]`, the `## Post-fix push` section has a `` resolve: `<command>` `` bullet — the instructions reference this bullet so the monitor strips backticks and runs the command.
-6. Passing check counts are surfaced only via the `**summary**` line — no per-check detail is emitted for passing checks. Failing check detail appears in `## Failing checks` (within `[FIX_CODE]` output). JSON surfaces check data as `checks: RelevantCheck[]` only on `fix_code` actions in lean mode; `--format=json --verbose` includes `checks` on all actions (full IterateResult).
+3. Every action ends with a `## Instructions` section — numbered `1.`, `2.`, … — that tells the agent exactly what to do. The skill follows those steps; it does not need its own dispatch table.
+4. Under `[FIX_CODE]`, the `## Post-fix push` section has a `` resolve: `<command>` `` bullet — the instructions reference this bullet so the skill strips backticks and runs the command.
+5. Passing check counts are surfaced only via the `**summary**` line — no per-check detail is emitted for passing checks. Failing check detail appears in `## Failing checks` (within `[FIX_CODE]` output). JSON surfaces check data as `checks: RelevantCheck[]` only on `fix_code` actions in lean mode; `--format=json --verbose` includes `checks` on all actions (full IterateResult).
 
 ---
 
@@ -78,7 +77,7 @@ When the current command includes a ready-delay override, the rerun command pres
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
-**What the monitor does:** Follow `## Instructions` — pick a fresh sleep/timeout and rerun.
+**What the skill does:** Follow `## Instructions` — pick a fresh sleep/timeout and rerun.
 
 ---
 
@@ -107,13 +106,13 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to recheck.
 ```
 
-**What the monitor does:** Follow `## Instructions` — pick a fresh sleep/timeout and rerun.
+**What the skill does:** Follow `## Instructions` — pick a fresh sleep/timeout and rerun.
 
 ---
 
 ## `cancel`
 
-Stops the monitor loop — no further iterations needed.
+Stops the iterate loop — no further iterations needed.
 
 **Trigger:** Either the PR is merged or closed (`state !== "OPEN"`), or the ready-delay timer elapsed (`readyState.shouldCancel`).
 
@@ -131,7 +130,7 @@ Stops the monitor loop — no further iterations needed.
 **status** `READY` · **merge** `CLEAN` · **state** `MERGED` · **repo** `owner/repo`
 **summary** 5 passing
 
-CANCEL: PR #42 is merged — stopping monitor
+CANCEL: PR #42 is merged — stopping
 
 ## Instructions
 
@@ -140,9 +139,9 @@ CANCEL: PR #42 is merged — stopping monitor
 
 Other heading variants: `# PR #42 [CANCEL] — closed`, `# PR #42 [CANCEL] — ready-delay-elapsed`.
 
-Other body-line variants: `CANCEL: PR #42 is closed — stopping monitor`, `CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping monitor`.
+Other body-line variants: `CANCEL: PR #42 is closed — stopping`, `CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping`.
 
-**What the monitor does:** Follow `## Instructions` — stop.
+**What the skill does:** Follow `## Instructions` — stop.
 
 ---
 
@@ -240,8 +239,9 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 
 1. Heading + base fields (always present).
 2. `## Review threads` — each thread under ``### `threadId=<id>` — <loc> (@author) [suggestion]?`` (or `### [threadId=<id>](<url>) — <loc> (@author) [suggestion]?` when a URL is available) where `<loc>` is `` `path:line` `` for single-line threads or `` `path:startLine-endLine` `` for multi-line threads. The full body follows as a `>` blockquote. Multi-paragraph bodies preserve empty lines as `>` lines. Threads with a ` ```suggestion ` fence carry a `[suggestion]` tag in the heading and a `Replaces lines …` block after the body showing the parsed replacement.
-3. `## Actionable comments` — same H3-plus-blockquote shape as threads minus the `<loc>`: ``### `commentId=<id>` `` or `### [commentId=<id>](<url>)` when a URL is available.
-4. `## Failing checks` — one bullet per failing check. Shape varies by locator:
+3. `## Review threads to resolve` — unresolved outdated/minimized inline threads that should be passed to `--resolve-thread-ids` but do not require code edits unless the agent chooses to act on the body.
+4. `## Actionable comments` — same H3-plus-blockquote shape as threads minus the `<loc>`: ``### `commentId=<id>` `` or `### [commentId=<id>](<url>)` when a URL is available.
+5. `## Failing checks` — one bullet per failing check. Shape varies by locator:
    - ``- `<runId>` — `<workflowName> › <jobName>` `` for GitHub Actions checks (`workflowName ›` prefix omitted when unavailable; `jobName` falls back to the check name when absent).
    - ``- external `<detailsUrl>` — `<name>` `` for external status checks (codecov, vercel, etc.) with null `runId` but a URL.
    - ``- (no runId) — `<name>` `` when both are null.
@@ -250,11 +250,10 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 
    The numbered instructions split accordingly: for GitHub Actions checks with a runId and no `[conclusion: CANCELLED]` or `[conclusion: STARTUP_FAILURE]`, three steps are emitted — fetch logs with `gh run view <runId> --log-failed`, rerun with `gh run rerun <runId> --failed` if transient, or apply a code fix if a real failure. For `[conclusion: CANCELLED]` checks, a single step says to rerun with `gh run rerun <runId>` (no `--failed` flag) if the cancellation looks unintended. For `[conclusion: STARTUP_FAILURE]` checks, a single step says to inspect metadata with `gh run view <runId>` and rerun with `gh run rerun <runId>` if the workflow should be attempted again. For external status checks (detailsUrl only), the step says to open the URL in a browser. When both are absent, the step says to escalate to a human.
 
-5. `## Review threads to resolve` — unresolved outdated/minimized inline threads that should be passed to `--resolve-thread-ids` but do not require code edits unless the agent chooses to act on the body.
 6. `## Changes-requested reviews` — one bullet per `CHANGES_REQUESTED` review: ``- `reviewId=<id>` (@<author>)``.
 7. `## Review summaries (first look — to be minimized)` — `COMMENTED` review summaries the agent has **not yet seen**. Each entry is rendered with an H3 heading (``### `reviewId=<id>` (@<author>)``) and the full body as a `>` blockquote. Their IDs are already included in `--minimize-comment-ids` in the resolve command, so no additional action is needed beyond reading them and recording any Shepherd Journal note. A per-item seen-marker file (`src/state/seen-comments.mts`) writes the marker on first encounter so subsequent runs skip the body. Not emitted when empty.
 8. `## Review summaries (edited since first look — already minimized; do not re-minimize)` — `COMMENTED` review summaries whose body was edited by the author after Shepherd last surfaced them. Each entry is rendered the same way as section 7 (H3 heading + `>` blockquote). These IDs are **NOT** included in `--minimize-comment-ids` — the review is already minimized on GitHub (or was in a prior iteration's minimize queue). Read the updated body and record any Shepherd Journal note, but do not pass these IDs to any mutation flag. The seen-marker hash is updated after display so the next run only re-surfaces them if the body changes again. Not emitted when empty.
-9. `## Review summaries (already surfaced — minimize queue)` — backticked review IDs (`PRR_…`) of `COMMENTED` review summaries whose bodies were surfaced in a **prior** iteration and whose body has not changed since. If `iterate.minimizeApprovals` is `true`, this section may also include `APPROVED` review IDs queued for minimization even though their bodies were not previously surfaced. All IDs (from sections 7 and 9) are merged into `--minimize-comment-ids` in the resolve command. Not emitted when empty.
+9. `## Review IDs to minimize queue` — backticked review IDs (`PRR_…`) of `COMMENTED` review summaries whose bodies were surfaced in a **prior** iteration and whose body has not changed since. If `iterate.minimizeApprovals` is `true`, this section may also include `APPROVED` review IDs queued for minimization even though their bodies were not previously surfaced. All IDs (from sections 7 and 9) are merged into `--minimize-comment-ids` in the resolve command. Not emitted when empty.
 10. `## Approvals (surfaced — not minimized)` — emitted when `iterate.minimizeApprovals` is `false` (default) and there are `APPROVED`-state reviews. H3 heading uses `` `reviewId=<id>` `` (same prefix scheme as other item types); body is a `>` blockquote or `(no review body)` when empty. Surfaced for visibility, but NOT included in `--minimize-comment-ids`.
 11. `## First-look items (N) — acknowledge status before acting` — threads and PR comments that are outdated, resolved, or minimized and have not yet been acknowledged by the agent. Emitted on first encounter only; a per-item seen-marker file (`src/state/seen-comments.mts`) suppresses them on subsequent runs. Each bullet carries a `[status: …]` tag: `outdated`, `outdated, auto-resolved`, `resolved`, or `minimized`. If the body was edited since the item was first acknowledged, the tag gains an `, edited` suffix (e.g. `[status: minimized, edited]`). If a first-look thread also appears under `## Review threads to resolve`, its ID is already included in the resolve command; otherwise do not pass first-look-only IDs to mutation flags. Not emitted when empty.
 12. `## In-progress runs` — backticked GitHub Actions run IDs of in-progress checks the agent should cancel before applying fixes. Emitted only when `fix.inProgressRunIds` is non-empty, which requires both (a) at least one in-progress check with a non-null run ID not already cancelled by the CLI and (b) a push is guaranteed this iteration (review threads, failing checks, changes-requested reviews, or rebase conflicts). Comment-only iterations do not emit this section because the agent may only minimize or acknowledge comments without making a superseding push. The agent cancels these before applying code fixes (step 1 of `## Instructions`). Distinct from `## Cancelled runs`: those IDs were already cancelled by the CLI before the agent acts; these IDs the agent must cancel itself now. Not emitted when empty.
@@ -262,7 +261,7 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 14. `## Post-fix push`:
     - ``- base: `<branch>` `` — rebase target for the push step.
     - ``- resolve: `<argv>` `` — fully-quoted resolve command. `$DISMISS_MESSAGE` and `$HEAD_SHA` are always quoted so substituting a multi-word sentence keeps it as one argument. `--require-sha "$HEAD_SHA"` is appended only when a push is required for the resolve mutation (threads/checks/reviews present); comment-only and summary-only dispatches omit it.
-15. `## Instructions` — numbered list to execute in order. The final instruction always refers back to the `resolve:` bullet rather than duplicating the command — that single source of truth is what the monitor executes.
+15. `## Instructions` — numbered list to execute in order. The final instruction always refers back to the `resolve:` bullet rather than duplicating the command — that single source of truth is what the skill executes.
 
 **Instruction variants:**
 
@@ -281,7 +280,7 @@ Step 1 is absent when no thread has a `[suggestion]` marker; step 2 omits the ma
 - An edited-items step is appended when `editedSummaries` is non-empty or any first-look thread/comment carries `edited: true` — it tells the agent to read the updated body but **not** include these IDs in any mutation flag.
 - The final "recheck" step has three variants: `CI needs time to run on the new push. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun \`npx pr-shepherd 42\` to recheck.`when a push occurred;`Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun \`npx pr-shepherd 42\` to recheck.` when only GitHub mutations were made or no push/mutations occurred.
 
-The JSON payload exposes the same data under `fix.{threads, resolutionOnlyThreads, actionableComments, reviewSummaryIds, firstLookSummaries, editedSummaries, surfacedApprovals, checks, changesRequestedReviews, resolveCommand, instructions, mode, firstLookThreads, firstLookComments, inProgressRunIds}` — where `fix.mode === "rebase-and-push"` is the type discriminator — plus top-level `baseBranch` (on `IterateResultBase`, not under `fix`) and `cancelled`. `fix.inProgressRunIds` contains the GitHub Actions run IDs the agent must cancel before applying fixes (mirrors `## In-progress runs` in the Markdown output); it is an empty array when there are no in-progress GitHub Actions run IDs to cancel (external status checks or already-cancelled runs are excluded) or when no push is expected this iteration. `resolutionOnlyThreads` contains unresolved outdated/minimized review threads routed to `--resolve-thread-ids` without causing a push or `--require-sha`. `reviewSummaryIds` contains the IDs routed to `--minimize-comment-ids` for review-level minimization: this includes review summaries (both first-look and already-seen), and may also include APPROVED review IDs when approval minimization is enabled. `firstLookSummaries` carries the full `Review` objects for bodies seen this iteration for the first time. `editedSummaries` carries the full `Review` objects for summaries whose body changed since last seen — these IDs are **not** in `reviewSummaryIds`. Both `firstLookSummaries` and `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `editedSummaries` and `surfacedApprovals` are informational only. `resolveCommand.argv` starts with the configured runner argv (`["npx", "pr-shepherd", …]`, `["pnpm", "exec", "pr-shepherd", …]`, or `["yarn", "run", "pr-shepherd", …]`). In lean JSON mode, `fix.*` arrays that are empty are omitted; `cancelled` is omitted when empty. Pass `--verbose` to include all fields. `firstLookThreads` and `firstLookComments` are informational unless the same thread appears in `resolutionOnlyThreads`.
+The JSON payload exposes the same data under `fix.{threads, resolutionOnlyThreads, actionableComments, reviewSummaryIds, firstLookSummaries, editedSummaries, surfacedApprovals, checks, changesRequestedReviews, resolveCommand, instructions, firstLookThreads, firstLookComments, inProgressRunIds}` plus top-level `baseBranch` (on `IterateResultBase`, not under `fix`) and `cancelled`. `fix.inProgressRunIds` contains the GitHub Actions run IDs the agent must cancel before applying fixes (mirrors `## In-progress runs` in the Markdown output); it is an empty array when there are no in-progress GitHub Actions run IDs to cancel (external status checks or already-cancelled runs are excluded) or when no push is expected this iteration. `resolutionOnlyThreads` contains unresolved outdated/minimized review threads routed to `--resolve-thread-ids` without causing a push or `--require-sha`. `reviewSummaryIds` contains the IDs routed to `--minimize-comment-ids` for review-level minimization: this includes review summaries (both first-look and already-seen), and may also include APPROVED review IDs when approval minimization is enabled. `firstLookSummaries` carries the full `Review` objects for bodies seen this iteration for the first time. `editedSummaries` carries the full `Review` objects for summaries whose body changed since last seen — these IDs are **not** in `reviewSummaryIds`. Both `firstLookSummaries` and `reviewSummaryIds` are merged into `--minimize-comment-ids` inside `resolveCommand.argv`; `editedSummaries` and `surfacedApprovals` are informational only. `resolveCommand.argv` starts with the configured runner argv (`["npx", "pr-shepherd", …]`, `["pnpm", "exec", "pr-shepherd", …]`, or `["yarn", "run", "pr-shepherd", …]`). In lean JSON mode, `fix.*` arrays that are empty are omitted; `cancelled` is omitted when empty. Pass `--verbose` to include all fields. `firstLookThreads` and `firstLookComments` are informational unless the same thread appears in `resolutionOnlyThreads`.
 
 **Resolve command rules (same in Markdown and JSON):**
 
@@ -389,13 +388,13 @@ The `resolve:` command at the bottom of `## Post-fix push` includes both IDs:
 
 Both IDs stay in `--resolve-thread-ids` — `commit-suggestion` no longer resolves threads automatically. If a patch failed to apply and was handled manually instead, the ID still belongs in `--resolve-thread-ids`.
 
-**What the monitor does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed in the monitor. See `## Instructions` in the output for the exact steps.
+**What the skill does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed. See `## Instructions` in the output for the exact steps.
 
 ---
 
 ## `escalate`
 
-Ambiguous state that requires human judgement — the monitor stops and surfaces details.
+Ambiguous state that requires human judgement — iteration stops and surfaces details.
 
 **Trigger:** Any of:
 
@@ -403,7 +402,7 @@ Ambiguous state that requires human judgement — the monitor stops and surfaces
 - **`fix-thrash`** — same thread dispatched ≥ `config.iterate.fixAttemptsPerThread` times (default 3) without resolving.
 - **`pr-level-changes-requested`** — reviewer requested changes but left no inline threads, comments, or CI failures to act on (not triggered when merge conflicts are present).
 - **`thread-missing-location`** — an actionable review thread has no file or line reference, so the code location cannot be found automatically.
-- **`base-branch-unknown`** — the GraphQL batch did not yield a usable base branch name: the derived value was empty or contained unsafe characters. Preempts both `[REBASE]` and any `[FIX_CODE]` that would require a push, since rebasing onto the wrong base is worse than pausing the monitor.
+- **`base-branch-unknown`** — the GraphQL batch did not yield a usable base branch name: the derived value was empty or contained unsafe characters. Preempts any `[FIX_CODE]` that would require a push, since rebasing onto the wrong base is worse than pausing iteration.
 
 **CLI side-effects:** None.
 
@@ -417,15 +416,15 @@ Ambiguous state that requires human judgement — the monitor stops and surfaces
 **status** `UNRESOLVED_COMMENTS` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 0 passing
 
-⚠️ /pr-shepherd:monitor paused — needs human direction
+⚠️ /pr-shepherd:pr-shepherd paused — needs human direction
 
 **Triggers:** `fix-thrash`
 
-Same thread(s) attempted multiple times without resolution — fix manually then rerun /pr-shepherd:monitor
+Same thread(s) attempted multiple times without resolution — fix manually then rerun /pr-shepherd:pr-shepherd
 
 ## Items needing attention
 
-- thread `PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate.mts:42` (@alice): The variable name is misleading
+- thread `PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate/index.mts:42` (@alice): The variable name is misleading
 
 ## Fix attempts
 
@@ -433,27 +432,21 @@ Same thread(s) attempted multiple times without resolution — fix manually then
 
 ---
 
-Run `/pr-shepherd:check 42` to see current state.
-After fixing manually, rerun `/pr-shepherd:monitor 42` to resume.
+Run `/pr-shepherd:pr-shepherd 42` to see current state.
+After fixing manually, rerun `/pr-shepherd:pr-shepherd 42` to resume.
 
 ## Instructions
 
-1. Stop — the PR needs human direction before monitoring can resume.
+1. Stop — the PR needs human direction before iterating can resume.
 ```
 
 The block after the base-fields line (separated by a blank line) is `escalate.humanMessage` in JSON — ready to print verbatim.
 
-**What the monitor does:** Follow `## Instructions` — stop.
+**What the skill does:** Follow `## Instructions` — stop.
 
 ---
 
 ## Archived / no longer emitted
-
-### `cooldown`
-
-> **This action is no longer emitted by `iterate`.** The cooldown early-return (skip if last commit is too fresh for CI) has been removed. `iterate` now always runs the full sweep. Agents use the unified "pick a fresh sleep/timeout between 30 seconds and 4 minutes" guidance instead.
-
-**Trigger:** Previously emitted when `nowSeconds − lastCommitTime < cooldownSeconds` (default 30s). Removed to simplify the decision tree — the sweep is cheap and CI may already have started.
 
 ### `rerun_ci`
 
@@ -461,8 +454,3 @@ The block after the base-fields line (separated by a blank line) is `escalate.hu
 
 **Trigger:** Previously emitted when one or more failing checks had `failureKind === "timeout"` or `"cancelled"` and no actionable work was found. Removed in favour of routing all failing checks through `fix_code` with raw log data.
 
-### `rebase`
-
-> **This action is no longer emitted by `iterate`.** Branch rebasing is now handled inside the `fix_code` instructions (see `## Post-fix push` and the rebase step in `## Instructions`). Current releases no longer include a dedicated `rebase` action or `[REBASE]` formatter output.
-
-**Trigger:** Previously emitted when a branch was `BEHIND` its base and no other actionable items were pending. Removed in favour of embedding the rebase step inside `fix_code` when conflicts are present.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,11 +27,10 @@ shepherd/
 │   └── fix-formatter.mts  # Markdown formatter for fix_code variant
 │
 ├── commands/              # one file (or dir) per subcommand
-│   ├── check.mts          # read-only snapshot (GraphQL fetch → classify → report)
-│   ├── check-status.mts   # derives check-command ShepherdStatus from a report
+│   ├── check.mts          # read-only snapshot (GraphQL fetch → classify → report); internal helper
+│   ├── check-status.mts   # derives ShepherdStatus from a report
 │   ├── commit-suggestion.mts  # applies a reviewer ```suggestion block as a commit
-│   ├── iterate.mts        # re-exports runIterate + renderResolveCommand
-│   ├── iterate/           # iterate subcommand internals
+│   ├── iterate/           # iterate subcommand (default invocation)
 │   │   ├── index.mts      # main runIterate orchestrator
 │   │   ├── classify.mts   # classifyReviewSummaries
 │   │   ├── escalate.mts   # escalation predicate

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -7,7 +7,7 @@ pr-shepherd -v|--version
 pr-shepherd [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
-pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # legacy-compatible spelling
+pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # legacy alias for pr-shepherd [PR]
 pr-shepherd log-file
 ```
 
@@ -169,12 +169,12 @@ If a patch fails to apply (drift since the suggestion was written), apply the fi
 
 ### pr-shepherd [PR]
 
-One monitor tick: classifies current PR state and emits a single action. Used by the cron loop — the monitor skill calls this on each tick and follows the `## Instructions` section verbatim. `pr-shepherd iterate [PR]` remains supported for backwards compatibility. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
+One iterate tick: classifies current PR state and emits a single action. The skill calls this on each tick and follows the `## Instructions` section verbatim. `pr-shepherd iterate [PR]` remains supported as a legacy alias. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
 
 ```sh
 pr-shepherd 42
 pr-shepherd 42 --ready-delay 15m          # override ready-delay for this run
-pr-shepherd iterate 42                    # legacy-compatible spelling
+pr-shepherd iterate 42                    # legacy alias
 ```
 
 **Flags:**
@@ -187,7 +187,7 @@ pr-shepherd iterate 42                    # legacy-compatible spelling
 | `--no-auto-mark-ready`        | false                                   | Skip converting draft → ready-for-review                                                             |
 | `--no-auto-cancel-actionable` | false                                   | Skip cancelling actionable failing runs                                                              |
 
-**Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Zero counts (`skipped`, `filtered`, `inProgress`) are omitted in lean mode; `copilotReviewInProgress` and `isDraft` are only shown when `true`; `shouldCancel` is never shown. Example for `[WAIT]`:
+**Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Zero counts (`skipped`, `filtered`, `inProgress`) are omitted in lean mode; `blockingBotReviewInProgress` and `isDraft` are only shown when `true`; `shouldCancel` is never shown. Example for `[WAIT]`:
 
 ```markdown
 # PR #42 [WAIT]

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -214,7 +214,7 @@ Example for `[FIX_CODE]` (richest action):
 
 ## Review threads
 
-### `threadId=PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate.mts:42` (@alice)
+### `threadId=PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate/index.mts:42` (@alice)
 
 > The variable name is misleading.
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ Override per-invocation with `--stall-timeout <duration>` (e.g. `--stall-timeout
 
 **Breaking change from `iterate.minimizeReviewSummaries.{bots, humans, approvals}`** — the old nested keys are no longer recognized.
 
-All `COMMENTED` review summaries (bot and human alike) are always minimized by the monitor / `iterate` loop. Review summary IDs ride along inside the existing resolve command — no code change needed to minimize them. Rendered under `## Review summaries (minimize only)` in the iterate markdown output.
+All `COMMENTED` review summaries (bot and human alike) are always minimized by the monitor / `iterate` loop. Review summary IDs ride along inside the existing resolve command — no code change needed to minimize them. Rendered under `## Review IDs to minimize queue` in the iterate markdown output.
 
 Opt in to also minimize `APPROVED`-state reviews (`pr approve` clicks with or without a body). Off by default because approvals are an affirmative signal you usually want to keep visible. Flip to `true` for long-running PRs where stale approvals pile up.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ Override per-invocation with `--stall-timeout <duration>` (e.g. `--stall-timeout
 
 **Breaking change from `iterate.minimizeReviewSummaries.{bots, humans, approvals}`** — the old nested keys are no longer recognized.
 
-All `COMMENTED` review summaries (bot and human alike) are always minimized by the monitor / `iterate` loop. Review summary IDs ride along inside the existing resolve command — no code change needed to minimize them. Rendered under `## Review IDs to minimize queue` in the iterate markdown output.
+All `COMMENTED` review summaries (bot and human alike) are always minimized by the `iterate` loop. Review summary IDs ride along inside the existing resolve command — no code change needed to minimize them. Rendered under `## Review IDs to minimize queue` in the iterate markdown output.
 
 Opt in to also minimize `APPROVED`-state reviews (`pr approve` clicks with or without a body). Off by default because approvals are an affirmative signal you usually want to keep visible. Flip to `true` for long-running PRs where stale approvals pile up.
 

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -38,7 +38,7 @@ resolves `pr-shepherd ...` without prompting to install the package.
    (for example, `pnpm exec`, `yarn run`, or `npx --no-install`).
 
    ```bash
-   <runner> pr-shepherd check <PR_NUMBER> --format=json
+   <runner> pr-shepherd iterate <PR_NUMBER> --format=json
    ```
 
    Parse the JSON and report:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -100,5 +100,5 @@ pr-shepherd <PR> --format=json
 For human-readable output:
 
 ```bash
-pr-shepherd check <PR>
+pr-shepherd iterate <PR>
 ```

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -25,9 +25,9 @@ Four recipes for common extension patterns.
 
    Add it to the `IterateResult` union.
 
-3. **Add the dispatch step** — in `commands/iterate.mts`, insert a new numbered step in the decision chain. Return the new result shape.
+3. **Add the dispatch step** — in `commands/iterate/index.mts`, insert a new numbered step in the decision chain. Return the new result shape.
 
-4. **Add the formatter** — in `cli/iterate-formatter.mts`, add a `case "my_action":` branch that emits the action-specific body and a numbered `## Instructions` section. The monitor skill follows those steps verbatim — no changes to `skills/monitor/SKILL.md` are required.
+4. **Add the formatter** — in `cli/iterate-formatter.mts`, add a `case "my_action":` branch that emits the action-specific body and a numbered `## Instructions` section. The iterate skill follows those steps verbatim — no changes to `skills/pr-shepherd/SKILL.md` are required.
 
 5. **Add tests** — in `commands/iterate.mock.test.mts`, add a `describe('runIterate — my_action')` block.
 

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -34,7 +34,7 @@ In `marketplace.json`:
 
 ## 2. Rename the loop tag
 
-The monitor prompt includes `#pr-shepherd-loop:pr=<N>:` so agents and logs can identify the PR being monitored. Change this string in `plugin/skills/monitor/SKILL.md` to avoid conflicts with other installations:
+The iterate skill includes `#pr-shepherd-loop:pr=<N>:` so agents and logs can identify the PR being iterated. Change this string in `plugin/skills/pr-shepherd/SKILL.md` to avoid conflicts with other installations:
 
 ```
 #my-shepherd-loop:pr=<PR_NUMBER>:

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -2,7 +2,7 @@
 
 [← README](../README.md) | [actions.md](actions.md)
 
-`commands/iterate.mts` is the heart of the watch loop. Each dynamic tick calls it once and interprets the JSON result.
+`commands/iterate/index.mts` is the heart of the iterate loop. Each tick calls it once and follows the `## Instructions` in the result.
 
 ## Steps
 
@@ -89,7 +89,7 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 
 ### 4. Mark ready
 
-**Check:** `report.status === 'READY'` AND `mergeStateStatus` is `CLEAN` (or `DRAFT` when `isDraft`) AND `!copilotReviewInProgress` AND `isDraft` AND `!shouldCancel`.
+**Check:** `report.status === 'READY'` AND `mergeStateStatus` is `CLEAN` (or `DRAFT` when `isDraft`) AND `!blockingBotReviewInProgress` AND `isDraft` AND `!shouldCancel`.
 
 **Side-effects:** `gh pr ready <PR>`
 

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -10,7 +10,7 @@ Located in `src/merge-status/derive.mts`. Given a `BatchPrData`, returns a `Merg
 | -------- | ------------------------------------------------- | -------------- | -------------------------------------------------------------------------- |
 | 0        | `state !== 'OPEN'`                                | (pass through) | `iterate` cancels loop at step 2.5; status field is still derived normally |
 | 1        | `mergeable === 'CONFLICTING'`                     | `CONFLICTS`    | GraphQL merge conflict signal                                              |
-| 2        | `blockingBotReviewInProgress`                         | `BLOCKED`      | Takes priority over BEHIND to avoid hiding a real blocker                  |
+| 2        | `blockingBotReviewInProgress`                     | `BLOCKED`      | Takes priority over BEHIND to avoid hiding a real blocker                  |
 | 3        | `mergeStateStatus === 'DIRTY'`                    | `CONFLICTS`    | REST-layer merge conflict signal                                           |
 | 4        | `mergeStateStatus === 'BEHIND'`                   | `BEHIND`       | Branch needs rebase                                                        |
 | 5        | `mergeStateStatus === 'BLOCKED'` or `'HAS_HOOKS'` | `BLOCKED`      | Protected branch rules blocking merge                                      |

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -10,7 +10,7 @@ Located in `src/merge-status/derive.mts`. Given a `BatchPrData`, returns a `Merg
 | -------- | ------------------------------------------------- | -------------- | -------------------------------------------------------------------------- |
 | 0        | `state !== 'OPEN'`                                | (pass through) | `iterate` cancels loop at step 2.5; status field is still derived normally |
 | 1        | `mergeable === 'CONFLICTING'`                     | `CONFLICTS`    | GraphQL merge conflict signal                                              |
-| 2        | `copilotReviewInProgress`                         | `BLOCKED`      | Takes priority over BEHIND to avoid hiding a real blocker                  |
+| 2        | `blockingBotReviewInProgress`                         | `BLOCKED`      | Takes priority over BEHIND to avoid hiding a real blocker                  |
 | 3        | `mergeStateStatus === 'DIRTY'`                    | `CONFLICTS`    | REST-layer merge conflict signal                                           |
 | 4        | `mergeStateStatus === 'BEHIND'`                   | `BEHIND`       | Branch needs rebase                                                        |
 | 5        | `mergeStateStatus === 'BLOCKED'` or `'HAS_HOOKS'` | `BLOCKED`      | Protected branch rules blocking merge                                      |
@@ -30,9 +30,9 @@ These are two different signals for the same underlying condition (merge conflic
 
 Both map to `CONFLICTS` in shepherd's derived status.
 
-### Copilot detection takes priority over BEHIND
+### Blocking-bot detection takes priority over BEHIND
 
-Priority 2 (copilot) comes before priority 4 (BEHIND). If a Copilot review is pending AND the branch is behind, shepherd reports `BLOCKED`, not `BEHIND`. This prevents the loop from rebasing and pushing when Copilot is still reviewing — the rebase would dismiss the in-progress review.
+Priority 2 (`blockingBotReviewInProgress`) comes before priority 4 (BEHIND). If a blocking bot review is pending AND the branch is behind, shepherd reports `BLOCKED`, not `BEHIND`. This prevents the loop from rebasing and pushing when the bot is still reviewing — the rebase would dismiss the in-progress review.
 
 ### DRAFT uses both `isDraft` and `mergeStateStatus === 'DRAFT'`
 
@@ -50,19 +50,19 @@ GitHub sometimes updates `mergeStateStatus` to `'DRAFT'` before the `isDraft` bo
 - `verdict.hasChecks` — at least one relevant (non-filtered, non-skipped) check has completed. Prevents a PR with zero relevant checks (CI never started, or all checks filtered/skipped) from prematurely triggering READY before any check has reported.
 - No unresolved threads, comments, or changes-requested reviews. This includes outdated/minimized threads that still have `isResolved === false`; those are routed as resolution-only work instead of being treated as ready.
 - `mergeStatus.status === "BLOCKED"` (from `deriveMergeStatus`).
-- `mergeStatus.copilotReviewInProgress === false` — a bot review still pending is shepherd's problem, not a hand-off case.
+- `mergeStatus.blockingBotReviewInProgress === false` — a bot review still pending is shepherd's problem, not a hand-off case.
 
 The specific reason GitHub is BLOCKED (`reviewDecision === "REVIEW_REQUIRED"`, `"APPROVED"` with insufficient approvals, signed-commit policy, etc.) is not consulted — it is informational only, surfaced in the iterate output for human/agent readers but not used to gate state. Shepherd cannot resolve any of these on its own.
 
 In this case `mergeStatus.status` in the report is still `BLOCKED` (truthful about the GitHub merge state), but the top-level `ShepherdStatus` is `READY`, signalling that shepherd has nothing more to do. The ready-delay timer starts, and `action: cancel` is emitted after it elapses.
 
-A `BLOCKED` case that does not satisfy the above (e.g. Copilot review in progress, unresolved threads, or failing CI) maps to `ShepherdStatus: "PENDING"`. The same applies to `UNSTABLE` (non-required checks are red but merge is not fully blocked) and `BEHIND` (head branch is out of date). `FAILING` is reserved for red CI checks (`verdict.anyFailing`) and merge conflicts (`CONFLICTS`).
+A `BLOCKED` case that does not satisfy the above (e.g. a blocking bot review in progress, unresolved threads, or failing CI) maps to `ShepherdStatus: "PENDING"`. The same applies to `UNSTABLE` (non-required checks are red but merge is not fully blocked) and `BEHIND` (head branch is out of date). `FAILING` is reserved for red CI checks (`verdict.anyFailing`) and merge conflicts (`CONFLICTS`).
 
-## Copilot detection
+## Blocking-bot review detection
 
-`detectCopilotReview(pr)` returns true when:
+`detectBlockingBotReview(pr)` returns true when:
 
-1. Any `reviewRequest` has a login starting with `"copilot"` (case-insensitive), OR
-2. Any `latestReview` has a login starting with `"copilot"` AND `state === 'PENDING'`
+1. Any `reviewRequest` has a login starting with one of the configured `mergeStatus.blockingReviewerLogins` prefixes (case-insensitive), OR
+2. Any `latestReview` has a matching login AND `state === 'PENDING'`
 
-A completed Copilot review (APPROVED or CHANGES_REQUESTED) does not set `copilotReviewInProgress`.
+A completed review (APPROVED or CHANGES_REQUESTED) does not set `blockingBotReviewInProgress`. The logins to treat as blocking bots are configured via `mergeStatus.blockingReviewerLogins` in `.pr-shepherdrc.yml` (default: `["copilot"]`).

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -10,7 +10,7 @@ The timer also starts when the PR is BLOCKED but shepherd has nothing left to do
 
 ## The `updateReadyDelay` function
 
-Located in `commands/ready-delay.mts`, called from `iterate.mts` (step 3).
+Located in `commands/ready-delay.mts`, called from `commands/iterate/index.mts` (step 3).
 
 ```
 updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -67,12 +67,12 @@ Codex runs the same skill — one tick per goal iteration. The CLI detects Codex
 export AGENT=codex
 ```
 
-## `/pr-shepherd:resolve`
+## Resolve without iterating
 
-To fix review comments without starting a full goal loop, run `pr-shepherd resolve` directly:
+To fix review comments without starting a full iterate loop, run `pr-shepherd resolve` directly:
 
 ```bash
 <runner> pr-shepherd resolve <N> --fetch
 ```
 
-Follow the `## Instructions` in the output. The resolve skill has been folded into the main `pr-shepherd` skill — the CLI's `fix_code` action emits the exact `resolve` command to run after pushing fixes.
+Follow the `## Instructions` in the output. The `fix_code` action emits the exact `resolve` command to run after pushing fixes — so a full `pr-shepherd` iterate tick also covers resolve.

--- a/src/cli-parser.commit-suggestion.mock.test.mts
+++ b/src/cli-parser.commit-suggestion.mock.test.mts
@@ -8,8 +8,8 @@ vi.mock("./commands/resolve.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 vi.mock("./github/client.mts", () => ({

--- a/src/cli-parser.iterate-codex.mock.test.mts
+++ b/src/cli-parser.iterate-codex.mock.test.mts
@@ -8,8 +8,8 @@ vi.mock("./commands/resolve.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 vi.mock("./github/client.mts", () => ({
@@ -17,7 +17,7 @@ vi.mock("./github/client.mts", () => ({
 }));
 
 import { main } from "./cli-parser.mts";
-import { runIterate } from "./commands/iterate.mts";
+import { runIterate } from "./commands/iterate/index.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 
 const mockRunIterate = vi.mocked(runIterate);

--- a/src/cli-parser.iterate-fix.mock.test.mts
+++ b/src/cli-parser.iterate-fix.mock.test.mts
@@ -8,8 +8,8 @@ vi.mock("./commands/resolve.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 vi.mock("./github/client.mts", () => ({
@@ -17,7 +17,7 @@ vi.mock("./github/client.mts", () => ({
 }));
 
 import { main } from "./cli-parser.mts";
-import { runIterate } from "./commands/iterate.mts";
+import { runIterate } from "./commands/iterate/index.mts";
 import type { IterateResult } from "./types.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 
@@ -84,7 +84,6 @@ describe("main — iterate text format (fix_code and checks)", () => {
     };
     if (result.action !== "fix_code") throw new Error("unreachable");
     result.fix = {
-      mode: "rebase-and-push",
       threads: [
         {
           id: "PRRT_1",
@@ -181,7 +180,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
   it("fix_code: renders '## Review IDs to minimize queue' for seen summary IDs", async () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
-    if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
+
     result.fix.reviewSummaryIds = ["PRR_BOT", "PRR_AP"];
     result.fix.resolveCommand = {
       argv: ["npx", "pr-shepherd", "resolve", "42", "--minimize-comment-ids", "PRR_BOT,PRR_AP"],
@@ -205,7 +204,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
   it("fix_code: renders '## Review summaries (first look — to be minimized)' with body when firstLookSummaries is non-empty", async () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
-    if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
+
     result.fix.firstLookSummaries = [
       { id: "PRR_FL", author: "copilot", body: "Nice work overall." },
     ];
@@ -232,7 +231,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
   it("fix_code: renders '## Approvals (surfaced — not minimized)' with H3 + blockquote", async () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
-    if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
+
     result.fix.surfacedApprovals = [
       { id: "PRR_HUMAN", author: "alice", body: "Looks reasonable but please double-check X." },
     ];
@@ -249,7 +248,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
   it("fix_code: approval with empty body renders '(no review body)' instead of bare blockquote", async () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
-    if (result.fix.mode !== "rebase-and-push") throw new Error("unreachable");
+
     result.fix.surfacedApprovals = [{ id: "PRR_EMPTY", author: "alice", body: "" }];
     mockRunIterate.mockResolvedValue(result);
 
@@ -371,7 +370,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
 
   it("fix_code: check with runId=null + detailsUrl renders 'external `<url>`', without detailsUrl falls back to '(no runId)'", async () => {
     const result = makeIterateResult("fix_code");
-    if (result.action !== "fix_code" || result.fix.mode !== "rebase-and-push") {
+    if (result.action !== "fix_code") {
       throw new Error("unreachable");
     }
     result.fix.checks = [
@@ -433,7 +432,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
 
   it("fix_code: cancelled check renders [conclusion: CANCELLED] tag without failedStep/summary", async () => {
     const result = makeIterateResult("fix_code");
-    if (result.action !== "fix_code" || result.fix.mode !== "rebase-and-push") {
+    if (result.action !== "fix_code") {
       throw new Error("unreachable");
     }
     result.fix.checks = [

--- a/src/cli-parser.iterate-fixtures.mts
+++ b/src/cli-parser.iterate-fixtures.mts
@@ -9,7 +9,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
     mergeStateStatus: "BLOCKED" as const,
     mergeStatus: "BLOCKED" as const,
     reviewDecision: null as null,
-    copilotReviewInProgress: false,
+    blockingBotReviewInProgress: false,
     isDraft: false,
     shouldCancel: false,
     remainingSeconds: 60,
@@ -25,7 +25,6 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
       ...base,
       action: "fix_code",
       fix: {
-        mode: "rebase-and-push",
         threads: [],
         resolutionOnlyThreads: [],
         actionableComments: [],
@@ -54,7 +53,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
       ...base,
       action: "cancel",
       reason: "ready-delay-elapsed" as const,
-      log: "CANCEL: PR #42 — stopping monitor",
+      log: "CANCEL: PR #42 — stopping",
     };
   if (action === "escalate") {
     return {
@@ -66,7 +65,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
         ambiguousComments: [],
         changesRequestedReviews: [],
         suggestion: "check manually",
-        humanMessage: "⚠️ /pr-shepherd:monitor paused — needs human direction",
+        humanMessage: "⚠️ /pr-shepherd:pr-shepherd paused — needs human direction",
       },
     };
   }

--- a/src/cli-parser.iterate-summary.mock.test.mts
+++ b/src/cli-parser.iterate-summary.mock.test.mts
@@ -8,8 +8,8 @@ vi.mock("./commands/resolve.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 vi.mock("./github/client.mts", () => ({
@@ -17,7 +17,7 @@ vi.mock("./github/client.mts", () => ({
 }));
 
 import { main } from "./cli-parser.mts";
-import { runIterate } from "./commands/iterate.mts";
+import { runIterate } from "./commands/iterate/index.mts";
 import type { IterateResult } from "./types.mts";
 
 const mockRunIterate = vi.mocked(runIterate);
@@ -35,7 +35,7 @@ function makeFixCodeResult(): IterateResult & { action: "fix_code" } {
     mergeStateStatus: "BLOCKED" as const,
     mergeStatus: "BLOCKED" as const,
     reviewDecision: null,
-    copilotReviewInProgress: false,
+    blockingBotReviewInProgress: false,
     isDraft: false,
     shouldCancel: false,
     remainingSeconds: 60,
@@ -44,7 +44,6 @@ function makeFixCodeResult(): IterateResult & { action: "fix_code" } {
     checks: [],
     action: "fix_code",
     fix: {
-      mode: "rebase-and-push",
       threads: [],
       resolutionOnlyThreads: [],
       actionableComments: [],

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -8,13 +8,13 @@ vi.mock("./commands/resolve.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 
 import { main } from "./cli-parser.mts";
-import { runIterate } from "./commands/iterate.mts";
+import { runIterate } from "./commands/iterate/index.mts";
 import type { CancelReason, IterateResult } from "./types.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 
@@ -175,9 +175,9 @@ describe("main — iterate text format", () => {
     const out = getStdout();
     expect(out).toMatch(/^# PR #42 \[ESCALATE\]\n/);
     expect(out).toContain("**status** `IN_PROGRESS`");
-    expect(out).toContain("⚠️ /pr-shepherd:monitor paused — needs human direction");
+    expect(out).toContain("⚠️ /pr-shepherd:pr-shepherd paused — needs human direction");
     expect(out).toContain("## Instructions");
-    expect(out).toContain("1. Stop — the PR needs human direction before monitoring can resume.");
+    expect(out).toContain("1. Stop — the PR needs human direction before iterating can resume.");
   });
 
   it("wait: instructions use unified sleep wording with rerun command", async () => {
@@ -219,7 +219,7 @@ describe("main — iterate text format", () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("escalate"));
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
-    expect(out).toContain("1. Stop — the PR needs human direction before monitoring can resume.");
+    expect(out).toContain("1. Stop — the PR needs human direction before iterating can resume.");
     expect(out).not.toContain("CronList");
   });
 
@@ -266,7 +266,7 @@ describe("main — iterate text format", () => {
   // ---------------------------------------------------------------------------
 
   it("lean mode (default): summary line omits zero counts, false booleans, and non-READY remainingSeconds", async () => {
-    // fixture: status=IN_PROGRESS, remainingSeconds=60, copilotReviewInProgress=false, isDraft=false
+    // fixture: status=IN_PROGRESS, remainingSeconds=60, blockingBotReviewInProgress=false, isDraft=false
     mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
     await main(["node", "shepherd", "iterate", "42"]);
     const text = getStdout();
@@ -275,7 +275,7 @@ describe("main — iterate text format", () => {
     expect(text).not.toContain("filtered");
     // False booleans omitted
     expect(text).not.toContain("shouldCancel");
-    expect(text).not.toContain("copilotReviewInProgress");
+    expect(text).not.toContain("blockingBotReviewInProgress");
     expect(text).not.toContain("isDraft");
     // remainingSeconds omitted when status != READY
     expect(text).not.toContain("remainingSeconds");
@@ -292,16 +292,16 @@ describe("main — iterate text format", () => {
     expect(getStdout()).toContain("**remainingSeconds** 300");
   });
 
-  it("lean mode: copilotReviewInProgress and isDraft shown only when true", async () => {
+  it("lean mode: blockingBotReviewInProgress and isDraft shown only when true", async () => {
     const result = {
       ...makeIterateResult("wait"),
-      copilotReviewInProgress: true,
+      blockingBotReviewInProgress: true,
       isDraft: true,
     };
     mockRunIterate.mockResolvedValue(result);
     await main(["node", "shepherd", "iterate", "42"]);
     const text = getStdout();
-    expect(text).toContain("**copilotReviewInProgress**");
+    expect(text).toContain("**blockingBotReviewInProgress**");
     expect(text).toContain("**isDraft**");
   });
 
@@ -311,7 +311,7 @@ describe("main — iterate text format", () => {
     const text = getStdout();
     expect(text).toContain("shouldCancel");
     expect(text).toContain(`**remainingSeconds** 60`);
-    expect(text).toContain("copilotReviewInProgress");
+    expect(text).toContain("blockingBotReviewInProgress");
     expect(text).toContain("isDraft");
     expect(text).toContain("0 skipped");
     expect(text).toContain("0 filtered");
@@ -338,7 +338,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42", "--format", "json"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.shouldCancel).toBeUndefined();
-    expect(parsed.copilotReviewInProgress).toBeUndefined();
+    expect(parsed.blockingBotReviewInProgress).toBeUndefined();
     expect(parsed.isDraft).toBeUndefined();
     expect(parsed.remainingSeconds).toBeUndefined();
     // checks omitted for wait action
@@ -360,7 +360,7 @@ describe("main — iterate text format", () => {
     await main(["node", "shepherd", "iterate", "42", "--format", "json", "--verbose"]);
     const parsed = JSON.parse(getStdout().trimEnd());
     expect(parsed.shouldCancel).toBe(false);
-    expect(parsed.copilotReviewInProgress).toBe(false);
+    expect(parsed.blockingBotReviewInProgress).toBe(false);
     expect(parsed.isDraft).toBe(false);
     expect(parsed.remainingSeconds).toBe(60);
     expect(parsed.summary.skipped).toBe(0);

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -10,8 +10,8 @@ vi.mock("./commands/resolve.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 import { main } from "./cli-parser.mts";

--- a/src/cli-parser.resolve-fetch-suggestion.mock.test.mts
+++ b/src/cli-parser.resolve-fetch-suggestion.mock.test.mts
@@ -6,8 +6,8 @@ vi.mock("./commands/resolve.mts", () => ({
   runResolveMutate: vi.fn(),
 }));
 vi.mock("./commands/commit-suggestion.mts", () => ({ runCommitSuggestion: vi.fn() }));
-vi.mock("./commands/iterate.mts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./commands/iterate.mts")>();
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
 });
 vi.mock("./github/client.mts", () => ({

--- a/src/cli/fix-formatter.mts
+++ b/src/cli/fix-formatter.mts
@@ -1,4 +1,4 @@
-import { renderResolveCommand } from "../commands/iterate.mts";
+import { renderResolveCommand } from "../commands/iterate/render.mts";
 import { joinSections } from "../util/markdown.mts";
 import { renderSuggestionBlock, renderLineRange } from "./suggestion-renderer.mts";
 import {

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -1,5 +1,5 @@
 import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
-import { runIterate } from "../commands/iterate.mts";
+import { runIterate } from "../commands/iterate/index.mts";
 import { loadConfig } from "../config/load.mts";
 import { detectAgentRuntime } from "../agent-runtime.mts";
 import { parseCommonArgs, getFlag, hasFlag } from "./args.mts";

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -12,17 +12,17 @@ import {
 /**
  * Format an IterateResult as human-readable Markdown.
  *
- * Load-bearing conventions the monitor SKILL relies on:
+ * Load-bearing conventions the iterate skill relies on:
  *   1. The H1 heading on line 1 contains `[<ACTION>]` — the action tag identifies
  *      the output for logging and validation. Behavior is driven by `## Instructions`,
  *      not by dispatching on the tag.
  *   2. `[FIX_CODE]` uses the `rebase-and-push` variant: the `resolve` bullet under
- *      `## Post-fix push` wraps the resolve command in backticks — the SKILL
+ *      `## Post-fix push` wraps the resolve command in backticks — the skill
  *      extracts the backticked content for execution.
  *   3. Every action ends with a `## Instructions` section — numbered `1.`, `2.`, … —
- *      that tells the monitor exactly what to do with this output. The section is
+ *      that tells the agent exactly what to do with this output. The section is
  *      unconditional: every action, every variant, always emits at least one step.
- *      The SKILL simply follows those steps; it does not need its own dispatch table.
+ *      The skill simply follows those steps; it does not need its own dispatch table.
  */
 export function formatIterateResult(
   result: IterateResult,
@@ -47,7 +47,7 @@ export function formatIterateResult(
 
   let summaryLine: string;
   if (verbose) {
-    summaryLine = `**summary** ${result.summary.passing} passing, ${result.summary.skipped} skipped, ${result.summary.filtered} filtered, ${result.summary.inProgress} inProgress · **remainingSeconds** ${result.remainingSeconds} · **copilotReviewInProgress** ${result.copilotReviewInProgress} · **isDraft** ${result.isDraft} · **shouldCancel** ${result.shouldCancel}`;
+    summaryLine = `**summary** ${result.summary.passing} passing, ${result.summary.skipped} skipped, ${result.summary.filtered} filtered, ${result.summary.inProgress} inProgress · **remainingSeconds** ${result.remainingSeconds} · **blockingBotReviewInProgress** ${result.blockingBotReviewInProgress} · **isDraft** ${result.isDraft} · **shouldCancel** ${result.shouldCancel}`;
   } else {
     const counts = [`${result.summary.passing} passing`];
     if (result.summary.skipped > 0) counts.push(`${result.summary.skipped} skipped`);
@@ -57,7 +57,7 @@ export function formatIterateResult(
     if (result.status === "READY" && result.remainingSeconds > 0) {
       segs.push(`**remainingSeconds** ${result.remainingSeconds}`);
     }
-    if (result.copilotReviewInProgress) segs.push(`**copilotReviewInProgress**`);
+    if (result.blockingBotReviewInProgress) segs.push(`**blockingBotReviewInProgress**`);
     if (result.isDraft) segs.push(`**isDraft**`);
     summaryLine = segs.join(" · ");
   }

--- a/src/cli/iterate-formatter.mts
+++ b/src/cli/iterate-formatter.mts
@@ -16,9 +16,8 @@ import {
  *   1. The H1 heading on line 1 contains `[<ACTION>]` — the action tag identifies
  *      the output for logging and validation. Behavior is driven by `## Instructions`,
  *      not by dispatching on the tag.
- *   2. `[FIX_CODE]` uses the `rebase-and-push` variant: the `resolve` bullet under
- *      `## Post-fix push` wraps the resolve command in backticks — the skill
- *      extracts the backticked content for execution.
+ *   2. `[FIX_CODE]` wraps the `resolve` command under `## Post-fix push` in
+ *      backticks — the skill extracts the backticked content for execution.
  *   3. Every action ends with a `## Instructions` section — numbered `1.`, `2.`, … —
  *      that tells the agent exactly what to do with this output. The section is
  *      unconditional: every action, every variant, always emits at least one step.

--- a/src/cli/iterate-instructions.mts
+++ b/src/cli/iterate-instructions.mts
@@ -26,7 +26,7 @@ export function buildSimpleIterateInstructions(
     case "cancel":
       return ["Stop — the active goal is complete."];
     case "escalate":
-      return ["Stop — the PR needs human direction before monitoring can resume."];
+      return ["Stop — the PR needs human direction before iterating can resume."];
   }
 }
 

--- a/src/cli/iterate-lean.mts
+++ b/src/cli/iterate-lean.mts
@@ -35,7 +35,7 @@ export function projectIterateLean(
     mergeStateStatus: result.mergeStateStatus,
     ...(result.mergeStatus === "BLOCKED" &&
       result.reviewDecision !== null && { reviewDecision: result.reviewDecision }),
-    ...(result.copilotReviewInProgress && { copilotReviewInProgress: true }),
+    ...(result.blockingBotReviewInProgress && { blockingBotReviewInProgress: true }),
     ...(result.isDraft && { isDraft: true }),
     summary: {
       passing: result.summary.passing,
@@ -78,7 +78,6 @@ export function projectIterateLean(
         ...(result.checks.length > 0 && { checks: result.checks }),
         ...(result.cancelled.length > 0 && { cancelled: result.cancelled }),
         fix: {
-          mode: result.fix.mode,
           ...(result.fix.threads.length > 0 && { threads: result.fix.threads }),
           ...(result.fix.resolutionOnlyThreads.length > 0 && {
             resolutionOnlyThreads: result.fix.resolutionOnlyThreads,
@@ -137,9 +136,9 @@ export function projectIterateLean(
           ...(result.escalate.changesRequestedReviews.length > 0 && {
             changesRequestedReviews: result.escalate.changesRequestedReviews,
           }),
-          ...(result.escalate.attemptHistory &&
-            result.escalate.attemptHistory.length > 0 && {
-              attemptHistory: result.escalate.attemptHistory,
+          ...(result.escalate.thrashHistory &&
+            result.escalate.thrashHistory.length > 0 && {
+              thrashHistory: result.escalate.thrashHistory,
             }),
           suggestion: result.escalate.suggestion,
           humanMessage: result.escalate.humanMessage,

--- a/src/cli/iterate-lean.test.mts
+++ b/src/cli/iterate-lean.test.mts
@@ -13,15 +13,15 @@ describe("projectIterateLean", () => {
     expect(lean.shouldCancel).toBeUndefined();
   });
 
-  it("omits copilotReviewInProgress when false", () => {
+  it("omits blockingBotReviewInProgress when false", () => {
     const lean = projectIterateLean(makeIterateResult("wait")) as Record<string, unknown>;
-    expect(lean.copilotReviewInProgress).toBeUndefined();
+    expect(lean.blockingBotReviewInProgress).toBeUndefined();
   });
 
-  it("includes copilotReviewInProgress: true when set", () => {
-    const result = { ...makeIterateResult("wait"), copilotReviewInProgress: true };
+  it("includes blockingBotReviewInProgress: true when set", () => {
+    const result = { ...makeIterateResult("wait"), blockingBotReviewInProgress: true };
     const lean = projectIterateLean(result) as Record<string, unknown>;
-    expect(lean.copilotReviewInProgress).toBe(true);
+    expect(lean.blockingBotReviewInProgress).toBe(true);
   });
 
   it("omits isDraft when false", () => {
@@ -292,7 +292,7 @@ describe("projectIterateLean", () => {
     expect(esc.unresolvedThreads).toBeUndefined();
     expect(esc.ambiguousComments).toBeUndefined();
     expect(esc.changesRequestedReviews).toBeUndefined();
-    expect(esc.attemptHistory).toBeUndefined();
+    expect(esc.thrashHistory).toBeUndefined();
     expect(esc.suggestion).toBe("check manually");
     expect(esc.humanMessage).toBeDefined();
   });
@@ -306,7 +306,7 @@ describe("projectIterateLean", () => {
     ];
     result.escalate.ambiguousComments = [{ id: "c1", author: "a", body: "?", url: "" }];
     result.escalate.changesRequestedReviews = [{ id: "rv1", author: "a", body: "" }];
-    result.escalate.attemptHistory = [{ threadId: "t1", attempts: 3 }];
+    result.escalate.thrashHistory = [{ threadId: "t1", attempts: 3 }];
 
     const lean = projectIterateLean(result) as Record<string, unknown>;
     const esc = lean.escalate as Record<string, unknown>;
@@ -314,6 +314,6 @@ describe("projectIterateLean", () => {
     expect((esc.unresolvedThreads as unknown[]).length).toBe(1);
     expect((esc.ambiguousComments as unknown[]).length).toBe(1);
     expect((esc.changesRequestedReviews as unknown[]).length).toBe(1);
-    expect((esc.attemptHistory as unknown[]).length).toBe(1);
+    expect((esc.thrashHistory as unknown[]).length).toBe(1);
   });
 });

--- a/src/commands/check-status.mts
+++ b/src/commands/check-status.mts
@@ -19,7 +19,7 @@ export function computeStatus(
   // is BLOCKED (review pending, insufficient approvals, branch-protection rule, etc.).
   // Requires hasChecks so that a PR with zero relevant checks (CI never started, or all
   // filtered/skipped) doesn't prematurely trigger READY before any check has reported.
-  // copilotReviewInProgress is still excluded — a bot review is shepherd's problem, not a hand-off.
+  // blockingBotReviewInProgress is still excluded — a bot review is shepherd's problem, not a hand-off.
   if (
     verdict.allPassed &&
     verdict.hasChecks &&
@@ -27,7 +27,7 @@ export function computeStatus(
     unresolvedComments === 0 &&
     changesRequestedReviews === 0 &&
     mergeStatus.status === "BLOCKED" &&
-    !mergeStatus.copilotReviewInProgress
+    !mergeStatus.blockingBotReviewInProgress
   ) {
     return "READY";
   }

--- a/src/commands/iterate.base-checks.mock.test.mts
+++ b/src/commands/iterate.base-checks.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -278,7 +278,7 @@ describe("runIterate — base.checks carries passing + failing (regression: miss
           isDraft: false,
           mergeable: "MERGEABLE",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "BEHIND",
         },
         checks: {

--- a/src/commands/iterate.classify.mock.test.mts
+++ b/src/commands/iterate.classify.mock.test.mts
@@ -223,7 +223,6 @@ describe("runIterate — review summary auto-minimize", () => {
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
 
-
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
     expect(result.fix.surfacedApprovals).toEqual([]);
     expect(result.fix.resolveCommand.argv).toContain("--minimize-comment-ids");
@@ -368,7 +367,6 @@ describe("runIterate — review summary auto-minimize", () => {
 
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
-
 
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
   });

--- a/src/commands/iterate.classify.mock.test.mts
+++ b/src/commands/iterate.classify.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -222,8 +222,8 @@ describe("runIterate — review summary auto-minimize", () => {
 
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
-    expect(result.fix.mode).toBe("rebase-and-push");
-    if (result.fix.mode !== "rebase-and-push") return;
+
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
     expect(result.fix.surfacedApprovals).toEqual([]);
     expect(result.fix.resolveCommand.argv).toContain("--minimize-comment-ids");
@@ -240,7 +240,7 @@ describe("runIterate — review summary auto-minimize", () => {
     });
     const result = await runIterate(makeOpts());
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BRK"]);
   });
 
@@ -253,7 +253,7 @@ describe("runIterate — review summary auto-minimize", () => {
     });
     const result = await runIterate(makeOpts());
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_GEM"]);
   });
 
@@ -266,7 +266,7 @@ describe("runIterate — review summary auto-minimize", () => {
     });
     const result = await runIterate(makeOpts());
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_HUMAN"]);
     expect(result.fix.surfacedApprovals).toEqual([]);
   });
@@ -280,7 +280,7 @@ describe("runIterate — review summary auto-minimize", () => {
     });
     const result = await runIterate(makeOpts());
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT", "PRR_HUMAN"]);
     expect(result.fix.surfacedApprovals).toEqual([]);
   });
@@ -316,7 +316,7 @@ describe("runIterate — review summary auto-minimize", () => {
     });
     const result = await runIterate(makeOpts());
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_AP"]);
   });
 
@@ -368,8 +368,8 @@ describe("runIterate — review summary auto-minimize", () => {
 
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
-    expect(result.fix.mode).toBe("rebase-and-push");
-    if (result.fix.mode !== "rebase-and-push") return;
+
+
     expect(result.fix.reviewSummaryIds).toEqual(["PRR_BOT"]);
   });
 
@@ -390,7 +390,7 @@ describe("runIterate — review summary auto-minimize", () => {
 
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.editedSummaries).toEqual([editedSummary]);
     expect(result.fix.reviewSummaryIds).toContain("PRR_SEEN");
     expect(result.fix.reviewSummaryIds).not.toContain("PRR_ED");
@@ -410,7 +410,7 @@ describe("runIterate — review summary auto-minimize", () => {
 
     expect(result.action).toBe("fix_code");
     if (result.action !== "fix_code") return;
-    if (result.fix.mode !== "rebase-and-push") return;
+
     expect(result.fix.firstLookSummaries).toEqual([summary]);
     expect(result.fix.reviewSummaryIds).toContain("PRR_FL");
   });

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -51,7 +51,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -82,7 +82,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -249,9 +249,9 @@ describe("runIterate — escalate (fix-thrash)", () => {
     expect(result.action).toBe("escalate");
     if (result.action === "escalate") {
       expect(result.escalate.triggers).toContain("fix-thrash");
-      expect(result.escalate.attemptHistory).toHaveLength(1);
-      expect(result.escalate.attemptHistory?.[0]?.threadId).toBe("thread-1");
-      expect(result.escalate.attemptHistory?.[0]?.attempts).toBe(3);
+      expect(result.escalate.thrashHistory).toHaveLength(1);
+      expect(result.escalate.thrashHistory?.[0]?.threadId).toBe("thread-1");
+      expect(result.escalate.thrashHistory?.[0]?.attempts).toBe(3);
     }
   });
 
@@ -415,7 +415,7 @@ describe("runIterate — escalate (pr-level-changes-requested suppressed during 
           isDraft: false,
           mergeable: "CONFLICTING",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "DIRTY",
         },
         changesRequestedReviews: [{ id: "review-1", author: "boss", body: "Needs rework" }],
@@ -492,7 +492,7 @@ function makeBlockedReadyReport(reviewDecision: "REVIEW_REQUIRED" | "APPROVED" |
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision,
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "BLOCKED",
     },
   });

--- a/src/commands/iterate.fix-code-actionable.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -294,7 +294,7 @@ describe("runIterate — fix_code (actionable threads)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.threads).toHaveLength(2);
       expect(result.fix.actionableComments).toHaveLength(0);
       expect(result.fix.checks).toHaveLength(0);
@@ -382,7 +382,7 @@ describe("runIterate — fix_code (actionable threads)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const joined = result.fix.instructions.join("\n");
       const journalMentions = joined.match(/## Shepherd Journal/g)?.length ?? 0;
       expect(joined).toContain("Shepherd Journal");
@@ -448,7 +448,7 @@ describe("runIterate — fix_code (actionable threads)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(1);
       const joined = result.fix.instructions.join("\n");
       const mentions = joined.match(/## Shepherd Journal/g)?.length ?? 0;

--- a/src/commands/iterate.fix-code-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -238,7 +238,7 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(1);
       expect(result.cancelled).toEqual(["run-99"]);
       const joined = result.fix.instructions.join("\n");
@@ -296,7 +296,7 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(2);
       expect(result.cancelled).toEqual(["run-101"]);
     }
@@ -334,7 +334,7 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
 
     // The fix_code decision must survive even when cancel side-effect fails entirely.
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(1);
       expect(result.cancelled).toEqual([]);
     }
@@ -373,7 +373,7 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
       const result = await runIterate(makeOpts());
 
       expect(result.action).toBe("fix_code");
-      if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+      if (result.action === "fix_code") {
         expect(result.cancelled).toEqual([]);
       }
       expect(stderrSpy).not.toHaveBeenCalled();
@@ -447,7 +447,7 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       // Both AgentChecks are present — each may carry distinct workflowName/jobName.
       expect(result.fix.checks).toHaveLength(2);
       expect(result.fix.checks.map((c) => c.runId)).toEqual(["run-300", "run-300"]);

--- a/src/commands/iterate.fix-code-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -211,7 +211,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
           isDraft: false,
           mergeable: "CONFLICTING",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "DIRTY",
         },
       }),
@@ -225,7 +225,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.threads).toHaveLength(0);
       expect(result.fix.checks).toHaveLength(0);
       // CONFLICTS-only: no commit step (nothing to commit), but we still
@@ -263,7 +263,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
           isDraft: false,
           mergeable: "CONFLICTING",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "DIRTY",
         },
         threads: {
@@ -284,7 +284,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.threads).toHaveLength(1);
       expect(result.fix.threads[0]?.id).toBe("thread-1");
       // Threads + CONFLICTS: commit step, rebase-with-conflict-resolution (not

--- a/src/commands/iterate.fix-code-in-progress.mock.test.mts
+++ b/src/commands/iterate.fix-code-in-progress.mock.test.mts
@@ -40,7 +40,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -67,7 +67,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -201,7 +201,7 @@ describe("fix_code — in-progress run cancellation", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.inProgressRunIds).toContain("run-in-1");
       expect(result.fix.inProgressRunIds).not.toContain("run-fail-1");
       expect(result.fix.instructions[0]).toMatch(/Cancel in-progress CI runs first/);
@@ -241,7 +241,7 @@ describe("fix_code — in-progress run cancellation", () => {
 
     const result = await runIterate(makeOpts());
 
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.inProgressRunIds).toHaveLength(0);
       expect(result.fix.instructions.join("\n")).not.toMatch(/Cancel in-progress CI runs first/);
     }
@@ -293,7 +293,7 @@ describe("fix_code — in-progress run cancellation", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.actionableComments).toHaveLength(1);
       expect(result.fix.inProgressRunIds).toHaveLength(0);
       expect(result.fix.instructions.join("\n")).not.toMatch(/Cancel in-progress CI runs first/);

--- a/src/commands/iterate.fix-code-projection.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -248,7 +248,7 @@ describe("runIterate — fix_code agent projection", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const t = result.fix.threads[0]!;
       expect(t.id).toBe("t-1");
       expect(t.path).toBe("src/foo.mts");
@@ -285,7 +285,7 @@ describe("runIterate — fix_code agent projection", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const c = result.fix.actionableComments[0]!;
       expect(c.id).toBe("c-1");
       expect(c.author).toBe("bob");
@@ -320,7 +320,7 @@ describe("runIterate — fix_code agent projection", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const c = result.fix.checks[0]!;
       expect(c.name).toBe("typecheck");
       expect(c.runId).toBe("run-55");
@@ -366,7 +366,7 @@ describe("runIterate — fix_code agent projection", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const instructionsJoined = result.fix.instructions.join("\n");
       // GitHub Actions check with runId — agent fetches logs and decides rerun vs fix
       expect(instructionsJoined).toContain("gh run view <runId> --log-failed");
@@ -412,7 +412,7 @@ describe("runIterate — fix_code agent projection", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const instructionsJoined = result.fix.instructions.join("\n");
       expect(instructionsJoined).toContain("(no runId)");
       expect(instructionsJoined).toMatch(/escalate/i);
@@ -468,7 +468,7 @@ describe("runIterate — fix_code agent projection", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(3);
       const joined = result.fix.instructions.join("\n");
       // All three instruction variants present:

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -52,7 +52,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -83,7 +83,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -248,7 +248,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
           isDraft: false,
           mergeable: "UNKNOWN",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "UNKNOWN",
         },
       }),
@@ -270,7 +270,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
           isDraft: false,
           mergeable: "UNKNOWN",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "UNKNOWN",
         },
       }),

--- a/src/commands/iterate.mts
+++ b/src/commands/iterate.mts
@@ -1,7 +1,0 @@
-export { runIterate } from "./iterate/index.mts";
-export {
-  FIX_INSTRUCTION_END_ITERATION,
-  FIX_INSTRUCTION_STOP_AFTER_PUSH,
-  FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK,
-  renderResolveCommand,
-} from "./iterate/render.mts";

--- a/src/commands/iterate.orchestrator.mock.test.mts
+++ b/src/commands/iterate.orchestrator.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -211,7 +211,7 @@ describe("runIterate — mark_ready", () => {
           isDraft: true,
           mergeable: "MERGEABLE",
           reviewDecision: "APPROVED",
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "CLEAN",
         },
       }),
@@ -236,7 +236,7 @@ describe("runIterate — mark_ready", () => {
     expect(graphqlCalls).toHaveLength(1);
   });
 
-  it("does NOT mark ready when copilotReviewInProgress", async () => {
+  it("does NOT mark ready when blockingBotReviewInProgress", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
         status: "READY",
@@ -246,7 +246,7 @@ describe("runIterate — mark_ready", () => {
           isDraft: true,
           mergeable: "MERGEABLE",
           reviewDecision: "APPROVED",
-          copilotReviewInProgress: true,
+          blockingBotReviewInProgress: true,
           mergeStateStatus: "CLEAN",
         },
       }),
@@ -277,7 +277,7 @@ describe("runIterate — triage via runCheck", () => {
           isDraft: false,
           mergeable: "UNKNOWN",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "UNKNOWN",
         },
         checks: {
@@ -317,7 +317,7 @@ describe("runIterate — triage via runCheck", () => {
           isDraft: false,
           mergeable: "CONFLICTING",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "DIRTY",
         },
         checks: {
@@ -385,7 +385,7 @@ describe("runIterate — triage via runCheck", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(1);
       expect(result.fix.checks[0]?.name).toBe("typecheck");
       expect(result.fix.checks[0]?.runId).toBe("run-3");

--- a/src/commands/iterate.render-escalate-fields.mock.test.mts
+++ b/src/commands/iterate.render-escalate-fields.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -256,7 +256,7 @@ describe("runIterate — prescriptive fields: resolveCommand shape", () => {
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const { resolveCommand } = result.fix;
       expect(resolveCommand.argv).toContain("--resolve-thread-ids");
       expect(resolveCommand.argv.join(" ")).toContain("thread-1");
@@ -300,7 +300,7 @@ describe("runIterate — prescriptive fields: resolveCommand shape", () => {
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       const { resolveCommand } = result.fix;
       expect(resolveCommand.argv).toContain("--dismiss-review-ids");
       expect(resolveCommand.argv.join(" ")).toContain("r-1");

--- a/src/commands/iterate.render-humanmessage.mock.test.mts
+++ b/src/commands/iterate.render-humanmessage.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -251,8 +251,8 @@ describe("runIterate — prescriptive fields: escalate humanMessage", () => {
       expect(humanMessage).toMatch(/fix-thrash/);
       expect(humanMessage).toMatch(/thread-1/);
       expect(humanMessage).toMatch(/src\/foo\.mts/);
-      expect(humanMessage).toMatch(/pr-shepherd:check 42/);
-      expect(humanMessage).toMatch(/pr-shepherd:monitor 42` to resume/);
+      expect(humanMessage).toMatch(/pr-shepherd:pr-shepherd 42/);
+      expect(humanMessage).toMatch(/pr-shepherd:pr-shepherd 42` to resume/);
     }
   });
 
@@ -301,7 +301,7 @@ describe("runIterate — prescriptive fields: escalate humanMessage", () => {
           isDraft: false,
           mergeable: "CONFLICTING",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "DIRTY",
         },
       }),

--- a/src/commands/iterate.render-resolve-cmd.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.mock.test.mts
@@ -54,7 +54,8 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate, renderResolveCommand } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
+import { renderResolveCommand } from "./iterate/render.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +86,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -380,7 +381,7 @@ describe("buildResolveCommand (via runIterate) — argv shape invariants", () =>
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("fix_code");
-    if (result.action === "fix_code" && result.fix.mode === "rebase-and-push") {
+    if (result.action === "fix_code") {
       expect(result.fix.resolveCommand.argv).not.toContain("$HEAD_SHA");
       expect(result.fix.resolveCommand.argv).not.toContain("--require-sha");
       expect(result.fix.resolveCommand.requiresHeadSha).toBe(true);

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -232,7 +232,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
           isDraft: mergeStatusVal === "DRAFT",
           mergeable: "MERGEABLE",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: mergeStatusVal,
         },
       }),
@@ -258,7 +258,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
           isDraft: false,
           mergeable: "MERGEABLE",
           reviewDecision: "APPROVED",
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "CLEAN",
         },
       }),
@@ -282,7 +282,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
           isDraft: false,
           mergeable: "UNKNOWN",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "UNKNOWN",
         },
       }),
@@ -402,7 +402,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
           isDraft: true,
           mergeable: "MERGEABLE",
           reviewDecision: "APPROVED",
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "DRAFT",
         },
       }),
@@ -438,7 +438,7 @@ describe("runIterate — HAS_HOOKS (derived BLOCKED)", () => {
         isDraft: false,
         mergeable: "MERGEABLE",
         reviewDecision,
-        copilotReviewInProgress: false,
+        blockingBotReviewInProgress: false,
         mergeStateStatus: "HAS_HOOKS",
       },
     });

--- a/src/commands/iterate.stall.mock.test.mts
+++ b/src/commands/iterate.stall.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {

--- a/src/commands/iterate.steps.mock.test.mts
+++ b/src/commands/iterate.steps.mock.test.mts
@@ -54,7 +54,7 @@ vi.mock("../state/iterate-stall.mts", () => ({
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
-import { runIterate } from "./iterate.mts";
+import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -85,7 +85,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
       isDraft: false,
       mergeable: "MERGEABLE",
       reviewDecision: "APPROVED",
-      copilotReviewInProgress: false,
+      blockingBotReviewInProgress: false,
       mergeStateStatus: "CLEAN",
     },
     checks: {
@@ -321,7 +321,7 @@ describe("runIterate — cancelled + BEHIND", () => {
           isDraft: false,
           mergeable: "MERGEABLE",
           reviewDecision: null,
-          copilotReviewInProgress: false,
+          blockingBotReviewInProgress: false,
           mergeStateStatus: "BEHIND",
         },
         checks: {

--- a/src/commands/iterate/escalate.mts
+++ b/src/commands/iterate/escalate.mts
@@ -1,5 +1,6 @@
 import type {
   EscalateDetails,
+  EscalateTrigger,
   ReviewThread,
   PrComment,
   Review,
@@ -8,8 +9,8 @@ import type {
 import { loadConfig } from "../../config/load.mts";
 
 export interface EscalateCheck {
-  triggers: string[];
-  thrashHistory?: EscalateDetails["attemptHistory"];
+  triggers: EscalateTrigger[];
+  thrashHistory?: EscalateDetails["thrashHistory"];
 }
 
 export function checkEscalateTriggers(
@@ -21,7 +22,7 @@ export function checkEscalateTriggers(
   threadAttempts: Record<string, number>,
   hasConflicts: boolean,
 ): EscalateCheck {
-  const triggers: string[] = [];
+  const triggers: EscalateTrigger[] = [];
   const maxAttempts = loadConfig().iterate.fixAttemptsPerThread;
 
   // Trigger 1: fix thrash — same thread dispatched too many times without resolving.
@@ -97,7 +98,7 @@ export function buildEscalateHumanMessage(
   pr: number,
 ): string {
   const lines: string[] = [];
-  lines.push("⚠️ /pr-shepherd:monitor paused — needs human direction");
+  lines.push("⚠️ /pr-shepherd:pr-shepherd paused — needs human direction");
   lines.push("");
   lines.push(`**Triggers:** ${escalate.triggers.map((t) => `\`${t}\``).join(", ")}`);
   lines.push("");
@@ -125,10 +126,10 @@ export function buildEscalateHumanMessage(
     }
   }
 
-  if (escalate.attemptHistory && escalate.attemptHistory.length > 0) {
+  if (escalate.thrashHistory && escalate.thrashHistory.length > 0) {
     lines.push("");
     lines.push("## Fix attempts");
-    for (const a of escalate.attemptHistory) {
+    for (const a of escalate.thrashHistory) {
       lines.push(`- thread \`${a.threadId}\` attempted ${a.attempts} times`);
     }
   }
@@ -136,12 +137,12 @@ export function buildEscalateHumanMessage(
   lines.push("");
   lines.push("---");
   lines.push("");
-  lines.push(`Run \`/pr-shepherd:check ${pr}\` to see current state.`);
-  lines.push(`After fixing manually, rerun \`/pr-shepherd:monitor ${pr}\` to resume.`);
+  lines.push(`Run \`/pr-shepherd:pr-shepherd ${pr}\` to see current state.`);
+  lines.push(`After fixing manually, rerun \`/pr-shepherd:pr-shepherd ${pr}\` to resume.`);
   return lines.join("\n");
 }
 
-export function buildEscalateSuggestion(triggers: string[], detail?: string): string {
+export function buildEscalateSuggestion(triggers: EscalateTrigger[], detail?: string): string {
   if (triggers.includes("stall-timeout")) {
     const mins = detail ?? "30";
     return `No progress detected for ${mins} minute${parseInt(mins, 10) === 1 ? "" : "s"} — state has not changed. Inspect the PR and resume manually once the blocking issue is resolved.`;
@@ -151,7 +152,7 @@ export function buildEscalateSuggestion(triggers: string[], detail?: string): st
     return `Could not determine the PR's base branch${reason} — refusing to emit a rebase that could force-push onto the wrong base. Run the rebase manually against the PR's real target branch.`;
   }
   if (triggers.includes("fix-thrash")) {
-    return "Same thread(s) attempted multiple times without resolution — fix manually then rerun /pr-shepherd:monitor";
+    return "Same thread(s) attempted multiple times without resolution — fix manually then rerun /pr-shepherd:pr-shepherd";
   }
   if (triggers.includes("pr-level-changes-requested")) {
     return "Reviewer requested changes but left no inline comments — read the review and act manually";

--- a/src/commands/iterate/fix-code.mts
+++ b/src/commands/iterate/fix-code.mts
@@ -79,7 +79,7 @@ export async function handleFixCode(ctx: HandleFixCodeContext): Promise<IterateR
       ),
       ambiguousComments: report.comments.actionable.map(toAgentComment),
       changesRequestedReviews: report.changesRequestedReviews,
-      attemptHistory: escalateTriggers.thrashHistory,
+      thrashHistory: escalateTriggers.thrashHistory,
       suggestion: buildEscalateSuggestion(escalateTriggers.triggers),
     };
     return {
@@ -176,7 +176,6 @@ export async function handleFixCode(ctx: HandleFixCodeContext): Promise<IterateR
       baseBranch: baseLookup.branch,
       action: "fix_code" as const,
       fix: {
-        mode: "rebase-and-push" as const,
         threads,
         resolutionOnlyThreads,
         actionableComments,

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -35,7 +35,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       mergeStateStatus: report.mergeStatus.mergeStateStatus,
       mergeStatus: report.mergeStatus.status,
       reviewDecision: report.mergeStatus.reviewDecision,
-      copilotReviewInProgress: report.mergeStatus.copilotReviewInProgress,
+      blockingBotReviewInProgress: report.mergeStatus.blockingBotReviewInProgress,
       isDraft: report.mergeStatus.isDraft,
       shouldCancel: true,
       remainingSeconds: 0,
@@ -45,7 +45,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       checks: buildRelevantChecks(report),
       action: "cancel",
       reason: report.mergeStatus.state === "MERGED" ? "merged" : "closed",
-      log: `CANCEL: PR #${report.pr} is ${state} — stopping monitor`,
+      log: `CANCEL: PR #${report.pr} is ${state} — stopping`,
     };
   }
 
@@ -70,7 +70,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     mergeStateStatus: report.mergeStatus.mergeStateStatus,
     mergeStatus: report.mergeStatus.status,
     reviewDecision: report.mergeStatus.reviewDecision,
-    copilotReviewInProgress: report.mergeStatus.copilotReviewInProgress,
+    blockingBotReviewInProgress: report.mergeStatus.blockingBotReviewInProgress,
     isDraft: report.mergeStatus.isDraft,
     shouldCancel: readyState.shouldCancel,
     remainingSeconds: readyState.remainingSeconds,
@@ -89,7 +89,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       ...base,
       action: "cancel",
       reason: "ready-delay-elapsed",
-      log: `CANCEL: PR #${base.pr} ${cancelNote} — ready-delay elapsed, stopping monitor`,
+      log: `CANCEL: PR #${base.pr} ${cancelNote} — ready-delay elapsed, stopping`,
     };
   }
 
@@ -141,7 +141,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   const canMarkReady =
     report.status === "READY" &&
     report.mergeStatus.isDraft &&
-    !report.mergeStatus.copilotReviewInProgress &&
+    !report.mergeStatus.blockingBotReviewInProgress &&
     !readyState.shouldCancel;
 
   if (canMarkReady && !opts.noAutoMarkReady && config.actions.autoMarkReady) {

--- a/src/commands/ready-delay.mts
+++ b/src/commands/ready-delay.mts
@@ -22,7 +22,7 @@ export interface ReadyDelayState {
    * longer than the configured ready-delay.
    */
   shouldCancel: boolean;
-  /** How many seconds remain in the ready-delay cooldown. */
+  /** How many seconds remain in the ready-delay. */
   remainingSeconds: number;
 }
 

--- a/src/github/batch.mts
+++ b/src/github/batch.mts
@@ -26,7 +26,7 @@ export interface FetchPrBatchOptions {
    * When false (default), the first-page approvedReviews are returned but
    * backward pagination is skipped. Iterate's approvals-minimize flow sets this
    * to true only when the user opts in, so long-lived PRs with > 50 approvals
-   * don't pay extra GraphQL round-trips per monitor tick for data no consumer
+   * don't pay extra GraphQL round-trips per iterate call for data no consumer
    * currently uses. The first page is free — already inside the one batch
    * request — so there's no need to conditionally omit the field itself.
    */

--- a/src/index.mts
+++ b/src/index.mts
@@ -4,10 +4,8 @@
  *
  * Usage:
  *   pr-shepherd [PR]
- *   pr-shepherd check [PR]
  *   pr-shepherd resolve [PR]
  *   pr-shepherd iterate [PR]
- *   pr-shepherd status PR1 [PR2 …]
  */
 
 import { main } from "./cli-parser.mts";

--- a/src/merge-status/derive.mts
+++ b/src/merge-status/derive.mts
@@ -6,7 +6,7 @@
  *
  * Interpretation order for `status` — first match wins:
  *   1. mergeable == CONFLICTING       → CONFLICTS (hard conflict even for drafts)
- *   2. copilotReviewInProgress        → BLOCKED
+ *   2. blockingBotReviewInProgress        → BLOCKED
  *   3. mergeStateStatus DIRTY         → CONFLICTS (GitHub merge conflicts, even for drafts)
  *   4. isDraft                        → DRAFT
  *   5. mergeStateStatus BEHIND        → BEHIND
@@ -20,13 +20,13 @@ import type { BatchPrData, MergeStatusResult } from "../types.mts";
 import { loadConfig } from "../config/load.mts";
 
 export function deriveMergeStatus(pr: BatchPrData): MergeStatusResult {
-  const copilotReviewInProgress = detectCopilotReview(pr);
+  const blockingBotReviewInProgress = detectBlockingBotReview(pr);
 
   let status: MergeStatusResult["status"];
 
   if (pr.mergeable === "CONFLICTING") {
     status = "CONFLICTS";
-  } else if (copilotReviewInProgress) {
+  } else if (blockingBotReviewInProgress) {
     status = "BLOCKED";
   } else if (pr.mergeStateStatus === "DIRTY") {
     // DIRTY means GitHub detected merge conflicts — surface as CONFLICTS even for drafts.
@@ -51,16 +51,16 @@ export function deriveMergeStatus(pr: BatchPrData): MergeStatusResult {
     isDraft: pr.isDraft,
     mergeable: pr.mergeable,
     reviewDecision: pr.reviewDecision,
-    copilotReviewInProgress,
+    blockingBotReviewInProgress,
     mergeStateStatus: pr.mergeStateStatus,
   };
 }
 
 // ---------------------------------------------------------------------------
-// Copilot review detection
+// Blocking bot review detection
 // ---------------------------------------------------------------------------
 
-function detectCopilotReview(pr: BatchPrData): boolean {
+function detectBlockingBotReview(pr: BatchPrData): boolean {
   // A blocking bot review is "in progress" when:
   //   1. Any reviewRequest has a login starting with one of the configured prefixes, OR
   //   2. Any latestReview has such a login AND state == "PENDING"

--- a/src/merge-status/derive.test.mts
+++ b/src/merge-status/derive.test.mts
@@ -42,7 +42,7 @@ describe("deriveMergeStatus", () => {
       makePr({ reviewRequests: [{ login: "copilot-pull-request-reviewer[bot]" }] }),
     );
     expect(result.status).toBe("BLOCKED");
-    expect(result.copilotReviewInProgress).toBe(true);
+    expect(result.blockingBotReviewInProgress).toBe(true);
   });
 
   it("Copilot review PENDING in latestReviews → BLOCKED", () => {
@@ -52,7 +52,7 @@ describe("deriveMergeStatus", () => {
       }),
     );
     expect(result.status).toBe("BLOCKED");
-    expect(result.copilotReviewInProgress).toBe(true);
+    expect(result.blockingBotReviewInProgress).toBe(true);
   });
 
   it("Copilot review APPROVED in latestReviews → not copilotInProgress", () => {
@@ -61,7 +61,7 @@ describe("deriveMergeStatus", () => {
         latestReviews: [{ login: "copilot[bot]", state: "APPROVED" }],
       }),
     );
-    expect(result.copilotReviewInProgress).toBe(false);
+    expect(result.blockingBotReviewInProgress).toBe(false);
   });
 
   it("CONFLICTING takes priority over copilot blocked", () => {

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -3,7 +3,7 @@
  *
  * These strip fields that are always-false by the time items reach iterate
  * (isResolved, isOutdated, isMinimized, createdAtUnix) and check metadata the
- * monitor prompt never reads (event, status, category).
+ * agent/iterate prompt never reads (event, status, category).
  * conclusion is preserved on AgentCheck so the formatter can branch on run-level conclusions.
  * detailsUrl is preserved in AgentCheck as a fallback for external status checks.
  * The original domain types are preserved for check command output.

--- a/src/reporters/agent.mts
+++ b/src/reporters/agent.mts
@@ -6,7 +6,7 @@
  * agent/iterate prompt never reads (event, status, category).
  * conclusion is preserved on AgentCheck so the formatter can branch on run-level conclusions.
  * detailsUrl is preserved in AgentCheck as a fallback for external status checks.
- * The original domain types are preserved for check command output.
+ * The original domain types are preserved as internal snapshot types.
  */
 
 import { extractSuggestion } from "../suggestions/extract.mts";

--- a/src/types/github.mts
+++ b/src/types/github.mts
@@ -146,7 +146,7 @@ export interface MergeStatusResult {
   isDraft: boolean;
   mergeable: MergeableState;
   reviewDecision: ReviewDecision;
-  copilotReviewInProgress: boolean;
+  blockingBotReviewInProgress: boolean;
   mergeStateStatus: MergeStateStatus;
 }
 
@@ -174,7 +174,7 @@ export interface BatchPrData {
   changesRequestedReviews: Review[];
   /** COMMENTED reviews with a non-empty, non-minimized body — surfaced for agent-driven minimize. */
   reviewSummaries: Review[];
-  /** APPROVED reviews that are not minimized — opt-in minimize target for the monitor loop. */
+  /** APPROVED reviews that are not minimized — opt-in minimize target for the iterate loop. */
   approvedReviews: Review[];
   checks: CheckRun[];
 }

--- a/src/types/iterate.mts
+++ b/src/types/iterate.mts
@@ -20,13 +20,20 @@ import type {
 
 export type ShepherdAction = "wait" | "fix_code" | "mark_ready" | "cancel" | "escalate";
 
+export type EscalateTrigger =
+  | "fix-thrash"
+  | "base-branch-unknown"
+  | "stall-timeout"
+  | "thread-missing-location"
+  | "pr-level-changes-requested";
+
 export interface EscalateDetails {
-  triggers: string[];
+  triggers: EscalateTrigger[];
   unresolvedThreads: AgentThread[];
   ambiguousComments: AgentComment[];
   changesRequestedReviews: Review[];
   /** Populated when fix-thrash triggered — threads that have been attempted too many times. */
-  attemptHistory?: Array<{ threadId: string; attempts: number }>;
+  thrashHistory?: Array<{ threadId: string; attempts: number }>;
   /** One-line hint for the human on what to do. */
   suggestion: string;
   /** Full human-readable block ready to print: headline, triggers, suggestions, thread list. */
@@ -50,11 +57,16 @@ export interface IterateResultBase {
    * Shepherd-derived merge classification (from deriveMergeStatus). Use this
    * (not raw mergeStateStatus) when gating on "is this PR merge-blocked?":
    * it collapses BLOCKED+HAS_HOOKS into "BLOCKED" and accounts for
-   * copilotReviewInProgress and isDraft overrides.
+   * blockingBotReviewInProgress and isDraft overrides.
+   *
+   * TODO(C2): Consider removing this field in favour of always using `mergeStateStatus`
+   * (the raw GitHub value). `mergeStateStatus` is more useful for agents since it
+   * distinguishes BLOCKED from HAS_HOOKS. Blocked by the large surface area of tests
+   * and formatters that currently branch on `mergeStatus`.
    */
   mergeStatus: ShepherdMergeStatus;
   reviewDecision: ReviewDecision;
-  copilotReviewInProgress: boolean;
+  blockingBotReviewInProgress: boolean;
   isDraft: boolean;
   shouldCancel: boolean;
   remainingSeconds: number;
@@ -101,7 +113,6 @@ export interface ResolveCommand {
  * then runs the pre-built resolve command. Emitted under `## Post-fix push`.
  */
 interface FixRebaseAndPush {
-  mode: "rebase-and-push";
   threads: AgentThread[];
   /** Unresolved threads that should be resolved on GitHub without requiring code edits. */
   resolutionOnlyThreads: ReviewThread[];

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -92,7 +92,7 @@ export interface ResolveOptions {
   requireSha?: string;
 }
 
-/** Thread shape emitted to the monitor agent — stripped of always-false flags. */
+/** Thread shape emitted to the iterate agent — stripped of always-false flags. */
 export interface AgentThread {
   id: string;
   path: string | null;
@@ -104,7 +104,7 @@ export interface AgentThread {
   suggestion?: SuggestionBlock; // present when body contains a ```suggestion fence
 }
 
-/** Comment shape emitted to the monitor agent — stripped of always-false flags. */
+/** Comment shape emitted to the iterate agent — stripped of always-false flags. */
 export interface AgentComment {
   id: string;
   author: string;
@@ -113,10 +113,16 @@ export interface AgentComment {
 }
 
 /**
- * Check shape emitted to the monitor agent under `fix_code`.
+ * Check shape emitted to the iterate agent under `fix_code`.
  * For cancelled checks, agents should rely on `name`/`runId`/`detailsUrl`/`conclusion`
  * to decide whether to rerun without log inspection; optional metadata such as
  * `workflowName`, `jobName`, `failedStep`, and `summary` may still be present when available.
+ *
+ * TODO(C1): Collapse AgentCheck into RelevantCheck — the only difference is that
+ * AgentCheck allows a null conclusion while RelevantCheck excludes null. Once
+ * toAgentCheck in reporters/agent.mts is confirmed to never receive a null conclusion
+ * (i.e., all upstream TriagedCheck sources guard against it), remove AgentCheck and
+ * replace all usages with RelevantCheck.
  */
 export interface AgentCheck {
   name: string;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "declaration": false,
     "sourceMap": false
   },
-  "exclude": ["node_modules", "bin", "src/**/*.test.mts", "src/**/*.mock.test.mts"]
+  "exclude": ["node_modules", "bin", "src/**/*.test.mts", "src/**/*.mock.test.mts", "src/**/*.fixtures.mts"]
 }


### PR DESCRIPTION
## Summary

Follows up on #188 (removed `check`/`monitor`/`status` subcommands), sweeping away stale strings, dead code, and doc drift left behind.

### Section A — stale strings & dead code
- Replace all user-visible `"monitor"`/`"check"` strings in CLI output/instructions with `"iterate"`/`"pr-shepherd"`
- Fix JSDoc/internal comments that still say "monitor"
- Add `src/**/*.fixtures.mts` to `tsconfig.build.json` excludes so fixture files are not compiled into the production build
- Delete `src/commands/iterate.mts` re-export shim; update all consumers to import from `src/commands/iterate/index.mts` or `/render.mts` directly
- Remove dead `FixRebaseAndPush.mode` discriminant field and all guards that branched on it

### Section B — documentation drift
- `README.md`: rename "Monitor a PR" section to "Iterate a PR to completion", update skill invocation
- `CLAUDE.md`: remove stale check output surface reference, fix skill path
- `docs/actions.md`: remove archived `cooldown`/`rebase` sections, rename `copilotReviewInProgress` → `blockingBotReviewInProgress`, fix escalate example strings
- All other docs: sync `iterate`/`pr-shepherd` naming, fix module paths

### Section C — types and naming
- Add `EscalateTrigger` union type; replace `string[]` with `EscalateTrigger[]` across escalate code and callers
- Rename `copilotReviewInProgress` → `blockingBotReviewInProgress` in `MergeStatusResult`, formatters, lean projection, and `merge-status/derive.mts` (including `detectCopilotReview` → `detectBlockingBotReview`)
- Rename `attemptHistory` → `thrashHistory` to match `EscalateDetails` type name
- Add `TODO(C1)` on `AgentCheck` (conclusion nullability differs from `RelevantCheck`; collapse deferred)
- Add `TODO(C2)` on `mergeStatus` field (wide usage; rename deferred)
- Fix comments that no longer match code

## Test plan
- [x] `npm run build` passes (TypeScript compiles clean)
- [x] `npm test` passes (773/773)
- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (via pre-push hook)

## Shepherd Journal

- [IC_kwDOSGizTs8AAAABCFoPVQ](https://github.com/jonathanong/pr-shepherd/pull/189#issuecomment-4435087189): Qodo bot comment — "Qodo reviews are paused for this user." Infrastructure/billing message, not a code review. No action needed; minimizing.
- `PRR_kwDOSGizTs7-5f0v` (@gemini-code-assist): "I have no feedback to provide." Informational review summary only; minimizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)