### PR TITLE
[codex] clarify runtime retry instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example Workflow:
 
 `pr-shepherd` optimizes token management, rate limits, and agentic orchestration by moving **ALL** deterministic logic and prompts to code via a CLI tool, enshrining what would be a large skill or command prompt (of which the agent would inevitably make mistakes) into the code and returning a clear, actionable prompt.
 
-The CLI emits unified sleep/timeout instructions for all runtimes: pick a fresh sleep/timeout between 30 seconds and 4 minutes and rerun the configured pr-shepherd command. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`. Generated commands use `cli.runner` from `.pr-shepherdrc.yml`: `auto` (default), `npx`, `pnpm`, or `yarn`.
+The CLI emits runtime-specific retry instructions. Claude-compatible output schedules exactly one next session-only iteration after a fresh delay between 30 seconds and 4 minutes, then ends the turn. Codex-compatible output sleeps inline for that delay, then reruns the configured pr-shepherd command. Codex is detected with `AGENT=codex` or the current Codex CLI signal `CODEX_CI=1`. Generated commands use `cli.runner` from `.pr-shepherdrc.yml`: `auto` (default), `npx`, `pnpm`, or `yarn`.
 
 At a high level, the skill invokes `pr-shepherd <PR>` through the selected package runner, which provides actionable feedback directly to the agent:
 
@@ -61,7 +61,7 @@ _(schematic — actual steps depend on PR state)_
 4. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`.
 5. Run the `resolve:` command above, substituting `"$HEAD_SHA"`.
 6. Add or update a `## Shepherd Journal` section in the PR description for any large decisions made, appending under the existing heading if it already exists.
-7. CI needs time to run on the new push. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 123` to recheck.
+7. CI needs time to run on the new push. Schedule one session-only follow-up task to run `npx pr-shepherd 123` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
 On every iteration, a command is returned to instruct the agent exactly what to do. No guessing, no thinking, as few agentic turns as possible:
@@ -97,7 +97,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling the reusable command with a fresh sleep/timeout between 30 seconds and 4 minutes before each rerun until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling the reusable command until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). Claude schedules one next session-only iteration per tick; Codex sleeps inline and reruns.
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 - Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
@@ -114,7 +114,7 @@ Recommendations:
 
 ### Iterate a PR to completion
 
-One-tick dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section telling the agent to pick a fresh 30s–4m delay and rerun; the loop continues until `[CANCEL]` or `[ESCALATE]`.
+One-tick dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section telling the agent how to run the next tick; the loop continues until `[CANCEL]` or `[ESCALATE]`.
 
 Claude Code (via `pr-shepherd` skill):
 
@@ -134,7 +134,7 @@ npx pr-shepherd iterate 42               # legacy-compatible spelling
 
 ## Iterate decision loop
 
-On each tick: fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (`fix_code`, `mark_ready`, `cancel`, `escalate`, or `wait`). All runtimes pick a fresh sleep/timeout between 30 seconds and 4 minutes for each nonterminal recurrence. See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
+On each tick: fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (`fix_code`, `mark_ready`, `cancel`, `escalate`, or `wait`). Claude schedules one next session-only iteration after a fresh 30s-4m delay; Codex sleeps inline for that delay and reruns. See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
 
 ## Install
 
@@ -216,7 +216,7 @@ Then iterate a PR from Codex with the target repository's package runner:
 
 For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd iterate 42`. For npm repos, use `npx pr-shepherd iterate 42`.
 
-Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. The skill runs one tick and the instructions tell you to pick a fresh sleep/timeout between 30 seconds and 4 minutes before the next rerun. Continue until Shepherd emits `[CANCEL]` or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `pr-shepherd iterate 42` remains supported for existing workflows.
+Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. The skill runs one tick and Codex-compatible instructions tell you to pick a fresh sleep/timeout between 30 seconds and 4 minutes before the next rerun. Continue until Shepherd emits `[CANCEL]` or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `pr-shepherd iterate 42` remains supported for existing workflows.
 
 ### As a global CLI
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -77,7 +77,7 @@ When the current command includes a ready-delay override, the rerun command pres
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
-**What the skill does:** Follow `## Instructions` — schedule exactly one next session-only iteration and end the turn.
+**What the skill does:** Follow `## Instructions`. For the Claude-compatible output shown above, schedule exactly one next session-only iteration and end the turn; Codex-compatible output sleeps inline and reruns the same command.
 
 ---
 
@@ -106,7 +106,7 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
-**What the skill does:** Follow `## Instructions` — schedule exactly one next session-only iteration and end the turn.
+**What the skill does:** Follow `## Instructions`. For the Claude-compatible output shown above, schedule exactly one next session-only iteration and end the turn; Codex-compatible output sleeps inline and reruns the same command.
 
 ---
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -6,7 +6,7 @@ Each default `pr-shepherd` invocation returns exactly one iterate action. The le
 
 The default output format is Markdown — what you see when running `pr-shepherd <PR>` through the selected package runner, and what the iterate skill reads on each tick. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
-Instruction wording uses unified sleep guidance for all runtimes: pick a fresh sleep/timeout between 30 seconds and 4 minutes and rerun the configured pr-shepherd command. The action data and section structure are otherwise the same.
+Instruction wording is runtime-specific. Claude-compatible output schedules exactly one next session-only iteration after a fresh delay between 30 seconds and 4 minutes, then ends the turn. Codex-compatible output sleeps inline for that delay, then reruns the configured pr-shepherd command. The action data and section structure are otherwise the same.
 
 Command examples use the default npm spelling (`npx pr-shepherd`). Repos can set `cli.runner` to `auto`, `npx`, `pnpm`, or `yarn`; generated text and JSON argv then use the selected runner (for example `pnpm exec pr-shepherd` or `yarn run pr-shepherd`) everywhere a pr-shepherd follow-up command is emitted.
 
@@ -70,14 +70,14 @@ WAIT: 3 passing, 2 in-progress — 120s until auto-cancel
 
 ## Instructions
 
-1. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to continue the active goal.
+1. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to continue the active goal once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
 When the current command includes a ready-delay override, the rerun command preserves it: `npx pr-shepherd 42 --ready-delay 15m`.
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
-**What the skill does:** Follow `## Instructions` — pick a fresh sleep/timeout and rerun.
+**What the skill does:** Follow `## Instructions` — schedule exactly one next session-only iteration and end the turn.
 
 ---
 
@@ -103,10 +103,10 @@ MARKED READY: PR #42 converted from draft to ready for review
 
 ## Instructions
 
-1. The CLI already marked the PR ready for review. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to recheck.
+1. The CLI already marked the PR ready for review. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
-**What the skill does:** Follow `## Instructions` — pick a fresh sleep/timeout and rerun.
+**What the skill does:** Follow `## Instructions` — schedule exactly one next session-only iteration and end the turn.
 
 ---
 
@@ -218,7 +218,7 @@ Actionable work needs a code fix, commit, and push.
 10. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
 11. Do not re-run `gh run cancel` on the IDs listed under `## Cancelled runs` — the CLI cancelled those runs before your push, and your push has already triggered new runs with different IDs.
 12. For any large decisions or rejections you made this iteration, add or update a `## Shepherd Journal` section in the PR description (`gh pr edit 42 --body …`) summarizing each decision and linking back to the originating comment, thread, or review. If this section already exists, append entries under it instead of creating a duplicate heading.
-13. CI needs time to run on the new push. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to recheck.
+13. CI needs time to run on the new push. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
 When one or more threads carry a `[suggestion]` marker, the `## Instructions` section opens with two different steps. Step 1 is new; step 2 gains a manual-fallback clause. All other steps renumber and are otherwise unchanged.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 
 - **No MCP surface** — skills call the CLI via `npx`; no long-lived MCP server, no extra auth boundary, smaller reasoning surface.
 - **Skills over subagents** — skill prompts inject into the main conversation rather than spawning a subagent that reloads CLAUDE.md every turn, keeping cost and latency low.
-- **Safe to interrupt** — durable state lives in the PR on GitHub; the cron loop self-terminates when the PR is merged, closed, or settles after ready-delay. Local state in `$PR_SHEPHERD_STATE_DIR` can be deleted without data loss.
+- **Safe to interrupt** — durable state lives in the PR on GitHub; the iterate loop self-terminates when the PR is merged, closed, or settles after ready-delay. Local state in `$PR_SHEPHERD_STATE_DIR` can be deleted without data loss.
 
 ## Module tree
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -199,10 +199,10 @@ WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
 
 ## Instructions
 
-1. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to continue the active goal.
+1. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to continue the active goal once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
-The instruction tells the agent to pick a fresh sleep/timeout between 30 seconds and 4 minutes and rerun the configured command. If `cli.runner` selects pnpm or Yarn, that command is rendered as `pnpm exec pr-shepherd 42` or `yarn run pr-shepherd 42`; if the current command used `--ready-delay`, the rerun command includes the same flag.
+Claude-compatible instructions tell the agent to schedule one next session-only iteration and end the turn. Codex-compatible instructions tell the agent to pick a fresh sleep/timeout between 30 seconds and 4 minutes and rerun the configured command inline. If `cli.runner` selects pnpm or Yarn, that command is rendered as `pnpm exec pr-shepherd 42` or `yarn run pr-shepherd 42`; if the current command used `--ready-delay`, the rerun command includes the same flag.
 
 Example for `[FIX_CODE]` (richest action):
 
@@ -248,7 +248,7 @@ at Object.<anonymous> (src/commands/iterate.test.mts:58:22)
 5. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`
 6. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
 7. For any large decisions made, add or update a `## Shepherd Journal` section in the PR description (`gh pr edit 42 --body …`), appending entries under the existing heading if present.
-8. CI needs time to run on the new push. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42 --ready-delay 15m` to recheck.
+8. CI needs time to run on the new push. Schedule one session-only follow-up task to run `npx pr-shepherd 42 --ready-delay 15m` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
 See [actions.md](actions.md) for all five actions and their complete output shapes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ actions:
 
 ## Agent detection
 
-`pr-shepherd` uses the calling-agent environment only to choose instruction wording. `AGENT=codex` and `CODEX_CI=1` select Codex-compatible monitor output. Other environments keep the default Claude-compatible `/loop` instructions.
+`pr-shepherd` uses the calling-agent environment only to choose instruction wording. `AGENT=codex` and `CODEX_CI=1` select Codex-compatible monitor output that sleeps inline before rerunning. Other environments keep the default Claude-compatible instructions that schedule exactly one next session-only iteration and end the turn.
 
 ---
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -62,7 +62,7 @@ rm $TMPDIR/pr-shepherd-state/acme-myrepo/42/ready-since.txt
 
 **Symptom:** Shepherd errors with `API rate limit exceeded` or `secondary rate limit`.
 
-**Cause:** Too many API calls. Common when the cache is bypassed frequently or the cron interval is very short.
+**Cause:** Too many API calls. Common when the cache is bypassed frequently or non-terminal ticks are scheduled too aggressively.
 
 **Fix options:**
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -26,7 +26,7 @@ flowchart TD
 
   DEC -->|cancel/escalate| STOP["stop"]
   DEC -->|fix_code| FIX[gh run view --log-failed →<br/>rerun or edit+commit →<br/>fetch + rebase + push →<br/>pr-shepherd resolve --require-sha HEAD]
-  FIX --> SLEEP[sleep 30s-4m]
+  FIX --> SLEEP[Claude schedules next tick<br/>Codex sleeps 30s-4m]
   DEC -->|other| SLEEP
   SLEEP --> ITER
 ```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,7 +21,7 @@ Use the skill inside a `/goal`:
 /goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
 ```
 
-The goal loop handles recurrence. Each tick the skill runs one iterate cycle and prints the output. The CLI's `## Instructions` tell the active goal to pick a fresh 30s–4m delay then rerun for non-terminal actions, or to stop on `[CANCEL]`/`[ESCALATE]`.
+The goal loop handles recurrence. Each tick the skill runs one iterate cycle and prints the output. For non-terminal actions, the CLI's `## Instructions` tell Claude to schedule exactly one next session-only iteration after a fresh 30s-4m delay and end the turn. Claude should not sleep inline or create a recurring cron. `[CANCEL]` and `[ESCALATE]` stop the goal.
 
 ## Codex
 
@@ -61,7 +61,7 @@ Use the skill inside a `/goal`:
 /goal $pr-shepherd 42
 ```
 
-Codex runs the same skill — one tick per goal iteration. The CLI detects Codex via `CODEX_CI=1` or `AGENT=codex` and adapts its `## Instructions` wording accordingly. If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking the CLI:
+Codex runs the same skill — one tick per goal iteration. The CLI detects Codex via `CODEX_CI=1` or `AGENT=codex` and adapts its `## Instructions` wording so Codex sleeps inline for a fresh 30s-4m delay before rerunning. If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking the CLI:
 
 ```sh
 export AGENT=codex

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. There is no fixed-interval cron or `/loop` scheduler — each non-terminal tick tells the running goal to pick a fresh 30s–4m delay and rerun the iterate command.
+pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. There is no recurring cron or fixed-interval `/loop` scheduler. Claude schedules exactly one next session-only iteration per non-terminal tick; Codex sleeps inline for a fresh 30s-4m delay and reruns the iterate command.
 
 Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with `/goal /pr-shepherd:pr-shepherd`; Codex users invoke it with `/goal $pr-shepherd`.
 
@@ -27,7 +27,7 @@ Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with
    The output begins with `# PR #N [ACTION]` and ends with a numbered `## Instructions` block. The skill follows those instructions exactly.
 
 3. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`)
-   The `## Instructions` tell the active goal: "Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `<runner> pr-shepherd <PR>` to continue the active goal."
+   The `## Instructions` tell the active goal how to continue. Claude schedules one next session-only follow-up task and ends the turn. Codex sleeps inline for a fresh 30s-4m delay, then reruns `<runner> pr-shepherd <PR>`.
 
 4. **Terminal actions**
    - `[CANCEL]` — PR is merged/closed, or the ready-delay has elapsed. Goal stops.
@@ -48,8 +48,9 @@ User                    Active Goal             shepherd iterate
  |                          |<-- [ACTION] + ## Instructions
  |                          |                        |
  |  [if non-terminal]       |                        |
- |                          |-- sleep 30s–4m         |
- |                          |-- pr-shepherd <PR> --> |  (next tick)
+ |                          |-- schedule next tick   |  (Claude)
+ |                          |-- sleep + rerun inline |  (Codex)
+ |                          |-- pr-shepherd <PR> --> |
  |                          |                        |
  |  [if cancel/escalate]    |                        |
  |                          |   goal ends            |
@@ -59,12 +60,13 @@ User                    Active Goal             shepherd iterate
  |                          |-- commit               |
  |                          |-- push                 |
  |                          |-- resolve threads      |
- |                          |-- sleep 30s–4m         |
- |                          |-- pr-shepherd <PR> --> |  (recheck)
+ |                          |-- schedule recheck     |  (Claude)
+ |                          |-- sleep + rerun inline |  (Codex)
+ |                          |-- pr-shepherd <PR> --> |
 ```
 
 ## Notes
 
-- The iterate loop does not have a fixed cadence. The agent picks a fresh delay (30s–4m) before each rerun, adapting to CI latency automatically.
+- The iterate loop does not have a fixed cadence. Each non-terminal tick uses a fresh delay (30s-4m), adapting to CI latency automatically.
 - Code changes (`fix_code`, rebase) are handled inline by the active goal — no subagent is spawned.
 - The ready-delay (default 10 minutes) is read from `watch.readyDelayMinutes` in `.pr-shepherdrc.yml`. See [ready-delay.md](ready-delay.md) and [configuration.md](configuration.md).

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -45,4 +45,4 @@ One-tick dispatcher for iterating a PR to completion.
 5. **Stop conditions:**
    - Stop when the CLI emits `[CANCEL]` (ready-delay completed, or PR merged/closed).
    - Stop when the CLI emits `[ESCALATE]`, including `stall-timeout` for repeated unchanged CI failures.
-   - All other actions (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) are non-terminal: follow the `## Instructions` to sleep/wait and rerun.
+   - All other actions (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) are non-terminal: follow the `## Instructions`. For Claude, schedule exactly one next session-only iteration and end the turn; do not sleep inline and do not create a recurring cron.

--- a/src/cli-parser.iterate-codex.mock.test.mts
+++ b/src/cli-parser.iterate-codex.mock.test.mts
@@ -49,6 +49,30 @@ afterEach(() => {
 });
 
 describe("main — iterate fix_code instruction rewriting", () => {
+  it("rewrites wait instruction to Codex sleep wording", async () => {
+    process.env.AGENT = "codex";
+    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+
+    await main(["node", "shepherd", "iterate", "42", "--ready-delay", "15m"]);
+    const out = getStdout();
+    expect(out).toContain(
+      "1. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42 --ready-delay 15m` to continue the active goal.",
+    );
+    expect(out).not.toContain("Schedule one session-only");
+  });
+
+  it("rewrites mark_ready instruction to Codex sleep wording", async () => {
+    process.env.AGENT = "codex";
+    mockRunIterate.mockResolvedValue(makeIterateResult("mark_ready"));
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+    expect(out).toContain(
+      "1. The CLI already marked the PR ready for review. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to recheck.",
+    );
+    expect(out).not.toContain("Schedule one session-only");
+  });
+
   it("text rewrites stop-after-push instruction to Codex sleep wording", async () => {
     process.env.AGENT = "codex";
     const result = makeIterateResult("fix_code");

--- a/src/cli-parser.iterate-codex.mock.test.mts
+++ b/src/cli-parser.iterate-codex.mock.test.mts
@@ -49,7 +49,8 @@ afterEach(() => {
 });
 
 describe("main — iterate fix_code instruction rewriting", () => {
-  it("text rewrites stop-after-push instruction to unified sleep wording", async () => {
+  it("text rewrites stop-after-push instruction to Codex sleep wording", async () => {
+    process.env.AGENT = "codex";
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
     result.fix.instructions = [
@@ -67,6 +68,7 @@ describe("main — iterate fix_code instruction rewriting", () => {
   });
 
   it("json rewrites stop-after-push instruction", async () => {
+    process.env.AGENT = "codex";
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
     result.fix.instructions = [
@@ -81,7 +83,8 @@ describe("main — iterate fix_code instruction rewriting", () => {
     ]);
   });
 
-  it("rewrites no-push final instruction to unified sleep wording", async () => {
+  it("rewrites no-push final instruction to Codex sleep wording", async () => {
+    process.env.AGENT = "codex";
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
     result.fix.instructions = ["Stop this iteration before the next tick."];
@@ -94,7 +97,8 @@ describe("main — iterate fix_code instruction rewriting", () => {
     ]);
   });
 
-  it("rewrites mutation-without-push final instruction to unified sleep wording", async () => {
+  it("rewrites mutation-without-push final instruction to Codex sleep wording", async () => {
+    process.env.AGENT = "codex";
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");
     result.fix.instructions = ["Stop this iteration before the next tick."];

--- a/src/cli-parser.iterate-fix.mock.test.mts
+++ b/src/cli-parser.iterate-fix.mock.test.mts
@@ -75,7 +75,7 @@ describe("main — iterate text format (fix_code and checks)", () => {
     // every iterate output ends with ## Instructions.
     expect(out).toContain("## Instructions");
     expect(out).toContain(
-      "1. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to recheck.",
+      "1. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.",
     );
   });
 

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -144,7 +144,8 @@ describe("main — iterate text format", () => {
     expect(out).toMatch(/^# PR #42 \[WAIT\]\n/);
     expect(out).toContain("WAIT: 0 passing, 1 in-progress");
     expect(out).toContain("## Instructions");
-    expect(out).toContain("1. Pick a fresh sleep/timeout between 30 seconds and 4 minutes");
+    expect(out).toContain("1. Schedule one session-only follow-up task");
+    expect(out).toContain("Do not sleep or rerun inline.");
   });
 
   it("mark_ready: heading includes [MARK_READY] tag and ## Instructions with end-iteration step", async () => {
@@ -155,7 +156,7 @@ describe("main — iterate text format", () => {
     expect(out).toContain("MARKED READY: PR 42");
     expect(out).toContain("## Instructions");
     expect(out).toContain(
-      "1. The CLI already marked the PR ready for review. Pick a fresh sleep/timeout between 30 seconds and 4 minutes",
+      "1. The CLI already marked the PR ready for review. Schedule one session-only follow-up task",
     );
   });
 
@@ -180,7 +181,7 @@ describe("main — iterate text format", () => {
     expect(out).toContain("1. Stop — the PR needs human direction before iterating can resume.");
   });
 
-  it("wait: instructions use unified sleep wording with rerun command", async () => {
+  it("wait: instructions use Claude one-shot scheduling wording with rerun command", async () => {
     const result = makeIterateResult("wait");
     if (result.action !== "wait") throw new Error("unreachable");
     result.log =
@@ -192,17 +193,17 @@ describe("main — iterate text format", () => {
       "WAIT: 6 passing, 1 in-progress — awaiting human review or branch protection",
     );
     expect(out).toContain(
-      "1. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42 --ready-delay 15m` to continue the active goal.",
+      "1. Schedule one session-only follow-up task to run `npx pr-shepherd 42 --ready-delay 15m` to continue the active goal once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.",
     );
     expect(out).not.toContain("auto-cancel");
   });
 
-  it("mark_ready: instructions use unified sleep wording with rerun command", async () => {
+  it("mark_ready: instructions use Claude one-shot scheduling wording with rerun command", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("mark_ready"));
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
     expect(out).toContain(
-      "1. The CLI already marked the PR ready for review. Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to recheck.",
+      "1. The CLI already marked the PR ready for review. Schedule one session-only follow-up task to run `npx pr-shepherd 42` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.",
     );
   });
 
@@ -238,7 +239,7 @@ describe("main — iterate text format", () => {
     expect(parsed.action).toBe("wait");
     expect(parsed.pr).toBe(42);
     expect(parsed.instructions).toEqual([
-      "Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun `npx pr-shepherd 42` to continue the active goal.",
+      "Schedule one session-only follow-up task to run `npx pr-shepherd 42` to continue the active goal once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.",
     ]);
   });
 

--- a/src/cli/iterate-instructions.mts
+++ b/src/cli/iterate-instructions.mts
@@ -6,23 +6,30 @@ import {
 import type { IterateResult } from "../types.mts";
 import { buildPrShepherdCommand, type CliRunner } from "./runner.mts";
 
-function buildRecheckInstruction(rerunCommand: string, tail: string): string {
-  return `Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun \`${rerunCommand}\` ${tail}`;
+function buildRecheckInstruction(
+  runtime: AgentRuntime,
+  rerunCommand: string,
+  purpose: string,
+): string {
+  if (runtime === "codex") {
+    return `Pick a fresh sleep/timeout between 30 seconds and 4 minutes, wait that long, then rerun \`${rerunCommand}\` to ${purpose}.`;
+  }
+  return `Schedule one session-only follow-up task to run \`${rerunCommand}\` to ${purpose} once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.`;
 }
 
 export function buildSimpleIterateInstructions(
   result: Exclude<IterateResult, { action: "fix_code" }>,
-  _runtime: AgentRuntime,
+  runtime: AgentRuntime,
   readyDelaySuffix?: string,
   runner?: CliRunner,
 ): string[] {
-  const rerunCommand = buildCodexIterateCommand(result.pr, readyDelaySuffix, runner);
+  const rerunCommand = buildIterateCommand(result.pr, readyDelaySuffix, runner);
   switch (result.action) {
     case "wait":
-      return [buildRecheckInstruction(rerunCommand, "to continue the active goal.")];
+      return [buildRecheckInstruction(runtime, rerunCommand, "continue the active goal")];
     case "mark_ready":
       return [
-        `The CLI already marked the PR ready for review. ${buildRecheckInstruction(rerunCommand, "to recheck.")}`,
+        `The CLI already marked the PR ready for review. ${buildRecheckInstruction(runtime, rerunCommand, "recheck")}`,
       ];
     case "cancel":
       return ["Stop — the active goal is complete."];
@@ -34,17 +41,17 @@ export function buildSimpleIterateInstructions(
 export function adaptFixCodeInstructions(
   instructions: string[],
   pr: number,
-  _runtime: AgentRuntime,
+  runtime: AgentRuntime,
   readyDelaySuffix?: string,
   runner?: CliRunner,
 ): string[] {
-  const rerunCommand = buildCodexIterateCommand(pr, readyDelaySuffix, runner);
+  const rerunCommand = buildIterateCommand(pr, readyDelaySuffix, runner);
   return instructions.map((instruction) => {
     if (instruction === FIX_INSTRUCTION_STOP_AFTER_PUSH) {
-      return `CI needs time to run on the new push. ${buildRecheckInstruction(rerunCommand, "to recheck.")}`;
+      return `CI needs time to run on the new push. ${buildRecheckInstruction(runtime, rerunCommand, "recheck")}`;
     }
     if (instruction === FIX_INSTRUCTION_STOP_BEFORE_NEXT_TICK) {
-      return buildRecheckInstruction(rerunCommand, "to recheck.");
+      return buildRecheckInstruction(runtime, rerunCommand, "recheck");
     }
     return instruction;
   });
@@ -54,7 +61,7 @@ export function adaptIterateLog(log: string, _runtime: AgentRuntime): string {
   return log.replace(/\s+—\s+\d+s until auto-cancel/g, "");
 }
 
-export function buildCodexIterateCommand(
+export function buildIterateCommand(
   pr: number,
   readyDelaySuffix?: string,
   runner?: CliRunner,


### PR DESCRIPTION
## Summary
- Split iterate retry instructions by runtime: Claude schedules one next session-only iteration and ends the turn, while Codex keeps inline sleep-and-rerun guidance.
- Update the pr-shepherd skill and docs to make one-shot scheduling explicit and avoid recurring cron language.
- Refresh text and JSON formatter tests for default Claude output and Codex-specific output.

## Validation
- npx vitest run src/cli-parser.iterate.mock.test.mts src/cli-parser.iterate-fix.mock.test.mts src/cli-parser.iterate-codex.mock.test.mts src/cli/iterate-lean.test.mts src/agent-runtime.test.mts
- npm run typecheck
- npm run format:check
- npm test
- npm run lint
