### PR TITLE
[codex] reset ready delay on unclean sweeps

### DIFF
--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -26,11 +26,11 @@
 
 ### 2. Ready-delay state machine
 
-**What:** `updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)` reads/writes `ready-since.txt`.
+**What:** `updateReadyDelay(pr, isCleanReadyHandoff, readyDelaySeconds, owner, repo)` reads/writes `ready-since.txt`.
 
-- On first READY sweep: creates the file with the current timestamp.
-- On subsequent READY sweeps: checks if `now − readySince >= readyDelaySeconds`. If so, `shouldCancel: true`.
-- On non-READY sweep: deletes the file (resets the countdown).
+- On first clean handoff sweep: creates the file with the current timestamp.
+- On subsequent clean handoff sweeps: checks if `now − readySince >= readyDelaySeconds`. If so, `shouldCancel: true`.
+- On any unclean sweep: deletes the file (resets the countdown). This includes non-READY status, failing CI, conflicts, unresolved/actionable comments, review-summary minimization, and first-look items.
 
 Before a READY sweep reaches the ready-delay state machine, `runCheck` performs one fresh REST mergeability read unless the UNKNOWN fallback already did so. If the refreshed mergeability reports `CONFLICTING`/`DIRTY`, the sweep becomes `FAILING`/`CONFLICTS`, resets the ready-delay marker, and routes to `fix_code`.
 

--- a/docs/ready-delay.md
+++ b/docs/ready-delay.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-The ready-delay prevents shepherd from cancelling the loop the instant CI goes green. It waits for a configurable window of consecutive READY status before emitting `action: cancel`. This gives reviewers time to post comments before the loop exits.
+The ready-delay prevents shepherd from cancelling the loop the instant CI goes green. It waits for a configurable window of consecutive clean handoff status before emitting `action: cancel`. A clean handoff means the current sweep is `READY` and has no actionable Shepherd work such as failing CI, conflicts, unresolved comments, review-summary minimization, or first-look items. This gives reviewers time to post comments before the loop exits without letting stale readiness survive a newly unclean PR.
 
 The timer also starts when the PR is BLOCKED but shepherd has nothing left to do — all CI is green, no unresolved threads or comments, no Copilot review pending. This covers any branch-protection reason: awaiting a first human review (`REVIEW_REQUIRED`), awaiting additional approvals (`APPROVED` but not enough), required signed commits, or other policy. From shepherd's perspective these are all hand-off states — it cannot resolve them — so the ready-delay countdown applies and the loop cancels once it elapses.
 
@@ -19,6 +19,8 @@ updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)
   → { isReady, shouldCancel, remainingSeconds }
 ```
 
+`isReady` is `true` only after iterate confirms the sweep is a clean handoff. A top-level `READY` report with actionable work still passes `false` so the marker resets before `fix_code` is emitted.
+
 ## Marker file
 
 **Path:** `$TMPDIR/pr-shepherd-state/<owner>-<repo>/<pr>/ready-since.txt`
@@ -27,13 +29,13 @@ updateReadyDelay(pr, isReady, readyDelaySeconds, owner, repo)
 
 ## Lifecycle
 
-| Event                                       | Effect on `ready-since.txt`                                                                             |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| First READY sweep                           | Created with current timestamp                                                                          |
-| Subsequent READY sweeps (delay not elapsed) | Read; `remainingSeconds` decremented                                                                    |
-| READY sweep, delay elapsed                  | Read; `shouldCancel: true` returned; existing `updateReadyDelay` code deletes the file before returning |
-| Non-READY sweep                             | Deleted (countdown resets)                                                                              |
-| PR merged/closed (step 1.5)                 | Deleted before iterate returns `cancel`                                                                 |
+| Event                                                | Effect on `ready-since.txt`                                                                             |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| First clean handoff sweep                            | Created with current timestamp                                                                          |
+| Subsequent clean handoff sweeps (delay not elapsed)  | Read; `remainingSeconds` decremented                                                                    |
+| Clean handoff sweep, delay elapsed                   | Read; `shouldCancel: true` returned; existing `updateReadyDelay` code deletes the file before returning |
+| Non-READY sweep, or READY sweep with actionable work | Deleted (countdown resets)                                                                              |
+| PR merged/closed (step 1.5)                          | Deleted before iterate returns `cancel`                                                                 |
 
 ## Clock-skew guard
 

--- a/src/commands/iterate.fix-code-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.mock.test.mts
@@ -237,6 +237,7 @@ describe("runIterate — fix_code (actionable CI failure)", () => {
 
     const result = await runIterate(makeOpts());
 
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
     expect(result.action).toBe("fix_code");
     if (result.action === "fix_code") {
       expect(result.fix.checks).toHaveLength(1);

--- a/src/commands/iterate.fix-code-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.mock.test.mts
@@ -224,6 +224,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
 
     const result = await runIterate(makeOpts());
 
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
     expect(result.action).toBe("fix_code");
     if (result.action === "fix_code") {
       expect(result.fix.threads).toHaveLength(0);
@@ -284,6 +285,7 @@ describe("runIterate — fix_code (merge conflicts)", () => {
 
     const result = await runIterate(makeOpts());
 
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
     expect(result.action).toBe("fix_code");
     if (result.action === "fix_code") {
       expect(result.fix.threads).toHaveLength(1);

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -263,6 +263,28 @@ describe("runIterate — cancel", () => {
     expect(result.action).toBe("fix_code");
     expect(result.shouldCancel).toBe(false);
   });
+
+  it("resets ready-delay when READY has pending comment minimization", async () => {
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        comments: { actionable: [], firstLook: [], minimizeIds: ["comment-1"] },
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
+    expect(result.action).toBe("fix_code");
+    if (result.action === "fix_code") {
+      expect(result.fix.reviewSummaryIds).toHaveLength(0);
+      expect(result.fix.resolveCommand.hasMutations).toBe(true);
+    }
+  });
 });
 
 describe("runIterate — cancel on merged/closed PR", () => {

--- a/src/commands/iterate.mock.test.mts
+++ b/src/commands/iterate.mock.test.mts
@@ -237,6 +237,32 @@ describe("runIterate — cancel", () => {
     expect(result.shouldCancel).toBe(true);
     expect(result.remainingSeconds).toBe(0);
   });
+
+  it("does not cancel from a stale ready-delay marker when READY has fix_code work", async () => {
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        reviewSummaries: [
+          {
+            id: "review-1",
+            author: "reviewer",
+            authorType: "User",
+            body: "Looks good overall.",
+          },
+        ],
+      }),
+    );
+    mockUpdateReadyDelay.mockResolvedValue({
+      isReady: false,
+      shouldCancel: false,
+      remainingSeconds: 600,
+    });
+
+    const result = await runIterate(makeOpts());
+
+    expect(mockUpdateReadyDelay).toHaveBeenCalledWith(42, false, 600, "owner", "repo");
+    expect(result.action).toBe("fix_code");
+    expect(result.shouldCancel).toBe(false);
+  });
 });
 
 describe("runIterate — cancel on merged/closed PR", () => {

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -58,10 +58,36 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     };
   }
 
-  const isReady = report.status === "READY";
+  const {
+    minimizeIds: reviewSummaryIds,
+    firstLookSummaries,
+    editedSummaries,
+    surfacedApprovals,
+  } = classifyReviewSummaries(
+    {
+      firstLook: report.firstLookSummaries,
+      seen: report.reviewSummaries,
+      edited: report.editedSummaries,
+    },
+    report.approvedReviews,
+    config.iterate.minimizeApprovals,
+    config.iterate.minimizeComments,
+  );
+  const hasActionableWork =
+    report.threads.actionable.length > 0 ||
+    report.threads.resolutionOnly.length > 0 ||
+    report.comments.actionable.length > 0 ||
+    report.changesRequestedReviews.length > 0 ||
+    report.checks.failing.length > 0 ||
+    report.mergeStatus.status === "CONFLICTS" ||
+    reviewSummaryIds.length > 0 ||
+    firstLookSummaries.length > 0 ||
+    editedSummaries.length > 0;
+
+  const isCleanReadyHandoff = report.status === "READY" && !hasActionableWork;
   const readyState = await updateReadyDelay(
     report.pr,
-    isReady,
+    isCleanReadyHandoff,
     readyDelaySeconds,
     repoOwner,
     repoName,
@@ -100,32 +126,6 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   }
 
   const headSha = (await getCurrentHeadSha()) ?? "unknown";
-
-  const {
-    minimizeIds: reviewSummaryIds,
-    firstLookSummaries,
-    editedSummaries,
-    surfacedApprovals,
-  } = classifyReviewSummaries(
-    {
-      firstLook: report.firstLookSummaries,
-      seen: report.reviewSummaries,
-      edited: report.editedSummaries,
-    },
-    report.approvedReviews,
-    config.iterate.minimizeApprovals,
-    config.iterate.minimizeComments,
-  );
-  const hasActionableWork =
-    report.threads.actionable.length > 0 ||
-    report.threads.resolutionOnly.length > 0 ||
-    report.comments.actionable.length > 0 ||
-    report.changesRequestedReviews.length > 0 ||
-    report.checks.failing.length > 0 ||
-    report.mergeStatus.status === "CONFLICTS" ||
-    reviewSummaryIds.length > 0 ||
-    firstLookSummaries.length > 0 ||
-    editedSummaries.length > 0;
 
   if (hasActionableWork) {
     return handleFixCode({

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -76,7 +76,10 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
   const hasActionableWork =
     report.threads.actionable.length > 0 ||
     report.threads.resolutionOnly.length > 0 ||
+    report.threads.firstLook.length > 0 ||
     report.comments.actionable.length > 0 ||
+    (report.comments.minimizeIds?.length ?? 0) > 0 ||
+    report.comments.firstLook.length > 0 ||
     report.changesRequestedReviews.length > 0 ||
     report.checks.failing.length > 0 ||
     report.mergeStatus.status === "CONFLICTS" ||


### PR DESCRIPTION
## Summary
- Reset the ready-delay marker unless the current sweep is a clean READY handoff.
- Prevent stale ready-delay cancellation when READY still has fix_code work such as comment minimization, failing CI, or conflicts.
- Update ready-delay docs and iterate flow docs for the clean-handoff lifecycle.

## Validation
- npx vitest run src/commands/iterate.mock.test.mts src/commands/iterate.fix-code-conflicts.mock.test.mts src/commands/iterate.fix-code-ci-failure.mock.test.mts src/commands/ready-delay.test.mts
- npm run typecheck
- npm run format:check
- pre-push hook: npm run lint
- pre-push hook: npm run typecheck
- pre-push hook: npm run format:check
