### PR TITLE
[codex] guard ready delay with fresh mergeability

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -114,9 +114,9 @@ MARKED READY: PR #42 converted from draft to ready for review
 
 Stops the iterate loop — no further iterations needed.
 
-**Trigger:** Either the PR is merged or closed (`state !== "OPEN"`), or the ready-delay timer elapsed (`readyState.shouldCancel`).
+**Trigger:** Either the PR is merged or closed (`state !== "OPEN"`), or the ready-delay timer elapsed after the current sweep still verifies the PR as a READY handoff state. Candidate READY reports get a fresh mergeability read before the timer can complete, so newly detected conflicts route to `fix_code` instead of `cancel`.
 
-**CLI side-effects:** None. The `ready-since.txt` file is left in place.
+**CLI side-effects:** None. The `ready-since.txt` file is deleted when ready-delay elapses.
 
 **Exit code:** 2
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -116,7 +116,7 @@ Stops the iterate loop — no further iterations needed.
 
 **Trigger:** Either the PR is merged or closed (`state !== "OPEN"`), or the ready-delay timer elapsed after the current sweep still verifies the PR as a READY handoff state. Candidate READY reports get a fresh mergeability read before the timer can complete, so newly detected conflicts route to `fix_code` instead of `cancel`.
 
-**CLI side-effects:** None. The `ready-since.txt` file is deleted when ready-delay elapses.
+**CLI side-effects:** Deletes any stale `ready-since.txt` marker when the PR is merged/closed or when ready-delay elapses.
 
 **Exit code:** 2
 

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -32,6 +32,8 @@
 - On subsequent READY sweeps: checks if `now − readySince >= readyDelaySeconds`. If so, `shouldCancel: true`.
 - On non-READY sweep: deletes the file (resets the countdown).
 
+Before a READY sweep reaches the ready-delay state machine, `runCheck` performs one fresh REST mergeability read unless the UNKNOWN fallback already did so. If the refreshed mergeability reports `CONFLICTING`/`DIRTY`, the sweep becomes `FAILING`/`CONFLICTS`, resets the ready-delay marker, and routes to `fix_code`.
+
 See [ready-delay.md](ready-delay.md) for full lifecycle.
 
 ---

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -18,9 +18,9 @@
 
 **Check:** `report.mergeStatus.state !== 'OPEN'`
 
-**Why:** GitHub returns `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` for merged/closed PRs. `runCheck` surfaces this as top-level `status: 'MERGED'` or `status: 'CLOSED'`, and this branch stops the loop before ready-delay or actionable checks.
+**Why:** GitHub returns `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` for merged/closed PRs. `runCheck` surfaces this as top-level `status: 'MERGED'` or `status: 'CLOSED'`, and this branch stops the loop before actionable checks.
 
-**Emits:** `action: 'cancel'` — skips ready-delay, skips all actionable checks.
+**Emits:** `action: 'cancel'` — clears any stale ready-delay marker, skips all actionable checks.
 
 ---
 

--- a/docs/merge-status.md
+++ b/docs/merge-status.md
@@ -30,6 +30,8 @@ These are two different signals for the same underlying condition (merge conflic
 
 Both map to `CONFLICTS` in shepherd's derived status.
 
+`runCheck` also refreshes mergeability for candidate READY handoffs. This catches short-lived GraphQL lag where the batch query still reports `CLEAN` but the REST pull-request endpoint already reports `DIRTY`; in that case the refreshed value maps to `CONFLICTS` before iterate can complete ready-delay.
+
 ### Terminal PRs use state, not mergeability
 
 GitHub often reports `mergeable: UNKNOWN` and `mergeStateStatus: UNKNOWN` after a PR is merged or closed. Shepherd treats `state` as authoritative for those PRs: `runCheck` returns top-level `status: "MERGED"` or `status: "CLOSED"` and skips CI/comment processing, while `deriveMergeStatus` continues to pass through the raw `state` and derived mergeability fields.

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -27,13 +27,13 @@ updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)
 
 ## Lifecycle
 
-| Event                                       | Effect on `ready-since.txt`                          |
-| ------------------------------------------- | ---------------------------------------------------- |
-| First READY sweep                           | Created with current timestamp                       |
-| Subsequent READY sweeps (delay not elapsed) | Read; `remainingSeconds` decremented                 |
-| READY sweep, delay elapsed                  | Read; `shouldCancel: true` returned; file deleted    |
-| Non-READY sweep                             | Deleted (countdown resets)                           |
-| PR merged/closed (step 2.5)                 | Not reached — `updateReadyDelay` is skipped entirely |
+| Event                                       | Effect on `ready-since.txt`                                                                             |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| First READY sweep                           | Created with current timestamp                                                                          |
+| Subsequent READY sweeps (delay not elapsed) | Read; `remainingSeconds` decremented                                                                    |
+| READY sweep, delay elapsed                  | Read; `shouldCancel: true` returned; existing `updateReadyDelay` code deletes the file before returning |
+| Non-READY sweep                             | Deleted (countdown resets)                                                                              |
+| PR merged/closed (step 2.5)                 | Not reached — `updateReadyDelay` is skipped entirely                                                    |
 
 ## Clock-skew guard
 

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -8,6 +8,8 @@ The ready-delay prevents shepherd from cancelling the loop the instant CI goes g
 
 The timer also starts when the PR is BLOCKED but shepherd has nothing left to do — all CI is green, no unresolved threads or comments, no Copilot review pending. This covers any branch-protection reason: awaiting a first human review (`REVIEW_REQUIRED`), awaiting additional approvals (`APPROVED` but not enough), required signed commits, or other policy. From shepherd's perspective these are all hand-off states — it cannot resolve them — so the ready-delay countdown applies and the loop cancels once it elapses.
 
+Before the timer starts or completes, Shepherd refreshes mergeability through GitHub's REST pull-request endpoint unless the current sweep already used that fallback for an UNKNOWN mergeability response. If the refresh reports conflicts, the PR drops out of READY, the timer resets, and iterate emits `fix_code`.
+
 ## The `updateReadyDelay` function
 
 Located in `commands/ready-delay.mts`, called from `commands/iterate/index.mts` (step 3).
@@ -25,15 +27,13 @@ updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)
 
 ## Lifecycle
 
-| Event                                       | Effect on `ready-since.txt`                                 |
-| ------------------------------------------- | ----------------------------------------------------------- |
-| First READY sweep                           | Created with current timestamp                              |
-| Subsequent READY sweeps (delay not elapsed) | Read; `remainingSeconds` decremented                        |
-| READY sweep, delay elapsed                  | Read; `shouldCancel: true` returned; file **left in place** |
-| Non-READY sweep                             | Deleted (countdown resets)                                  |
-| PR merged/closed (step 2.5)                 | Not reached — `updateReadyDelay` is skipped entirely        |
-
-The file is **left in place** when `shouldCancel: true` fires. This prevents the countdown from restarting if the loop somehow continues after the cancel (e.g., a race condition between overlapping dynamic ticks).
+| Event                                       | Effect on `ready-since.txt`                          |
+| ------------------------------------------- | ---------------------------------------------------- |
+| First READY sweep                           | Created with current timestamp                       |
+| Subsequent READY sweeps (delay not elapsed) | Read; `remainingSeconds` decremented                 |
+| READY sweep, delay elapsed                  | Read; `shouldCancel: true` returned; file deleted    |
+| Non-READY sweep                             | Deleted (countdown resets)                           |
+| PR merged/closed (step 2.5)                 | Not reached — `updateReadyDelay` is skipped entirely |
 
 ## Clock-skew guard
 

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -33,7 +33,7 @@ updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)
 | Subsequent READY sweeps (delay not elapsed) | Read; `remainingSeconds` decremented                                                                    |
 | READY sweep, delay elapsed                  | Read; `shouldCancel: true` returned; existing `updateReadyDelay` code deletes the file before returning |
 | Non-READY sweep                             | Deleted (countdown resets)                                                                              |
-| PR merged/closed (step 2.5)                 | Not reached — `updateReadyDelay` is skipped entirely                                                    |
+| PR merged/closed (step 1.5)                 | Deleted before iterate returns `cancel`                                                                 |
 
 ## Clock-skew guard
 

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -144,6 +144,57 @@ describe("runCheck — UNKNOWN merge state", () => {
   });
 });
 
+describe("runCheck — READY mergeability recheck", () => {
+  it("refreshes mergeability before returning READY and returns FAILING when REST reports conflicts", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }),
+    });
+    mockGetMergeableState.mockResolvedValue({
+      mergeable: "CONFLICTING",
+      mergeStateStatus: "DIRTY",
+    });
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(mockGetMergeableState).toHaveBeenCalledTimes(1);
+    expect(report.status).toBe("FAILING");
+    expect(report.mergeStatus.status).toBe("CONFLICTS");
+    expect(report.mergeStatus.mergeable).toBe("CONFLICTING");
+    expect(report.mergeStatus.mergeStateStatus).toBe("DIRTY");
+  });
+
+  it("keeps READY when the refresh reports a human handoff state", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }),
+    });
+    mockGetMergeableState.mockResolvedValue({
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "BLOCKED",
+    });
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.status).toBe("READY");
+    expect(report.mergeStatus.status).toBe("BLOCKED");
+    expect(report.mergeStatus.mergeStateStatus).toBe("BLOCKED");
+  });
+
+  it("does not recheck twice when UNKNOWN fallback already refreshed mergeability", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }),
+    });
+    mockGetMergeableState.mockResolvedValue({
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+    });
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.status).toBe("READY");
+    expect(mockGetMergeableState).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("runCheck — terminal PR state", () => {
   it("returns MERGED and skips CI/comment processing when PR is MERGED", async () => {
     const failingCheck = makeCheck({ category: "failing", conclusion: "FAILURE" });
@@ -411,6 +462,10 @@ describe("runCheck — BLOCKED + clean (hand off to humans)", () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({ mergeStateStatus: "BLOCKED", reviewDecision: "REVIEW_REQUIRED" }),
     });
+    mockGetMergeableState.mockResolvedValue({
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "BLOCKED",
+    });
     const report = await runCheck(BASE_OPTS);
     expect(report.status).toBe("READY");
     expect(report.mergeStatus.status).toBe("BLOCKED");
@@ -534,6 +589,10 @@ describe("runCheck — BLOCKED + clean (hand off to humans)", () => {
   it("returns READY when HAS_HOOKS (derived BLOCKED) and CI passed", async () => {
     mockFetchPrBatch.mockResolvedValue({
       data: makeBatchData({ mergeStateStatus: "HAS_HOOKS", reviewDecision: "REVIEW_REQUIRED" }),
+    });
+    mockGetMergeableState.mockResolvedValue({
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "HAS_HOOKS",
     });
     const report = await runCheck(BASE_OPTS);
     expect(report.status).toBe("READY");

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -1,5 +1,5 @@
 import { fetchPrBatch } from "../github/batch.mts";
-import { getRepoInfo, getCurrentPrNumber, getMergeableState } from "../github/client.mts";
+import { getRepoInfo, getCurrentPrNumber } from "../github/client.mts";
 import { classifyChecks, getCiVerdict } from "../checks/classify.mts";
 import { mergeStartupFailureChecks } from "../checks/startup-failures.mts";
 import { fetchStartupFailureChecks, triageFailingChecks } from "../checks/triage.mts";
@@ -10,6 +10,11 @@ import { loadConfig } from "../config/load.mts";
 import { classifyVisibleComments } from "../comments/visible-comments.mts";
 import { computeStatus } from "./check-status.mts";
 import { buildTerminalReport } from "./check-terminal-report.mts";
+import {
+  isBlockedByFilteredCheck,
+  refreshReadyMergeability,
+  refreshUnknownMergeability,
+} from "./ready-mergeability.mts";
 import { loadSeenMap, markSeen, classifyItem } from "../state/seen-comments.mts";
 import type {
   GlobalOptions,
@@ -32,21 +37,10 @@ export async function runCheck(
   const paginateApprovedReviews = config.iterate.minimizeApprovals;
   const result = await fetchPrBatch(prNumber, repo, { paginateApprovedReviews });
   let batchData = result.data;
-
-  // Fall back to REST when GraphQL returns UNKNOWN — skip for non-OPEN PRs.
-  if (
-    (batchData.state ?? "OPEN") === "OPEN" &&
-    (batchData.mergeable === "UNKNOWN" || batchData.mergeStateStatus === "UNKNOWN")
-  ) {
-    const restState = await getMergeableState(prNumber, repo.owner, repo.name);
-    batchData = {
-      ...batchData,
-      mergeable: restState.mergeable ?? batchData.mergeable,
-      mergeStateStatus: restState.mergeStateStatus ?? batchData.mergeStateStatus,
-    };
-  }
-
-  const mergeStatus = deriveMergeStatus(batchData);
+  const unknownRefresh = await refreshUnknownMergeability(prNumber, repo, batchData);
+  batchData = unknownRefresh.batchData;
+  const didRefreshMergeability = unknownRefresh.didRefresh;
+  let mergeStatus = deriveMergeStatus(batchData);
   if (mergeStatus.state === "MERGED" || mergeStatus.state === "CLOSED") {
     return buildTerminalReport(prNumber, repo, batchData, mergeStatus, mergeStatus.state);
   }
@@ -59,18 +53,14 @@ export async function runCheck(
   const allChecks = mergeStartupFailureChecks(batchData.checks, startupFailureChecks);
   const classifiedChecks = classifyChecks(allChecks);
   const verdict = getCiVerdict(classifiedChecks);
-
   const passing = classifiedChecks.filter((c) => c.category === "passed");
   const failing = classifiedChecks.filter((c) => c.category === "failing");
   const inProgress = classifiedChecks.filter((c) => c.category === "in_progress");
   const skipped = classifiedChecks.filter((c) => c.category === "skipped");
   const filtered = classifiedChecks.filter((c) => c.category === "filtered");
-
   const triaged =
     failing.length > 0 && !opts.skipTriage ? await triageFailingChecks(failing, repo) : failing;
-
   const stateKey = { owner: repo.owner, repo: repo.name, pr: prNumber };
-
   const unresolvedThreads = batchData.reviewThreads.filter((t) => !t.isResolved);
   const outdated = getOutdatedThreads(unresolvedThreads);
   let autoResolved: typeof outdated = [];
@@ -126,7 +116,6 @@ export async function runCheck(
     const base = { ...c, firstLookStatus: "minimized" as const };
     return cls === "edited" ? [{ ...base, edited: true as const }] : [base];
   });
-
   const firstLookSummaries: typeof batchData.reviewSummaries = [];
   const editedSummaries: typeof batchData.reviewSummaries = [];
   const seenSummaries: typeof batchData.reviewSummaries = [];
@@ -143,24 +132,33 @@ export async function runCheck(
     ...visibleCommentClassification.toMarkSeen.map((c) => markSeen(stateKey, c.id, c.body)),
     ...[...firstLookSummaries, ...editedSummaries].map((r) => markSeen(stateKey, r.id, r.body)),
   ]);
-
   const resolutionOnlyThreads = unresolvedThreads.filter(
     (t) => !autoResolvedIds.has(t.id) && (t.isOutdated || t.isMinimized),
   );
 
-  const blockedByFilteredCheck =
-    mergeStatus.status === "BLOCKED" &&
-    !verdict.anyFailing &&
-    !verdict.anyInProgress &&
-    verdict.filteredNames.length > 0;
-
-  const status = computeStatus(
+  let status = computeStatus(
     verdict,
     activeThreads.length + resolutionOnlyThreads.length,
     visibleCommentClassification.actionable.length,
     mergeStatus,
     batchData.changesRequestedReviews.length,
   );
+
+  if (status === "READY" && !didRefreshMergeability) {
+    const refreshed = await refreshReadyMergeability(
+      prNumber,
+      repo,
+      batchData,
+      verdict,
+      activeThreads.length + resolutionOnlyThreads.length,
+      visibleCommentClassification.actionable.length,
+    );
+    batchData = refreshed.batchData;
+    mergeStatus = refreshed.mergeStatus;
+    status = refreshed.status;
+  }
+
+  const blockedByFilteredCheck = isBlockedByFilteredCheck(mergeStatus, verdict);
 
   return {
     pr: prNumber,

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -240,7 +240,7 @@ describe("runIterate — cancel", () => {
 });
 
 describe("runIterate — cancel on merged/closed PR", () => {
-  it("returns action: cancel and does not call updateReadyDelay when PR is MERGED", async () => {
+  it("returns action: cancel and clears ready-delay when PR is MERGED", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
         status: "MERGED",
@@ -261,10 +261,10 @@ describe("runIterate — cancel on merged/closed PR", () => {
     expect(result.action).toBe("cancel");
     expect(result.status).toBe("MERGED");
     expect(result.state).toBe("MERGED");
-    expect(mockUpdateReadyDelay).not.toHaveBeenCalled();
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
   });
 
-  it("returns action: cancel when PR is CLOSED", async () => {
+  it("returns action: cancel and clears ready-delay when PR is CLOSED", async () => {
     mockRunCheck.mockResolvedValue(
       makeReport({
         status: "CLOSED",
@@ -285,7 +285,7 @@ describe("runIterate — cancel on merged/closed PR", () => {
     expect(result.action).toBe("cancel");
     expect(result.status).toBe("CLOSED");
     expect(result.state).toBe("CLOSED");
-    expect(mockUpdateReadyDelay).not.toHaveBeenCalled();
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
   });
 });
 

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -35,6 +35,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
 
   if (report.mergeStatus.state !== "OPEN") {
     const state = report.mergeStatus.state.toLowerCase();
+    await updateReadyDelay(report.pr, false, readyDelaySeconds, repoOwner, repoName);
     await clearStallState(stallKey);
     return {
       pr: report.pr,

--- a/src/commands/ready-mergeability.mts
+++ b/src/commands/ready-mergeability.mts
@@ -1,0 +1,71 @@
+import { getMergeableState, type RepoInfo } from "../github/client.mts";
+import { deriveMergeStatus } from "../merge-status/derive.mts";
+import type { CiVerdict } from "../checks/classify.mts";
+import type { BatchPrData, MergeStatusResult, ShepherdStatus } from "../types.mts";
+import { computeStatus } from "./check-status.mts";
+
+interface ReadyMergeabilityRefresh {
+  batchData: BatchPrData;
+  mergeStatus: MergeStatusResult;
+  status: ShepherdStatus;
+}
+
+export async function refreshUnknownMergeability(
+  prNumber: number,
+  repo: RepoInfo,
+  batchData: BatchPrData,
+): Promise<{ batchData: BatchPrData; didRefresh: boolean }> {
+  if (
+    (batchData.state ?? "OPEN") !== "OPEN" ||
+    (batchData.mergeable !== "UNKNOWN" && batchData.mergeStateStatus !== "UNKNOWN")
+  ) {
+    return { batchData, didRefresh: false };
+  }
+
+  return { batchData: await readMergeability(prNumber, repo, batchData), didRefresh: true };
+}
+
+export async function refreshReadyMergeability(
+  prNumber: number,
+  repo: RepoInfo,
+  batchData: BatchPrData,
+  verdict: CiVerdict,
+  unresolvedThreads: number,
+  unresolvedComments: number,
+): Promise<ReadyMergeabilityRefresh> {
+  const refreshedBatchData = await readMergeability(prNumber, repo, batchData);
+  const mergeStatus = deriveMergeStatus(refreshedBatchData);
+  const status = computeStatus(
+    verdict,
+    unresolvedThreads,
+    unresolvedComments,
+    mergeStatus,
+    refreshedBatchData.changesRequestedReviews.length,
+  );
+  return { batchData: refreshedBatchData, mergeStatus, status };
+}
+
+export function isBlockedByFilteredCheck(
+  mergeStatus: MergeStatusResult,
+  verdict: CiVerdict,
+): boolean {
+  return (
+    mergeStatus.status === "BLOCKED" &&
+    !verdict.anyFailing &&
+    !verdict.anyInProgress &&
+    verdict.filteredNames.length > 0
+  );
+}
+
+async function readMergeability(
+  prNumber: number,
+  repo: RepoInfo,
+  batchData: BatchPrData,
+): Promise<BatchPrData> {
+  const restState = await getMergeableState(prNumber, repo.owner, repo.name);
+  return {
+    ...batchData,
+    mergeable: restState.mergeable ?? batchData.mergeable,
+    mergeStateStatus: restState.mergeStateStatus ?? batchData.mergeStateStatus,
+  };
+}


### PR DESCRIPTION
## Summary
- Refresh mergeability before a READY handoff can start or complete ready-delay.
- Route stale GraphQL CLEAN data to the existing CONFLICTS/fix_code path when REST reports DIRTY/CONFLICTING.
- Document the guarded ready-delay boundary and marker behavior.

## Root Cause
GitHub GraphQL can briefly report CLEAN while the REST pull request endpoint already reports conflicts. If a stale ready-since marker had elapsed, iterate could emit ready-delay-elapsed CANCEL before surfacing the conflict.

## Validation
- npx vitest run src/commands/check.mock.test.mts src/commands/iterate.fix-code-conflicts.mock.test.mts src/commands/iterate.render.mock.test.mts src/commands/ready-delay.test.mts
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
