### PR TITLE
[codex] fix terminal PR check status

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -127,8 +127,8 @@ Stops the iterate loop — no further iterations needed.
 ```markdown
 # PR #42 [CANCEL] — merged
 
-**status** `READY` · **merge** `CLEAN` · **state** `MERGED` · **repo** `owner/repo`
-**summary** 5 passing
+**status** `MERGED` · **merge** `UNKNOWN` · **state** `MERGED` · **repo** `owner/repo`
+**summary** 0 passing
 
 CANCEL: PR #42 is merged — stopping
 
@@ -139,7 +139,7 @@ CANCEL: PR #42 is merged — stopping
 
 Other heading variants: `# PR #42 [CANCEL] — closed`, `# PR #42 [CANCEL] — ready-delay-elapsed`.
 
-Other body-line variants: `CANCEL: PR #42 is closed — stopping`, `CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping`.
+Merged and closed PRs surface terminal top-level statuses (`MERGED` or `CLOSED`) because `runCheck` short-circuits before CI/comment processing. Other body-line variants: `CANCEL: PR #42 is closed — stopping`, `CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping`.
 
 **What the skill does:** Follow `## Instructions` — stop.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -18,9 +18,9 @@
 pr-shepherd <PR> --format=json
 ```
 
-Should return `{"action":"cancel","state":"MERGED",...}`.
+Should return `{"action":"cancel","status":"MERGED","state":"MERGED",...}`.
 
-If it still returns `wait`, check that `report.mergeStatus.state` is being set correctly in the JSON output.
+If it still returns `wait`, check that `report.mergeStatus.state` is being set correctly in the JSON output. If it returns `cancel` but the status is not `MERGED` or `CLOSED`, check that `runCheck` is short-circuiting terminal PRs before CI/comment processing.
 
 ---
 

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -8,7 +8,7 @@
 
 ### 1. Sweep
 
-**What:** `runCheck({ autoResolve: true })` fires one GraphQL batch query (CI checks + review threads + PR comments + merge state). Also auto-resolves any threads GitHub has marked `isOutdated`.
+**What:** `runCheck({ autoResolve: true })` fires one GraphQL batch query (CI checks + review threads + PR comments + merge state). If the PR is already merged or closed, it returns a terminal report immediately; otherwise it auto-resolves any threads GitHub has marked `isOutdated`.
 
 **Why:** Auto-resolving outdated threads here means the main agent doesn't have to manually call `resolve` after every push.
 
@@ -18,7 +18,7 @@
 
 **Check:** `report.mergeStatus.state !== 'OPEN'`
 
-**Why:** GitHub returns `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` for merged/closed PRs. Without this branch the loop falls through to `action: wait` and polls forever.
+**Why:** GitHub returns `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` for merged/closed PRs. `runCheck` surfaces this as top-level `status: 'MERGED'` or `status: 'CLOSED'`, and this branch stops the loop before ready-delay or actionable checks.
 
 **Emits:** `action: 'cancel'` — skips ready-delay, skips all actionable checks.
 

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -6,18 +6,18 @@
 
 Located in `src/merge-status/derive.mts`. Given a `BatchPrData`, returns a `MergeStatusResult`.
 
-| Priority | Condition                                         | Status         | Notes                                                                      |
-| -------- | ------------------------------------------------- | -------------- | -------------------------------------------------------------------------- |
-| 0        | `state !== 'OPEN'`                                | (pass through) | `iterate` cancels loop at step 2.5; status field is still derived normally |
-| 1        | `mergeable === 'CONFLICTING'`                     | `CONFLICTS`    | GraphQL merge conflict signal                                              |
-| 2        | `blockingBotReviewInProgress`                     | `BLOCKED`      | Takes priority over BEHIND to avoid hiding a real blocker                  |
-| 3        | `mergeStateStatus === 'DIRTY'`                    | `CONFLICTS`    | REST-layer merge conflict signal                                           |
-| 4        | `mergeStateStatus === 'BEHIND'`                   | `BEHIND`       | Branch needs rebase                                                        |
-| 5        | `mergeStateStatus === 'BLOCKED'` or `'HAS_HOOKS'` | `BLOCKED`      | Protected branch rules blocking merge                                      |
-| 6        | `mergeStateStatus === 'UNSTABLE'`                 | `UNSTABLE`     | Some checks not passing                                                    |
-| 7        | `isDraft` or `mergeStateStatus === 'DRAFT'`       | `DRAFT`        | Draft PR state                                                             |
-| 8        | `mergeStateStatus === 'UNKNOWN'`                  | `UNKNOWN`      | GitHub hasn't computed merge state yet                                     |
-| 9        | (fallthrough)                                     | `CLEAN`        | Ready to merge                                                             |
+| Priority | Condition                                         | Status         | Notes                                                                          |
+| -------- | ------------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
+| 0        | `state !== 'OPEN'`                                | (pass through) | `runCheck` returns top-level `MERGED`/`CLOSED`; derived merge status stays raw |
+| 1        | `mergeable === 'CONFLICTING'`                     | `CONFLICTS`    | GraphQL merge conflict signal                                                  |
+| 2        | `blockingBotReviewInProgress`                     | `BLOCKED`      | Takes priority over BEHIND to avoid hiding a real blocker                      |
+| 3        | `mergeStateStatus === 'DIRTY'`                    | `CONFLICTS`    | REST-layer merge conflict signal                                               |
+| 4        | `mergeStateStatus === 'BEHIND'`                   | `BEHIND`       | Branch needs rebase                                                            |
+| 5        | `mergeStateStatus === 'BLOCKED'` or `'HAS_HOOKS'` | `BLOCKED`      | Protected branch rules blocking merge                                          |
+| 6        | `mergeStateStatus === 'UNSTABLE'`                 | `UNSTABLE`     | Some checks not passing                                                        |
+| 7        | `isDraft` or `mergeStateStatus === 'DRAFT'`       | `DRAFT`        | Draft PR state                                                                 |
+| 8        | `mergeStateStatus === 'UNKNOWN'`                  | `UNKNOWN`      | GitHub hasn't computed merge state yet                                         |
+| 9        | (fallthrough)                                     | `CLEAN`        | Ready to merge                                                                 |
 
 ## Gotchas
 
@@ -29,6 +29,10 @@ These are two different signals for the same underlying condition (merge conflic
 - `mergeStateStatus === 'DIRTY'` — REST API's signal. The `getMergeableState` REST fallback can return `DIRTY` when GraphQL returns `UNKNOWN`.
 
 Both map to `CONFLICTS` in shepherd's derived status.
+
+### Terminal PRs use state, not mergeability
+
+GitHub often reports `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` after a PR is merged or closed. Shepherd treats `state` as authoritative for those PRs: `runCheck` returns top-level `status: "MERGED"` or `status: "CLOSED"` and skips CI/comment processing, while `deriveMergeStatus` continues to pass through the raw `state` and derived mergeability fields.
 
 ### Blocking-bot detection takes priority over BEHIND
 

--- a/src/cli/args.test.mts
+++ b/src/cli/args.test.mts
@@ -225,6 +225,8 @@ describe("parseDurationToMinutes", () => {
 
 describe("statusToExitCode", () => {
   it.each<[string, number]>([
+    ["MERGED", 0],
+    ["CLOSED", 0],
     ["READY", 0],
     ["IN_PROGRESS", 2],
     ["UNRESOLVED_COMMENTS", 3],

--- a/src/cli/exit-codes.mts
+++ b/src/cli/exit-codes.mts
@@ -12,6 +12,8 @@ export function parseDurationToMinutes(s: string, defaultMinutes?: number): numb
 
 export function statusToExitCode(status: string): number {
   switch (status) {
+    case "MERGED":
+    case "CLOSED":
     case "READY":
       return 0;
     case "IN_PROGRESS":

--- a/src/commands/check-terminal-report.mts
+++ b/src/commands/check-terminal-report.mts
@@ -1,0 +1,43 @@
+import type { BatchPrData, MergeStatusResult, ShepherdReport } from "../types.mts";
+
+export function buildTerminalReport(
+  prNumber: number,
+  repo: { owner: string; name: string },
+  batchData: BatchPrData,
+  mergeStatus: MergeStatusResult,
+  status: "MERGED" | "CLOSED",
+): ShepherdReport {
+  return {
+    pr: prNumber,
+    nodeId: batchData.nodeId,
+    repo: `${repo.owner}/${repo.name}`,
+    status,
+    baseBranch: batchData.baseRefName,
+    mergeStatus,
+    checks: {
+      passing: [],
+      failing: [],
+      inProgress: [],
+      skipped: [],
+      filtered: [],
+      filteredNames: [],
+      blockedByFilteredCheck: false,
+    },
+    threads: {
+      actionable: [],
+      resolutionOnly: [],
+      autoResolved: [],
+      autoResolveErrors: [],
+      firstLook: [],
+    },
+    comments: {
+      actionable: [],
+      firstLook: [],
+    },
+    changesRequestedReviews: [],
+    reviewSummaries: [],
+    firstLookSummaries: [],
+    editedSummaries: [],
+    approvedReviews: [],
+  };
+}

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -144,6 +144,64 @@ describe("runCheck — UNKNOWN merge state", () => {
   });
 });
 
+describe("runCheck — terminal PR state", () => {
+  it("returns MERGED and skips CI/comment processing when PR is MERGED", async () => {
+    const failingCheck = makeCheck({ category: "failing", conclusion: "FAILURE" });
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        state: "MERGED",
+        mergeable: "UNKNOWN",
+        mergeStateStatus: "UNKNOWN",
+        checks: [failingCheck],
+        reviewThreads: [makeThread({ id: "t-outdated", isOutdated: true })],
+        comments: [makeComment({ id: "c-min", isMinimized: true })],
+      }),
+    });
+
+    const report = await runCheck({ ...BASE_OPTS, autoResolve: true });
+
+    expect(report.status).toBe("MERGED");
+    expect(report.mergeStatus.state).toBe("MERGED");
+    expect(report.mergeStatus.status).toBe("UNKNOWN");
+    expect(report.checks.failing).toEqual([]);
+    expect(report.threads.firstLook).toEqual([]);
+    expect(report.comments.firstLook).toEqual([]);
+    expect(mockGetMergeableState).not.toHaveBeenCalled();
+    expect(mockFetchStartupFailureChecks).not.toHaveBeenCalled();
+    expect(mockTriageFailingChecks).not.toHaveBeenCalled();
+    expect(mockAutoResolveOutdated).not.toHaveBeenCalled();
+    expect(mockLoadSeenMap).not.toHaveBeenCalled();
+    expect(mockMarkSeen).not.toHaveBeenCalled();
+  });
+
+  it("returns CLOSED and skips CI/comment processing when PR is CLOSED", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        state: "CLOSED",
+        mergeable: "UNKNOWN",
+        mergeStateStatus: "UNKNOWN",
+        checks: [makeCheck({ category: "in_progress", status: "IN_PROGRESS", conclusion: null })],
+        reviewThreads: [makeThread({ id: "t-active" })],
+        comments: [makeComment({ id: "c-active" })],
+      }),
+    });
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.status).toBe("CLOSED");
+    expect(report.mergeStatus.state).toBe("CLOSED");
+    expect(report.checks.inProgress).toEqual([]);
+    expect(report.threads.actionable).toEqual([]);
+    expect(report.comments.actionable).toEqual([]);
+    expect(mockGetMergeableState).not.toHaveBeenCalled();
+    expect(mockFetchStartupFailureChecks).not.toHaveBeenCalled();
+    expect(mockTriageFailingChecks).not.toHaveBeenCalled();
+    expect(mockAutoResolveOutdated).not.toHaveBeenCalled();
+    expect(mockLoadSeenMap).not.toHaveBeenCalled();
+    expect(mockMarkSeen).not.toHaveBeenCalled();
+  });
+});
+
 // skipTriage
 
 describe("runCheck — skipTriage", () => {

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -9,6 +9,7 @@ import { deriveMergeStatus } from "../merge-status/derive.mts";
 import { loadConfig } from "../config/load.mts";
 import { classifyVisibleComments } from "../comments/visible-comments.mts";
 import { computeStatus } from "./check-status.mts";
+import { buildTerminalReport } from "./check-terminal-report.mts";
 import { loadSeenMap, markSeen, classifyItem } from "../state/seen-comments.mts";
 import type {
   GlobalOptions,
@@ -18,14 +19,9 @@ import type {
   FirstLookComment,
 } from "../types.mts";
 
-export interface CheckCommandOptions extends GlobalOptions {
-  /** When true, auto-resolve outdated threads. */
-  autoResolve?: boolean;
-  /** When true, skip fetching job info and log tails for failing checks. */
-  skipTriage?: boolean;
-}
-
-export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdReport> {
+export async function runCheck(
+  opts: GlobalOptions & { autoResolve?: boolean; skipTriage?: boolean },
+): Promise<ShepherdReport> {
   const repo = await getRepoInfo();
   const prNumber = opts.prNumber ?? (await getCurrentPrNumber());
   if (prNumber === null) {
@@ -48,6 +44,11 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
       mergeable: restState.mergeable ?? batchData.mergeable,
       mergeStateStatus: restState.mergeStateStatus ?? batchData.mergeStateStatus,
     };
+  }
+
+  const mergeStatus = deriveMergeStatus(batchData);
+  if (mergeStatus.state === "MERGED" || mergeStatus.state === "CLOSED") {
+    return buildTerminalReport(prNumber, repo, batchData, mergeStatus, mergeStatus.state);
   }
 
   const startupFailureChecks = await fetchStartupFailureChecks(
@@ -146,8 +147,6 @@ export async function runCheck(opts: CheckCommandOptions): Promise<ShepherdRepor
   const resolutionOnlyThreads = unresolvedThreads.filter(
     (t) => !autoResolvedIds.has(t.id) && (t.isOutdated || t.isMinimized),
   );
-
-  const mergeStatus = deriveMergeStatus(batchData);
 
   const blockedByFilteredCheck =
     mergeStatus.status === "BLOCKED" &&

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -243,6 +243,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
   it("returns action: cancel and does not call updateReadyDelay when PR is MERGED", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
+        status: "MERGED",
         mergeStatus: {
           status: "UNKNOWN",
           state: "MERGED",
@@ -258,6 +259,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("cancel");
+    expect(result.status).toBe("MERGED");
     expect(result.state).toBe("MERGED");
     expect(mockUpdateReadyDelay).not.toHaveBeenCalled();
   });
@@ -265,6 +267,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
   it("returns action: cancel when PR is CLOSED", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
+        status: "CLOSED",
         mergeStatus: {
           status: "UNKNOWN",
           state: "CLOSED",
@@ -280,6 +283,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("cancel");
+    expect(result.status).toBe("CLOSED");
     expect(result.state).toBe("CLOSED");
     expect(mockUpdateReadyDelay).not.toHaveBeenCalled();
   });

--- a/src/commands/iterate.orchestrator.mock.test.mts
+++ b/src/commands/iterate.orchestrator.mock.test.mts
@@ -272,6 +272,7 @@ describe("runIterate — triage via runCheck", () => {
   it("returns action: cancel when PR is MERGED even with failing checks", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
+        status: "MERGED",
         mergeStatus: {
           status: "UNKNOWN",
           state: "MERGED",
@@ -306,6 +307,7 @@ describe("runIterate — triage via runCheck", () => {
     const result = await runIterate(makeOpts());
 
     expect(result.action).toBe("cancel");
+    expect(result.status).toBe("MERGED");
   });
 
   it("returns fix_code for CONFLICTS even with a failing check (CONFLICTS is always actionable)", async () => {

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -253,6 +253,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
   it("cancel.log mentions PR state and reason=merged when PR is merged", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
+        status: "MERGED",
         mergeStatus: {
           status: "CLEAN",
           state: "MERGED",
@@ -267,6 +268,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("cancel");
+    expect(result.status).toBe("MERGED");
     if (result.action === "cancel") {
       expect(result.reason).toBe("merged");
       expect(result.log).toMatch(/CANCEL/);
@@ -277,6 +279,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
   it("cancel.reason=closed and log mentions closed when PR is closed", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
+        status: "CLOSED",
         mergeStatus: {
           status: "UNKNOWN",
           state: "CLOSED",
@@ -291,6 +294,7 @@ describe("runIterate — prescriptive fields: log strings", () => {
 
     const result = await runIterate(makeOpts());
     expect(result.action).toBe("cancel");
+    expect(result.status).toBe("CLOSED");
     if (result.action === "cancel") {
       expect(result.reason).toBe("closed");
       expect(result.log).toMatch(/CANCEL/);

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -28,11 +28,9 @@ export interface FirstLookComment extends PrComment {
   edited?: boolean;
 }
 
-// ---------------------------------------------------------------------------
-// Shepherd check report (output of the check command)
-// ---------------------------------------------------------------------------
-
 export type ShepherdStatus =
+  | "MERGED"
+  | "CLOSED"
   | "READY"
   | "FAILING"
   | "PENDING"


### PR DESCRIPTION
## Summary
- Report merged and closed PRs as terminal top-level statuses from `runCheck` before CI/comment processing.
- Add a small terminal report helper so terminal PRs skip startup-check triage, auto-resolve, and seen-marker writes.
- Update iterate/status exit-code expectations and docs for merged/closed PR output.

## Root Cause
GitHub can keep returning `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` after a PR is merged. Shared report consumers could therefore still see an active readiness status such as `IN_PROGRESS` instead of the terminal PR state.

## Validation
- `npm run lint`
- `npx vitest run src/commands/check.mock.test.mts src/commands/iterate.mock.test.mts src/commands/iterate.render.mock.test.mts src/commands/iterate.orchestrator.mock.test.mts src/cli/args.test.mts`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`

## Note
- A direct local built-CLI check for filaments PR #3090 could not run from this checkout because `pr-shepherd` resolves PR numbers against the current repository (`jonathanong/pr-shepherd`).