### PR TITLE
[codex] require 100% line coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,8 +4,9 @@ coverage:
   status:
     project:
       default:
-        threshold: 1%
+        target: 100%
+        threshold: 0%
     patch:
       default:
-        target: 85%
-        threshold: 5%
+        target: 100%
+        threshold: 0%

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "format": "oxfmt src/ plugins/ .agents/plugins/ docs/ README.md",
     "format:check": "oxfmt --check src/ plugins/ .agents/plugins/ docs/ README.md",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage && node scripts/strip-lcov-branches.mjs",
     "test:watch": "vitest"
   },
   "keywords": [

--- a/scripts/strip-lcov-branches.mjs
+++ b/scripts/strip-lcov-branches.mjs
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = "coverage/lcov.info";
+const input = readFileSync(path, "utf8");
+const output = input
+  .split("\n")
+  .filter(
+    (line) =>
+      !line.startsWith("BRDA:") && !line.startsWith("BRF:") && !line.startsWith("BRH:"),
+  )
+  .join("\n");
+
+writeFileSync(path, output);

--- a/src/checks/triage.mock.test.mts
+++ b/src/checks/triage.mock.test.mts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -8,6 +9,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 import { fetchStartupFailureChecks, triageFailingChecks } from "./triage.mts";
+import { mergeStartupFailureChecks } from "./startup-failures.mts";
 import type { ClassifiedCheck } from "../types.mts";
 
 const REPO = { owner: "owner", name: "repo" };
@@ -192,6 +194,44 @@ describe("fetchStartupFailureChecks", () => {
     expect(check).not.toHaveProperty("summary");
   });
 
+  it("omits summary when GitHub omits display_title", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeWorkflowRunsResponse([
+        {
+          id: 124,
+          name: "CI",
+          event: "pull_request",
+          status: "completed",
+          conclusion: "startup_failure",
+          html_url: "https://github.com/owner/repo/actions/runs/124",
+          pull_requests: [{ number: 42, head: { sha: "abc123" } }],
+        },
+      ]),
+    );
+
+    const [check] = await fetchStartupFailureChecks(REPO, "abc123", 42);
+
+    expect(check!.name).toBe("CI");
+    expect(check).not.toHaveProperty("summary");
+  });
+
+  it("filters out runs when GitHub omits pull_requests", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeWorkflowRunsResponse([
+        {
+          id: 125,
+          name: "CI",
+          event: "pull_request",
+          status: "completed",
+          conclusion: "startup_failure",
+          html_url: "https://github.com/owner/repo/actions/runs/125",
+        },
+      ]),
+    );
+
+    await expect(fetchStartupFailureChecks(REPO, "abc123", 42)).resolves.toEqual([]);
+  });
+
   it("filters out startup-failure runs from other PRs sharing the same head SHA", async () => {
     mockFetch.mockResolvedValueOnce(
       makeWorkflowRunsResponse([
@@ -221,6 +261,56 @@ describe("fetchStartupFailureChecks", () => {
     expect(checks.map((c) => c.runId)).toEqual(["456"]);
   });
 
+  it("matches startup-failure runs when GitHub omits the PR head SHA", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeWorkflowRunsResponse([
+        {
+          id: 789,
+          name: "CI",
+          event: "pull_request",
+          status: "completed",
+          conclusion: "startup_failure",
+          html_url: "https://github.com/owner/repo/actions/runs/789",
+          pull_requests: [{ number: 42, head: null }],
+        },
+      ]),
+    );
+
+    const checks = await fetchStartupFailureChecks(REPO, "abc123", 42);
+
+    expect(checks.map((c) => c.runId)).toEqual(["789"]);
+  });
+
+  it("warns when startup-failure pagination reaches the cap", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      for (let page = 0; page < 10; page++) {
+        mockFetch.mockResolvedValueOnce(
+          makeWorkflowRunsResponse(
+            Array.from({ length: 100 }, (_, i) => ({
+              id: page * 100 + i,
+              name: "CI",
+              event: "pull_request",
+              status: "completed",
+              conclusion: "startup_failure",
+              html_url: `https://github.com/owner/repo/actions/runs/${page * 100 + i}`,
+              pull_requests: [{ number: 42, head: { sha: "abc123" } }],
+            })),
+          ),
+        );
+      }
+
+      const checks = await fetchStartupFailureChecks(REPO, "abc123", 42);
+
+      expect(checks).toHaveLength(1000);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining("startup-failure run pagination cap"),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it("returns an empty supplement when the Actions runs fetch fails", async () => {
     mockFetch.mockResolvedValueOnce(makeErrorResponse(403));
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -235,6 +325,36 @@ describe("fetchStartupFailureChecks", () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+});
+
+describe("mergeStartupFailureChecks", () => {
+  it("replaces duplicate check runs and removes superseded duplicates", () => {
+    const original = [
+      makeCheck({ name: "old first", runId: "run-1", conclusion: "FAILURE" }),
+      makeCheck({ name: "old duplicate", runId: "run-1", conclusion: "FAILURE" }),
+      makeCheck({ name: "status context", runId: null, conclusion: "FAILURE" }),
+    ];
+    const startup = [
+      makeCheck({ name: "startup", runId: "run-1", conclusion: "STARTUP_FAILURE" }),
+      makeCheck({ name: "new startup", runId: "run-2", conclusion: "STARTUP_FAILURE" }),
+    ];
+
+    expect(mergeStartupFailureChecks(original, startup).map((check) => check.name)).toEqual([
+      "startup",
+      "status context",
+      "new startup",
+    ]);
+  });
+
+  it("appends startup failures that do not have a runId", () => {
+    const startup = makeCheck({
+      name: "startup without run id",
+      runId: null,
+      conclusion: "STARTUP_FAILURE",
+    });
+
+    expect(mergeStartupFailureChecks([], [startup])).toEqual([startup]);
   });
 });
 
@@ -339,6 +459,34 @@ describe("triageFailingChecks — failedStep", () => {
     mockFetch.mockResolvedValueOnce(makeErrorResponse(500));
     const [result] = await triageFailingChecks([makeCheck({ conclusion: "FAILURE" })], REPO);
     expect(result!.failedStep).toBeUndefined();
+  });
+
+  it("warns and returns accumulated jobs when job pagination reaches the cap", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      for (let page = 0; page < 20; page++) {
+        mockFetch.mockResolvedValueOnce(
+          makeJobsResponse(
+            Array.from({ length: 100 }, (_, i) => ({
+              name: page === 0 && i === 0 ? "tests" : `job-${page}-${i}`,
+              workflow_name: "CI",
+              conclusion: page === 0 && i === 0 ? "failure" : "success",
+              steps:
+                page === 0 && i === 0
+                  ? [{ name: "Run tests", number: 1, conclusion: "failure" }]
+                  : [],
+            })),
+          ),
+        );
+      }
+
+      const [result] = await triageFailingChecks([makeCheck()], REPO);
+
+      expect(result!.failedStep).toBe("Run tests");
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("job pagination cap"));
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });
 

--- a/src/cli-parser.commit-suggestion.mock.test.mts
+++ b/src/cli-parser.commit-suggestion.mock.test.mts
@@ -150,6 +150,21 @@ describe("main — commit-suggestion", () => {
     expect(out).toContain("--- a/a.ts");
   });
 
+  it("text output handles multi-line suggestions without a patch or follow-up instructions", async () => {
+    mockRunCommitSuggestion.mockResolvedValue({
+      ...SUGGESTION_RESULT,
+      startLine: 5,
+      endLine: 7,
+      patch: "",
+      postActionInstructions: [],
+    });
+    await main(["node", "shepherd", "commit-suggestion", "--thread-id", "t1", "--message", "fix"]);
+    const out = getStdout();
+    expect(out).toContain("a.ts (lines 5–7)");
+    expect(out).not.toContain("```diff");
+    expect(out).not.toContain("## Instructions");
+  });
+
   it("text output shows ## Suggested commit message section", async () => {
     mockRunCommitSuggestion.mockResolvedValue(SUGGESTION_RESULT);
     await main(["node", "shepherd", "commit-suggestion", "--thread-id", "t1", "--message", "fix"]);

--- a/src/cli-parser.iterate-fix.mock.test.mts
+++ b/src/cli-parser.iterate-fix.mock.test.mts
@@ -218,6 +218,36 @@ describe("main — iterate text format (fix_code and checks)", () => {
     expect(out).not.toContain("## Approvals (surfaced");
   });
 
+  it("fix_code: renders resolution-only threads with status tags", async () => {
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+
+    result.fix.resolutionOnlyThreads = [
+      {
+        id: "PRT_min",
+        isResolved: false,
+        isOutdated: false,
+        isMinimized: true,
+        path: "src/old.ts",
+        line: 3,
+        startLine: null,
+        author: "reviewer",
+        authorType: "User" as const,
+        body: "already hidden",
+        url: "https://example.com/thread",
+        createdAtUnix: 0,
+      },
+    ];
+    mockRunIterate.mockResolvedValue(result);
+
+    await main(["node", "shepherd", "iterate", "42"]);
+    const out = getStdout();
+
+    expect(out).toContain("## Review threads to resolve");
+    expect(out).toContain("`threadId=PRT_min`");
+    expect(out).toContain("[status: minimized]");
+  });
+
   it("fix_code: renders '## Review summaries (first look)' with body when firstLookSummaries is non-empty", async () => {
     const result = makeIterateResult("fix_code");
     if (result.action !== "fix_code") throw new Error("unreachable");

--- a/src/cli-parser.iterate.mock.test.mts
+++ b/src/cli-parser.iterate.mock.test.mts
@@ -15,6 +15,7 @@ vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
 
 import { main } from "./cli-parser.mts";
 import { runIterate } from "./commands/iterate/index.mts";
+import { formatIterateResult } from "./cli/iterate-formatter.mts";
 import type { CancelReason, IterateResult } from "./types.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 
@@ -293,6 +294,16 @@ describe("main — iterate text format", () => {
     expect(getStdout()).toContain("**remainingSeconds** 300");
   });
 
+  it("lean mode: summary shows non-zero skipped, filtered, and in-progress counts", async () => {
+    const result = {
+      ...makeIterateResult("wait"),
+      summary: { passing: 2, skipped: 1, filtered: 1, inProgress: 3 },
+    };
+    mockRunIterate.mockResolvedValue(result);
+    await main(["node", "shepherd", "iterate", "42"]);
+    expect(getStdout()).toContain("2 passing, 1 skipped, 1 filtered, 3 inProgress");
+  });
+
   it("lean mode: blockingBotReviewInProgress and isDraft shown only when true", async () => {
     const result = {
       ...makeIterateResult("wait"),
@@ -316,6 +327,10 @@ describe("main — iterate text format", () => {
     expect(text).toContain("isDraft");
     expect(text).toContain("0 skipped");
     expect(text).toContain("0 filtered");
+  });
+
+  it("formatIterateResult uses default options when called directly", () => {
+    expect(formatIterateResult(makeIterateResult("wait"))).toContain("# PR #42 [WAIT]");
   });
 
   // Per CLAUDE.md output-format invariant: text and JSON must surface equivalent

--- a/src/cli-parser.mock.test.mts
+++ b/src/cli-parser.mock.test.mts
@@ -7,6 +7,9 @@ vi.mock("./commands/resolve.mts", () => ({
   runResolveFetch: vi.fn(),
   runResolveMutate: vi.fn(),
 }));
+vi.mock("./commands/log-file.mts", () => ({
+  runLogFile: vi.fn(),
+}));
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
@@ -15,10 +18,12 @@ vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
   return { ...actual, runIterate: vi.fn() };
 });
 import { main } from "./cli-parser.mts";
+import { runLogFile } from "./commands/log-file.mts";
 import { runResolveFetch, runResolveMutate } from "./commands/resolve.mts";
 
 const mockRunResolveFetch = vi.mocked(runResolveFetch);
 const mockRunResolveMutate = vi.mocked(runResolveMutate);
+const mockRunLogFile = vi.mocked(runLogFile);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let stdoutSpy: any;
@@ -39,6 +44,34 @@ afterEach(() => {
   process.exitCode = undefined;
   stdoutSpy.mockRestore();
   stderrSpy.mockRestore();
+});
+
+describe("main — log-file", () => {
+  it("prints the log path as text without initializing normal command dispatch", async () => {
+    mockRunLogFile.mockResolvedValue({ path: "/tmp/shepherd.md" });
+    await main(["node", "shepherd", "log-file"]);
+    expect(getStdout()).toBe("/tmp/shepherd.md\n");
+    expect(mockRunResolveFetch).not.toHaveBeenCalled();
+  });
+
+  it("prints the log path as JSON for --format=json", async () => {
+    mockRunLogFile.mockResolvedValue({ path: "/tmp/shepherd.md" });
+    await main(["node", "shepherd", "log-file", "--format=json"]);
+    expect(JSON.parse(getStdout())).toEqual({ path: "/tmp/shepherd.md" });
+  });
+
+  it("prints the log path as JSON for --format json", async () => {
+    mockRunLogFile.mockResolvedValue({ path: "/tmp/shepherd.md" });
+    await main(["node", "shepherd", "log-file", "--format", "json"]);
+    expect(JSON.parse(getStdout())).toEqual({ path: "/tmp/shepherd.md" });
+  });
+
+  it("reports log-file errors and sets exitCode", async () => {
+    mockRunLogFile.mockRejectedValue(new Error("not in repo"));
+    await main(["node", "shepherd", "log-file"]);
+    expect(stderrSpy).toHaveBeenCalledWith("pr-shepherd: log-file: Error: not in repo\n");
+    expect(process.exitCode).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -164,6 +197,66 @@ describe("main — resolve", () => {
     expect(out).toContain("reset at 2023-11-14T22:13:20.000Z");
     expect(out).toContain("Not minimized due to rate limit (2): c-3, c-4");
     expect(out).not.toContain("Errors:");
+  });
+
+  it("formatMutateResult renders rate-limit stop without optional limit details", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      resolvedThreads: [],
+      minimizedComments: [],
+      dismissedReviews: [],
+      errors: ["rate limit: secondary limit"],
+      rateLimit: { message: "secondary limit" },
+    });
+
+    await main(["node", "shepherd", "resolve", "42", "--resolve-thread-ids", "t-1"]);
+
+    const out = getStdout();
+    expect(out).toContain("Stopped: GitHub rate limit hit — secondary limit");
+    expect(out).not.toContain("retry after");
+    expect(out).not.toContain("remaining");
+    expect(out).not.toContain("reset at");
+  });
+
+  it("formatMutateResult renders dismissed reviews, unresolved, unminimized, and undismissed IDs", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      resolvedThreads: [],
+      minimizedComments: [],
+      dismissedReviews: ["r-1"],
+      errors: [],
+      unresolvedThreads: ["t-1"],
+      unminimizedComments: ["c-1"],
+      undismissedReviews: ["r-2"],
+    });
+
+    await main([
+      "node",
+      "shepherd",
+      "resolve",
+      "42",
+      "--dismiss-review-ids",
+      "r-1,r-2",
+      "--message",
+      "done",
+    ]);
+
+    const out = getStdout();
+    expect(out).toContain("Dismissed reviews (1): r-1");
+    expect(out).toContain("Not resolved due to rate limit (1): t-1");
+    expect(out).toContain("Not minimized due to rate limit (1): c-1");
+    expect(out).toContain("Not dismissed due to rate limit (1): r-2");
+  });
+
+  it("formatMutateResult renders non-rate-limit errors", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      resolvedThreads: [],
+      minimizedComments: [],
+      dismissedReviews: [],
+      errors: ["t-1: nope"],
+    });
+
+    await main(["node", "shepherd", "resolve", "42", "--resolve-thread-ids", "t-1"]);
+
+    expect(getStdout()).toContain("Errors:\n  t-1: nope");
   });
 
   it("resolve mutate --format=json includes rate-limit stop and pending IDs", async () => {

--- a/src/cli/args.test.mts
+++ b/src/cli/args.test.mts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   getFlag,
   hasFlag,
@@ -12,6 +12,8 @@ import {
   statusToExitCode,
   iterateActionToExitCode,
 } from "./exit-codes.mts";
+import { validateDurationFlag } from "./duration-flag.mts";
+import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------
@@ -117,8 +119,16 @@ describe("parseStatusPrNumbers", () => {
     expect(parseStatusPrNumbers(["--format", "json", "42"])).toEqual([42]);
   });
 
+  it("skips a known value flag at the end of the argv", () => {
+    expect(parseStatusPrNumbers(["--message"])).toEqual([]);
+  });
+
   it("skips boolean flags", () => {
     expect(parseStatusPrNumbers(["--dry-run", "42"])).toEqual([42]);
+  });
+
+  it("ignores non-numeric positional args", () => {
+    expect(parseStatusPrNumbers(["abc", "42"])).toEqual([42]);
   });
 
   it("returns empty for no PR numbers", () => {
@@ -146,9 +156,37 @@ describe("parseCommonArgs — PR number detection", () => {
     expect(prNumber).toBe(42);
   });
 
+  it("does not skip past argv when a known value flag is missing its value", () => {
+    const { prNumber, extra } = parseCommonArgs(["--message"]);
+    expect(prNumber).toBeUndefined();
+    expect(extra).toEqual(["--message"]);
+  });
+
   it("supports --format=json inline form", () => {
     const { global: g } = parseCommonArgs(["--format=json", "42"]);
     expect(g.format).toBe("json");
+  });
+
+  it("sets verbose when --verbose is present and strips it from extra", () => {
+    const { global: g, extra } = parseCommonArgs(["--verbose", "42", "--fetch"]);
+    expect(g.verbose).toBe(true);
+    expect(extra).toEqual(["--fetch"]);
+  });
+
+  it("skips known value flags in --flag=value form during PR detection", () => {
+    const { prNumber, extra } = parseCommonArgs(["--thread-id=123", "42"]);
+    expect(prNumber).toBe(42);
+    expect(extra).toContain("--thread-id=123");
+  });
+
+  it("does not skip the value after unknown inline flags during PR detection", () => {
+    const { prNumber } = parseCommonArgs(["--unknown=100", "42"]);
+    expect(prNumber).toBe(42);
+  });
+
+  it("treats unknown standalone flags without following values as non-PR args", () => {
+    const { prNumber } = parseCommonArgs(["--unknown", "--dry-run", "42"]);
+    expect(prNumber).toBe(42);
   });
 
   it("supports --format json space form", () => {
@@ -217,6 +255,10 @@ describe("parseDurationToMinutes", () => {
   it("uses a different explicit defaultMinutes value", () => {
     expect(parseDurationToMinutes("notaduration", 15)).toBe(15);
   });
+
+  it("falls back to configured default when invalid input has no explicit default", () => {
+    expect(parseDurationToMinutes("notaduration")).toBe(10);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -238,10 +280,6 @@ describe("statusToExitCode", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// iterateActionToExitCode
-// ---------------------------------------------------------------------------
-
 describe("iterateActionToExitCode", () => {
   it.each<[ShepherdAction, number]>([
     ["fix_code", 1],
@@ -249,7 +287,96 @@ describe("iterateActionToExitCode", () => {
     ["escalate", 3],
     ["wait", 0],
     ["mark_ready", 0],
-  ])("%s → %d", (action, code) => {
+  ])("%s -> %d", (action, code) => {
     expect(iterateActionToExitCode(action)).toBe(code);
+  });
+});
+
+describe("validateDurationFlag", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    stderrSpy.mockRestore();
+  });
+
+  it("returns undefined when the flag is absent", () => {
+    expect(validateDurationFlag("cmd", "--ready-delay", null, false)).toBeUndefined();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing separate value", () => {
+    expect(validateDurationFlag("cmd", "--ready-delay", null, true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("requires a value"));
+  });
+
+  it("rejects the next flag as a value", () => {
+    expect(validateDurationFlag("cmd", "--ready-delay", "--format", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("requires a value"));
+  });
+
+  it("rejects malformed durations", () => {
+    expect(validateDurationFlag("cmd", "--ready-delay", "soon", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("invalid --ready-delay"));
+  });
+
+  it("returns trimmed valid durations", () => {
+    expect(validateDurationFlag("cmd", "--ready-delay", " 2h ", true)).toBe("2h");
+  });
+});
+
+describe("default iterate invocation helpers", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    stderrSpy.mockRestore();
+  });
+
+  it("recognizes omitted subcommand, PR numbers, PR URLs, and default flags", () => {
+    expect(isDefaultIterateInvocation(undefined)).toBe(true);
+    expect(isDefaultIterateInvocation("42")).toBe(true);
+    expect(isDefaultIterateInvocation("https://github.com/o/r/pull/42")).toBe(true);
+    expect(isDefaultIterateInvocation("--format=json")).toBe(true);
+    expect(isDefaultIterateInvocation("--no-auto-mark-ready")).toBe(true);
+    expect(isDefaultIterateInvocation("resolve")).toBe(false);
+  });
+
+  it("accepts a single PR plus known default iterate flags", () => {
+    expect(
+      validateDefaultIterateArgs([
+        "42",
+        "--format",
+        "json",
+        "--ready-delay=5m",
+        "--stall-timeout",
+        "1h",
+        "--verbose",
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects missing values for default iterate value flags", () => {
+    expect(validateDefaultIterateArgs(["42", "--ready-delay"])).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown subcommand"));
+  });
+
+  it("rejects duplicate PR-like positionals and unknown args", () => {
+    expect(validateDefaultIterateArgs(["42", "43"])).toBe(false);
+    expect(validateDefaultIterateArgs(["--unknown"])).toBe(false);
   });
 });

--- a/src/cli/first-look.test.mts
+++ b/src/cli/first-look.test.mts
@@ -4,6 +4,17 @@ import { formatFetchResult } from "./formatters.mts";
 import { formatFixCodeResult } from "./fix-formatter.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 import type { IterateResult } from "../types.mts";
+import {
+  renderAuthor,
+  renderBodyPreview,
+  renderCommentBullet,
+  renderReviewBullet,
+  renderReviewListSection,
+  renderThreadBullet,
+  renderThreadResolutionStatusTag,
+} from "./list-formatters.mts";
+import { renderLineRange, renderSuggestionBlock } from "./suggestion-renderer.mts";
+import { safeFence } from "./fence.mts";
 
 // ---------------------------------------------------------------------------
 // Cross-call-site identity assertion (issue #127 acceptance criterion)
@@ -124,6 +135,55 @@ describe("## Review summaries (edited since first look) — fix-formatter render
   });
 });
 
+describe("formatFixCodeResult — fallback branches", () => {
+  it("renders missing locations, missing check metadata, cancelled checks, and empty review bodies", () => {
+    const iterResult: IterateResult = { ...makeIterateResult("fix_code") };
+    if (iterResult.action !== "fix_code") throw new Error("unreachable");
+    iterResult.fix = {
+      ...iterResult.fix,
+      threads: [
+        {
+          id: "T_NO_LOC",
+          path: null,
+          line: null,
+          startLine: undefined,
+          author: "alice",
+          authorType: "User",
+          body: "thread body",
+          url: "",
+        },
+      ],
+      checks: [
+        {
+          name: "external-check",
+          conclusion: null,
+          detailsUrl: "https://checks.example/1",
+          runId: null,
+        },
+        {
+          name: "cancelled-check",
+          jobName: "cancelled-job",
+          conclusion: "CANCELLED",
+          detailsUrl: null,
+          runId: null,
+          failedStep: "should not render",
+          summary: "should not render",
+        },
+      ],
+      firstLookSummaries: [{ id: "R_EMPTY", author: "reviewer", authorType: "User", body: "   " }],
+      editedSummaries: [{ id: "R_EDITED_EMPTY", author: "reviewer", authorType: "User", body: "" }],
+    };
+
+    const output = formatFixCodeResult("# PR #42 [FIX_CODE]", iterResult);
+
+    expect(output).toContain("(no location)");
+    expect(output).toContain("external `https://checks.example/1`");
+    expect(output).toContain("[conclusion: CANCELLED]");
+    expect(output).not.toContain("should not render");
+    expect(output).toContain("(no review body)");
+  });
+});
+
 describe("## First-look items — cross-call-site consistency", () => {
   it("formatFixCodeResult and formatFetchResult render an identical section for the same input", () => {
     // Site A: formatFixCodeResult (iterate fix_code)
@@ -157,5 +217,90 @@ describe("## First-look items — cross-call-site consistency", () => {
     );
 
     expect(siteA).toBe(siteB);
+  });
+});
+
+describe("list and suggestion render helpers", () => {
+  it("renders author, body preview, line ranges, and safe fences", () => {
+    expect(renderAuthor("alice")).toBe("@alice");
+    expect(renderBodyPreview("  first line  \r\nsecond")).toBe("first line");
+    expect(renderBodyPreview("x".repeat(120))).toHaveLength(100);
+    expect(renderLineRange(undefined, null)).toBe("?");
+    expect(renderLineRange(2, 5)).toBe("2-5");
+    expect(renderLineRange(5, 5)).toBe("5");
+    expect(safeFence("no ticks")).toBe("```");
+    expect(safeFence("````")).toBe("`````");
+  });
+
+  it("renders thread/comment/review bullets across optional branches", () => {
+    expect(renderThreadResolutionStatusTag({})).toBe("[status: unresolved]");
+    expect(renderThreadResolutionStatusTag({ isOutdated: true, isMinimized: true })).toBe(
+      "[status: outdated, minimized]",
+    );
+    expect(
+      renderThreadBullet({
+        id: "T1",
+        path: null,
+        startLine: null,
+        line: null,
+        author: "alice",
+        body: "body",
+        suggestion: { startLine: 1, endLine: 1, lines: ["x"], author: "alice" },
+      }),
+    ).toContain("`(no location)`");
+    expect(
+      renderThreadBullet(
+        {
+          id: "T2",
+          url: "https://example.com/t",
+          path: "src/a.ts",
+          startLine: 1,
+          line: 2,
+          author: "alice",
+          authorType: "User",
+          body: "body",
+          suggestion: { startLine: 1, endLine: 2, lines: ["x"], author: "alice" },
+        },
+        { renderSuggestion: true, statusTag: "[status: unresolved]" },
+      ),
+    ).toContain("Replaces lines 1–2");
+    expect(
+      renderCommentBullet(
+        { id: "C1", url: "https://example.com/c", author: "bot", body: "comment" },
+        { statusTag: "[status: minimized]" },
+      ),
+    ).toContain("[↗](https://example.com/c)");
+    expect(
+      renderReviewBullet({ id: "R1", author: "reviewer", body: "" }, { includeBody: true }),
+    ).not.toContain(": ");
+    expect(
+      renderReviewBullet({ id: "R2", author: "reviewer", body: "summary" }, { includeBody: true }),
+    ).toContain(": summary");
+  });
+
+  it("renders review list sections only when non-empty", () => {
+    expect(renderReviewListSection("Reviews", [])).toBeNull();
+    expect(
+      renderReviewListSection("Reviews", [{ id: "R1", author: "alice", body: "looks good" }]),
+    ).toBe("## Reviews\n\n- `reviewId=R1` (@alice): looks good");
+  });
+
+  it("renders deletion, blank-line, and multiline suggestion blocks", () => {
+    expect(renderSuggestionBlock({ startLine: 1, endLine: 1, lines: [], author: "a" })).toContain(
+      "with nothing",
+    );
+    expect(renderSuggestionBlock({ startLine: 1, endLine: 1, lines: [""], author: "a" })).toContain(
+      "with a blank line",
+    );
+    expect(
+      renderSuggestionBlock({ startLine: 1, endLine: 2, lines: ["a", "b"], author: "a" }, ""),
+    ).toContain("a\nb");
+  });
+});
+
+describe("iterate fixture fallback", () => {
+  it("falls back to wait for unknown actions at runtime", () => {
+    const result = makeIterateResult("unknown" as never);
+    expect(result.action).toBe("wait");
   });
 });

--- a/src/cli/iterate-lean.test.mts
+++ b/src/cli/iterate-lean.test.mts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { projectIterateLean } from "./iterate-lean.mts";
+import { projectIterateLean, projectIterateVerbose } from "./iterate-lean.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 
 describe("projectIterateLean", () => {
@@ -235,6 +235,25 @@ describe("projectIterateLean", () => {
       { id: "c1", author: "a", authorType: "Unknown" as const, body: "nit", url: "" },
     ];
     result.fix.reviewSummaryIds = ["r1"];
+    result.fix.resolutionOnlyThreads = [
+      {
+        id: "t-resolve",
+        path: "src/old.ts",
+        line: 2,
+        startLine: null,
+        author: "a",
+        authorType: "Unknown" as const,
+        body: "old",
+        url: "",
+        isResolved: false,
+        isOutdated: true,
+        isMinimized: false,
+        createdAtUnix: 0,
+      },
+    ];
+    result.fix.firstLookSummaries = [
+      { id: "summary-1", author: "a", authorType: "Unknown" as const, body: "summary" },
+    ];
     result.fix.surfacedApprovals = [
       { id: "s1", author: "a", authorType: "Unknown" as const, body: "summary" },
     ];
@@ -274,20 +293,51 @@ describe("projectIterateLean", () => {
       { name: "lint", conclusion: "FAILURE" as const, runId: "r2", detailsUrl: null },
     ];
     result.cancelled = ["run-1"];
+    result.fix.inProgressRunIds = ["run-2"];
 
     const lean = projectIterateLean(result) as Record<string, unknown>;
     const fix = lean.fix as Record<string, unknown>;
     expect((fix.threads as unknown[]).length).toBe(1);
+    expect((fix.resolutionOnlyThreads as unknown[]).length).toBe(1);
     expect((fix.checks as unknown[]).length).toBe(1);
     expect((lean.checks as unknown[]).length).toBe(1);
     expect((fix.instructions as unknown[]).length).toBe(1);
     expect((fix.actionableComments as unknown[]).length).toBe(1);
     expect((fix.reviewSummaryIds as unknown[]).length).toBe(1);
+    expect((fix.firstLookSummaries as unknown[]).length).toBe(1);
     expect((fix.surfacedApprovals as unknown[]).length).toBe(1);
     expect((fix.firstLookThreads as unknown[]).length).toBe(1);
     expect((fix.firstLookComments as unknown[]).length).toBe(1);
+    expect((fix.inProgressRunIds as unknown[]).length).toBe(1);
     expect((fix.changesRequestedReviews as unknown[]).length).toBe(1);
     expect((lean.cancelled as unknown[]).length).toBe(1);
+  });
+
+  it("projectIterateVerbose adapts fix_code instructions", () => {
+    const result = makeIterateResult("fix_code");
+    if (result.action !== "fix_code") throw new Error("unreachable");
+    result.fix.instructions = ["Stop this iteration before the next tick."];
+    const verbose = projectIterateVerbose(result, { runtime: "codex" }) as typeof result;
+    expect(verbose.fix.instructions[0]).toContain("rerun `npx pr-shepherd 42`");
+  });
+
+  it("projectIterateVerbose adapts non-fix logs and adds instructions", () => {
+    const verbose = projectIterateVerbose(makeIterateResult("wait"), {
+      runtime: "codex",
+    }) as Record<string, unknown>;
+    expect(verbose.log).toContain("WAIT");
+    expect(verbose.instructions).toBeDefined();
+  });
+
+  it("projectIterateVerbose uses default options for fix_code and wait", () => {
+    const fixResult = makeIterateResult("fix_code");
+    if (fixResult.action !== "fix_code") throw new Error("unreachable");
+    expect((projectIterateVerbose(fixResult) as typeof fixResult).fix.instructions[0]).toContain(
+      "npx pr-shepherd 42",
+    );
+
+    const wait = projectIterateVerbose(makeIterateResult("wait")) as Record<string, unknown>;
+    expect(wait.instructions).toBeDefined();
   });
 
   // ---------------------------------------------------------------------------

--- a/src/cli/runner.test.mts
+++ b/src/cli/runner.test.mts
@@ -113,6 +113,13 @@ describe("resolveCliRunner", () => {
     expect(resolveCliRunner("auto", nested)).toBe("npx");
   });
 
+  it("caches detected runners per start directory", () => {
+    writePackage({ packageManager: "pnpm@10.0.0" });
+    expect(resolveCliRunner("auto", tmpDir)).toBe("pnpm");
+    writePackage({ packageManager: "yarn@4.0.0" });
+    expect(resolveCliRunner("auto", tmpDir)).toBe("pnpm");
+  });
+
   it("rejects unsupported config values", () => {
     expect(() => parseCliRunner("bun")).toThrow("cli.runner");
   });
@@ -144,5 +151,13 @@ describe("buildPrShepherdCommand", () => {
     expect(renderShellCommand(["--message", "$DISMISS_MESSAGE", "hello world"])).toBe(
       '--message "$DISMISS_MESSAGE" "hello world"',
     );
+  });
+
+  it("single-quotes args with double quotes or dollar signs when possible", () => {
+    expect(renderShellCommand(["--message", 'hello "$USER"'])).toBe("--message 'hello \"$USER\"'");
+  });
+
+  it("throws for args that cannot be safely quoted", () => {
+    expect(() => renderShellCommand(["can't use $USER"])).toThrow("Unexpected character");
   });
 });

--- a/src/commands/check-status.test.mts
+++ b/src/commands/check-status.test.mts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { computeStatus } from "./check-status.mts";
+import type { CiVerdict } from "../checks/classify.mts";
+import type { MergeStatusResult } from "../types.mts";
+
+const cleanMerge: MergeStatusResult = {
+  status: "CLEAN",
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  reviewDecision: "APPROVED",
+  blockingBotReviewInProgress: false,
+  mergeStateStatus: "CLEAN",
+};
+
+const passingVerdict: CiVerdict = {
+  anyFailing: false,
+  anyInProgress: false,
+  allPassed: true,
+  hasChecks: true,
+  filteredNames: [],
+};
+
+describe("computeStatus", () => {
+  it("returns UNKNOWN for unknown merge states that have no other blockers", () => {
+    expect(computeStatus(passingVerdict, 0, 0, { ...cleanMerge, status: "UNKNOWN" }, 0)).toBe(
+      "UNKNOWN",
+    );
+  });
+
+  it("returns UNRESOLVED_COMMENTS for review work after CI and merge state are clear", () => {
+    expect(computeStatus(passingVerdict, 1, 0, cleanMerge, 0)).toBe("UNRESOLVED_COMMENTS");
+    expect(computeStatus(passingVerdict, 0, 1, cleanMerge, 0)).toBe("UNRESOLVED_COMMENTS");
+    expect(computeStatus(passingVerdict, 0, 0, cleanMerge, 1)).toBe("UNRESOLVED_COMMENTS");
+  });
+
+  it("returns UNKNOWN when clean but CI has not passed", () => {
+    expect(
+      computeStatus({ ...passingVerdict, allPassed: false, hasChecks: true }, 0, 0, cleanMerge, 0),
+    ).toBe("UNKNOWN");
+  });
+
+  it("returns READY for draft PRs when checks have passed and no review work remains", () => {
+    expect(computeStatus(passingVerdict, 0, 0, { ...cleanMerge, status: "DRAFT" }, 0)).toBe(
+      "READY",
+    );
+  });
+});

--- a/src/commands/check.mock.test.mts
+++ b/src/commands/check.mock.test.mts
@@ -645,6 +645,36 @@ describe("runCheck — reviewSummaries + approvedReviews pass-through", () => {
     expect(mockMarkSeen).not.toHaveBeenCalledWith(expect.anything(), "PRR_SUM", expect.anything());
   });
 
+  it("re-surfaces edited summaries separately and marks the updated body seen", async () => {
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([["PRR_SUM", { seenAt: 1000, bodyHash: hashBody("old overview") }]]),
+    );
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        reviewSummaries: [
+          {
+            id: "PRR_SUM",
+            author: "copilot",
+            authorType: "Unknown" as const,
+            body: "new overview",
+          },
+        ],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.editedSummaries).toEqual([
+      {
+        id: "PRR_SUM",
+        author: "copilot",
+        authorType: "Unknown" as const,
+        body: "new overview",
+      },
+    ]);
+    expect(report.firstLookSummaries).toEqual([]);
+    expect(report.reviewSummaries).toEqual([]);
+    expect(mockMarkSeen).toHaveBeenCalledWith(expect.anything(), "PRR_SUM", "new overview");
+  });
+
   it("defaults to empty arrays when batch has none", async () => {
     mockFetchPrBatch.mockResolvedValue({ data: makeBatchData() });
     const report = await runCheck(BASE_OPTS);
@@ -876,6 +906,48 @@ describe("runCheck — first-look items", () => {
     expect(report.threads.firstLook).toHaveLength(1);
     expect(report.threads.firstLook[0]?.edited).toBe(true);
     expect(report.threads.firstLook[0]?.firstLookStatus).toBe("outdated");
+  });
+
+  it("re-surfaces edited resolved and minimized threads and minimized comments", async () => {
+    const resolved = makeThread({
+      id: "t-resolved",
+      isResolved: true,
+      isOutdated: false,
+      body: "resolved new",
+    });
+    const minimizedThread = makeThread({
+      id: "t-minimized",
+      isMinimized: true,
+      body: "minimized new",
+    });
+    const minimizedComment = makeComment({
+      id: "c-minimized",
+      isMinimized: true,
+      body: "comment new",
+    });
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        reviewThreads: [resolved, minimizedThread],
+        comments: [minimizedComment],
+      }),
+    });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([
+        ["t-resolved", { seenAt: 1000, bodyHash: hashBody("resolved old") }],
+        ["t-minimized", { seenAt: 1000, bodyHash: hashBody("minimized old") }],
+        ["c-minimized", { seenAt: 1000, bodyHash: hashBody("comment old") }],
+      ]),
+    );
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.threads.firstLook.map((t) => [t.id, t.firstLookStatus, t.edited])).toEqual([
+      ["t-resolved", "resolved", true],
+      ["t-minimized", "minimized", true],
+    ]);
+    expect(report.comments.firstLook.map((c) => [c.id, c.firstLookStatus, c.edited])).toEqual([
+      ["c-minimized", "minimized", true],
+    ]);
   });
 
   it("calls markSeen for each first-look item with the item body", async () => {

--- a/src/commands/iterate.escalate.mock.test.mts
+++ b/src/commands/iterate.escalate.mock.test.mts
@@ -55,8 +55,15 @@ vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 import { runIterate } from "./iterate/index.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
+import { getCurrentPrNumber } from "../github/client.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
 import { readStallState, writeStallState } from "../state/iterate-stall.mts";
+import {
+  buildEscalateHumanMessage,
+  buildEscalateSuggestion,
+  checkEscalateTriggers,
+} from "./iterate/escalate.mts";
+import { buildRelevantChecks, buildWaitLog, getCurrentHeadSha } from "./iterate/helpers.mts";
 import type { ShepherdReport, IterateCommandOptions } from "../types.mts";
 
 // ---------------------------------------------------------------------------
@@ -65,6 +72,7 @@ import type { ShepherdReport, IterateCommandOptions } from "../types.mts";
 
 const mockRunCheck = vi.mocked(runCheck);
 const mockUpdateReadyDelay = vi.mocked(updateReadyDelay);
+const mockGetCurrentPrNumber = vi.mocked(getCurrentPrNumber);
 const mockReadFixAttempts = vi.mocked(readFixAttempts);
 const mockWriteFixAttempts = vi.mocked(writeFixAttempts);
 const mockReadStallState = vi.mocked(readStallState);
@@ -342,6 +350,169 @@ describe("runIterate — escalate (fix-thrash)", () => {
     expect(mockWriteFixAttempts).toHaveBeenCalledOnce();
     const [, written] = mockWriteFixAttempts.mock.calls[0]!;
     expect(written.threadAttempts["thread-1"]).toBe(2);
+  });
+});
+
+describe("escalate message helpers", () => {
+  it("includes ambiguous comments and fallback suggestions", () => {
+    const message = buildEscalateHumanMessage(
+      {
+        triggers: ["thread-missing-location"],
+        unresolvedThreads: [],
+        ambiguousComments: [
+          {
+            id: "c-ambiguous",
+            author: "reviewer",
+            authorType: "User",
+            body: "Please consider the whole design\nmore detail",
+            url: "",
+          },
+        ],
+        changesRequestedReviews: [],
+        suggestion: "manual",
+      },
+      42,
+    );
+
+    expect(message).toContain("comment `c-ambiguous`");
+    expect(message).toContain("Please consider the whole design");
+    expect(buildEscalateSuggestion([])).toBe("Ambiguous state — inspect the PR and act manually");
+  });
+
+  it("renders thread/review item fallbacks, thrash attempts, and singular stall wording", () => {
+    const message = buildEscalateHumanMessage(
+      {
+        triggers: ["fix-thrash"],
+        unresolvedThreads: [
+          {
+            id: "t-no-loc",
+            path: null,
+            line: null,
+            startLine: undefined,
+            author: "reviewer",
+            authorType: "User",
+            body: "Thread body\nmore detail",
+            url: "",
+          },
+        ],
+        ambiguousComments: [],
+        changesRequestedReviews: [
+          { id: "r1", author: "reviewer", authorType: "User", body: "Review body\nmore detail" },
+        ],
+        thrashHistory: [{ threadId: "t-no-loc", attempts: 3 }],
+        suggestion: "manual",
+      },
+      42,
+    );
+
+    expect(message).toContain("(no location)");
+    expect(message).toContain("review `r1`");
+    expect(message).toContain("attempted 3 times");
+    expect(buildEscalateSuggestion(["stall-timeout"], "1")).toContain("1 minute —");
+    expect(buildEscalateSuggestion(["base-branch-unknown"])).toContain("base branch");
+  });
+
+  it("uses zero attempts for missing thread attempt records", () => {
+    mockLoadConfig.mockReturnValue(defaultConfig());
+    const { triggers, thrashHistory } = checkEscalateTriggers(
+      [
+        {
+          id: "t1",
+          isResolved: false,
+          isOutdated: false,
+          isMinimized: false,
+          path: "src/a.ts",
+          line: 1,
+          startLine: null,
+          author: "reviewer",
+          authorType: "User",
+          body: "body",
+          url: "",
+          createdAtUnix: 0,
+        },
+      ],
+      [],
+      [],
+      [],
+      [],
+      {},
+      false,
+    );
+
+    expect(triggers).toEqual([]);
+    expect(thrashHistory).toBeUndefined();
+  });
+});
+
+describe("iterate helper fallbacks", () => {
+  it("returns null when current HEAD cannot be read", async () => {
+    mockExecFile.mockRejectedValueOnce(new Error("not a git repo"));
+    await expect(getCurrentHeadSha()).resolves.toBeNull();
+  });
+
+  it("covers relevant-check filtering and wait-log branches", () => {
+    const report = makeReport({
+      checks: {
+        passing: [
+          {
+            name: "skipped",
+            status: "COMPLETED",
+            conclusion: "SKIPPED",
+            detailsUrl: "",
+            event: "pull_request",
+            runId: "run-skip",
+            category: "passed",
+          },
+        ],
+        failing: [
+          {
+            name: "failed",
+            status: "COMPLETED",
+            conclusion: "FAILURE",
+            detailsUrl: "",
+            event: "pull_request",
+            runId: "run-fail",
+            category: "failing",
+            workflowName: "CI",
+            jobName: "test",
+            failedStep: "Run tests",
+            summary: "failed summary",
+          },
+        ],
+        inProgress: [],
+        skipped: [],
+        filtered: [],
+        filteredNames: [],
+        blockedByFilteredCheck: false,
+      },
+    });
+
+    expect(buildRelevantChecks(report).map((check) => check.name)).toEqual(["failed"]);
+    expect(
+      buildWaitLog({
+        pr: 42,
+        repo: "owner/repo",
+        status: "IN_PROGRESS",
+        state: "OPEN",
+        mergeStateStatus: "BEHIND",
+        mergeStatus: "BEHIND",
+        reviewDecision: null,
+        blockingBotReviewInProgress: false,
+        isDraft: false,
+        shouldCancel: false,
+        remainingSeconds: 0,
+        summary: { passing: 1, skipped: 0, filtered: 0, inProgress: 0 },
+        baseBranch: "main",
+        checks: [],
+      }),
+    ).toContain("branch is behind base");
+  });
+});
+
+describe("runIterate — no PR", () => {
+  it("throws when no PR number is passed and no current PR is found", async () => {
+    mockGetCurrentPrNumber.mockResolvedValueOnce(null);
+    await expect(runIterate({ format: "json" })).rejects.toThrow("No open PR found");
   });
 });
 

--- a/src/commands/iterate.render.mock.test.mts
+++ b/src/commands/iterate.render.mock.test.mts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,7 @@ const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
 import { runIterate } from "./iterate/index.mts";
+import { buildFixInstructions } from "./iterate/render.mts";
 import { runCheck } from "./check.mts";
 import { updateReadyDelay } from "./ready-delay.mts";
 import { readFixAttempts, writeFixAttempts } from "../state/fix-attempts.mts";
@@ -199,6 +201,47 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("buildFixInstructions", () => {
+  it("adds edited guidance for edited first-look threads", () => {
+    const instructions = buildFixInstructions(
+      [],
+      [],
+      [],
+      [],
+      "main",
+      {
+        argv: ["npx", "pr-shepherd", "resolve", "42"],
+        requiresHeadSha: false,
+        requiresDismissMessage: false,
+        hasMutations: false,
+      },
+      false,
+      42,
+      0,
+      [
+        {
+          id: "t-edited",
+          isResolved: false,
+          isOutdated: true,
+          isMinimized: false,
+          path: "src/a.ts",
+          line: 1,
+          startLine: null,
+          author: "reviewer",
+          authorType: "User",
+          body: "updated",
+          url: "",
+          createdAtUnix: 0,
+          firstLookStatus: "outdated",
+          edited: true,
+        },
+      ],
+    );
+
+    expect(instructions.join("\n")).toContain("were updated by their author");
+  });
 });
 
 describe("runIterate — prescriptive fields: log strings", () => {

--- a/src/commands/ready-mergeability.test.mts
+++ b/src/commands/ready-mergeability.test.mts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../github/client.mts", () => ({
+  getMergeableState: vi.fn(),
+}));
+
+import {
+  isBlockedByFilteredCheck,
+  refreshReadyMergeability,
+  refreshUnknownMergeability,
+} from "./ready-mergeability.mts";
+import { getMergeableState } from "../github/client.mts";
+import type { BatchPrData } from "../types.mts";
+
+const mockGetMergeableState = vi.mocked(getMergeableState);
+const REPO = { owner: "owner", name: "repo" };
+
+function makeBatch(overrides: Partial<BatchPrData> = {}): BatchPrData {
+  return {
+    nodeId: "PR_1",
+    number: 42,
+    state: "OPEN",
+    isDraft: false,
+    mergeable: "UNKNOWN",
+    mergeStateStatus: "UNKNOWN",
+    reviewDecision: "APPROVED",
+    headRefOid: "abc123",
+    headRefName: "feature",
+    headRepoWithOwner: "owner/repo",
+    baseRefName: "main",
+    reviewRequests: [],
+    latestReviews: [],
+    reviewThreads: [],
+    comments: [],
+    changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
+    checks: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("refreshUnknownMergeability", () => {
+  it("does not refresh closed PRs or PRs with known mergeability", async () => {
+    await expect(
+      refreshUnknownMergeability(42, REPO, makeBatch({ state: "CLOSED" })),
+    ).resolves.toMatchObject({ didRefresh: false });
+    await expect(
+      refreshUnknownMergeability(
+        42,
+        REPO,
+        makeBatch({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }),
+      ),
+    ).resolves.toMatchObject({ didRefresh: false });
+    expect(mockGetMergeableState).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshReadyMergeability", () => {
+  it("falls back to existing mergeability fields when REST returns nulls", async () => {
+    const batch = makeBatch({
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "APPROVED",
+      checks: [
+        {
+          name: "ci",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          detailsUrl: "",
+          event: "pull_request",
+          runId: null,
+        },
+      ],
+    });
+    mockGetMergeableState.mockResolvedValue({
+      mergeable: null as unknown as "MERGEABLE",
+      mergeStateStatus: null as unknown as "CLEAN",
+    });
+
+    const refreshed = await refreshReadyMergeability(
+      42,
+      REPO,
+      batch,
+      {
+        allPassed: true,
+        anyFailing: false,
+        anyInProgress: false,
+        hasChecks: true,
+        filteredNames: [],
+      },
+      0,
+      0,
+    );
+
+    expect(refreshed.batchData.mergeable).toBe("MERGEABLE");
+    expect(refreshed.batchData.mergeStateStatus).toBe("CLEAN");
+    expect(refreshed.status).toBe("READY");
+  });
+});
+
+describe("isBlockedByFilteredCheck", () => {
+  it("requires BLOCKED merge state, no failing/running checks, and at least one filtered check", () => {
+    const mergeStatus = {
+      status: "BLOCKED" as const,
+      state: "OPEN" as const,
+      isDraft: false,
+      mergeable: "MERGEABLE" as const,
+      reviewDecision: "APPROVED" as const,
+      blockingBotReviewInProgress: false,
+      mergeStateStatus: "BLOCKED" as const,
+    };
+
+    expect(
+      isBlockedByFilteredCheck(mergeStatus, {
+        allPassed: true,
+        anyFailing: false,
+        anyInProgress: false,
+        hasChecks: true,
+        filteredNames: ["ci / push"],
+      }),
+    ).toBe(true);
+    expect(
+      isBlockedByFilteredCheck(mergeStatus, {
+        allPassed: false,
+        anyFailing: true,
+        anyInProgress: false,
+        hasChecks: true,
+        filteredNames: ["ci / push"],
+      }),
+    ).toBe(false);
+    expect(
+      isBlockedByFilteredCheck(mergeStatus, {
+        allPassed: false,
+        anyFailing: false,
+        anyInProgress: true,
+        hasChecks: true,
+        filteredNames: ["ci / push"],
+      }),
+    ).toBe(false);
+    expect(
+      isBlockedByFilteredCheck(
+        { ...mergeStatus, status: "CLEAN" },
+        {
+          allPassed: true,
+          anyFailing: false,
+          anyInProgress: false,
+          hasChecks: true,
+          filteredNames: ["ci / push"],
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/commands/resolve.mock.test.mts
+++ b/src/commands/resolve.mock.test.mts
@@ -276,6 +276,70 @@ describe("runResolveFetch — auto-resolves outdated threads", () => {
     expect(result.commitSuggestionsEnabled).toBe(true);
   });
 
+  it("re-surfaces edited outdated threads and edited minimized comments", async () => {
+    const outdated = makeThread({
+      id: "t-edited-outdated",
+      isOutdated: true,
+      isResolved: false,
+      body: "new outdated body",
+    });
+    const minimizedComment = makeComment({
+      id: "c-edited-min",
+      isMinimized: true,
+      body: "new minimized body",
+    });
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ reviewThreads: [outdated], comments: [minimizedComment] }),
+    });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([
+        ["t-edited-outdated", { seenAt: 1, bodyHash: hashBody("old outdated body") }],
+        ["c-edited-min", { seenAt: 1, bodyHash: hashBody("old minimized body") }],
+      ]),
+    );
+
+    const result = await runResolveFetch(BASE_OPTS);
+
+    expect(result.firstLookThreads).toMatchObject([
+      { id: "t-edited-outdated", firstLookStatus: "outdated", edited: true },
+    ]);
+    expect(result.firstLookComments).toMatchObject([
+      { id: "c-edited-min", firstLookStatus: "minimized", edited: true },
+    ]);
+  });
+
+  it("re-surfaces edited resolved and minimized threads", async () => {
+    const resolved = makeThread({
+      id: "t-edited-resolved",
+      isResolved: true,
+      isOutdated: false,
+      body: "new resolved body",
+    });
+    const minimized = makeThread({
+      id: "t-edited-min",
+      isResolved: false,
+      isOutdated: false,
+      isMinimized: true,
+      body: "new minimized body",
+    });
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ reviewThreads: [resolved, minimized] }),
+    });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([
+        ["t-edited-resolved", { seenAt: 1, bodyHash: hashBody("old resolved body") }],
+        ["t-edited-min", { seenAt: 1, bodyHash: hashBody("old minimized body") }],
+      ]),
+    );
+
+    const result = await runResolveFetch(BASE_OPTS);
+
+    expect(result.firstLookThreads).toMatchObject([
+      { id: "t-edited-resolved", firstLookStatus: "resolved", edited: true },
+      { id: "t-edited-min", firstLookStatus: "minimized", edited: true },
+    ]);
+  });
+
   it("actionableComments excludes minimized comments", async () => {
     const visible = makeComment({ id: "c-visible", isMinimized: false });
     const minimized = makeComment({ id: "c-min", isMinimized: true });
@@ -650,5 +714,37 @@ describe("runResolveFetch — first-look items", () => {
     const result = await runResolveFetch(BASE_OPTS);
     expect(result.firstLookThreads).toHaveLength(0);
     expect(mockMarkSeen).toHaveBeenCalledWith(expect.any(Object), "c-min", "nit");
+  });
+
+  it("suppresses unchanged resolved/minimized threads and minimized comments", async () => {
+    const resolved = makeThread({ id: "t-resolved", isResolved: true, body: "resolved" });
+    const minimizedThread = makeThread({
+      id: "t-minimized",
+      isMinimized: true,
+      body: "minimized thread",
+    });
+    const minimizedComment = makeComment({
+      id: "c-minimized",
+      isMinimized: true,
+      body: "minimized comment",
+    });
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        reviewThreads: [resolved, minimizedThread],
+        comments: [minimizedComment],
+      }),
+    });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([
+        ["t-resolved", { seenAt: 1000, bodyHash: hashBody("resolved") }],
+        ["t-minimized", { seenAt: 1000, bodyHash: hashBody("minimized thread") }],
+        ["c-minimized", { seenAt: 1000, bodyHash: hashBody("minimized comment") }],
+      ]),
+    );
+
+    const result = await runResolveFetch(BASE_OPTS);
+
+    expect(result.firstLookThreads).toEqual([]);
+    expect(result.firstLookComments).toEqual([]);
   });
 });

--- a/src/comments/minimize-policy.test.mts
+++ b/src/comments/minimize-policy.test.mts
@@ -3,6 +3,18 @@ import { describe, expect, it } from "vitest";
 import { shouldMinimizeAuthor } from "./minimize-policy.mts";
 
 describe("shouldMinimizeAuthor", () => {
+  it.each([
+    [undefined, "Unknown", true],
+    ["all", "User", true],
+    ["bots", "Bot", true],
+    ["bots", "User", false],
+    ["users", "User", true],
+    ["users", "Bot", false],
+    ["none", "Bot", false],
+  ] as const)("policy %s author %s -> %s", (policy, authorType, expected) => {
+    expect(shouldMinimizeAuthor(authorType, policy)).toBe(expected);
+  });
+
   it("throws for invalid runtime policies", () => {
     expect(() => shouldMinimizeAuthor("Bot", "bot" as never)).toThrow(
       "Invalid minimizeComments policy: bot",

--- a/src/comments/resolve.mock.test.mts
+++ b/src/comments/resolve.mock.test.mts
@@ -45,6 +45,17 @@ describe("applyResolveOptions — validation", () => {
       "--message is required",
     );
   });
+
+  it("does nothing when no mutation IDs are provided", async () => {
+    const result = await applyResolveOptions(1, REPO, {});
+    expect(result).toEqual({
+      resolvedThreads: [],
+      minimizedComments: [],
+      dismissedReviews: [],
+      errors: [],
+    });
+    expect(mockGraphql).not.toHaveBeenCalled();
+  });
 });
 
 describe("applyResolveOptions — mutations", () => {

--- a/src/config/load.test.mts
+++ b/src/config/load.test.mts
@@ -90,6 +90,15 @@ describe("loadConfig — no rc file", () => {
     expect(output).toContain("iterate.minimizeComments");
   });
 
+  it("rejects invalid cli config shapes and falls back to defaults", async () => {
+    writeFileSync(join(tmpDir, RC), "cli: null\n");
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const loadConfig = await freshLoadConfig();
+    const result = loadConfig();
+    expect(result.cli?.runner).toBe("auto");
+    expect(stderrSpy.mock.calls.map((c) => c[0]).join("")).toContain("cli must be a plain object");
+  });
+
   it("returns defaults for empty YAML (yaml.parse returns null)", async () => {
     writeFileSync(join(tmpDir, RC), "");
     const loadConfig = await freshLoadConfig();

--- a/src/github/batch.mock.test.mts
+++ b/src/github/batch.mock.test.mts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("./client.mts", () => ({
@@ -439,6 +440,55 @@ describe("fetchPrBatch — checks pagination", () => {
     mockGraphql.mockResolvedValue(makeResponse(nullRollupPage));
 
     await expect(fetchPrBatch(42, REPO)).rejects.toThrow("Check-context pagination interrupted");
+  });
+
+  it("throws when check pagination sees a different head commit", async () => {
+    const makeCheckNode = (name: string) => ({
+      __typename: "CheckRun",
+      name,
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      detailsUrl: null,
+      checkSuite: null,
+    });
+    const firstPage = makeRawPr({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              oid: "old-sha",
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: { hasNextPage: true, endCursor: "cursor-ch1" },
+                  nodes: [makeCheckNode("check-1")],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const nextPage = makeRawPr({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              oid: "new-sha",
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [makeCheckNode("check-2")],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(firstPage));
+    mockGraphql.mockResolvedValue(makeResponse(nextPage));
+
+    await expect(fetchPrBatch(42, REPO)).rejects.toThrow("head commit changed");
   });
 });
 

--- a/src/github/client.mock.test.mts
+++ b/src/github/client.mock.test.mts
@@ -198,6 +198,14 @@ describe("getRepoInfo — remote URL parsing", () => {
     });
     expect(await getRepoInfo()).toEqual({ owner: "owner", name: "repo" });
   });
+
+  it("throws for unsupported remote URL shapes", async () => {
+    mockExecFile.mockResolvedValue({
+      stdout: "https://github.com/owner/repo/extra.git\n",
+      stderr: "",
+    });
+    await expect(getRepoInfo()).rejects.toThrow("Cannot parse GitHub remote URL");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/github/http.mock.test.mts
+++ b/src/github/http.mock.test.mts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -171,6 +172,17 @@ describe("graphql — error handling", () => {
     await expect(graphql("{ q }")).rejects.toThrow(/bad field/);
   });
 
+  it("throws on a GraphQL null data payload without errors", async () => {
+    process.env["GH_TOKEN"] = "tok";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: () => Promise.resolve({ data: null }),
+    });
+    await expect(graphql("{ q }")).rejects.toThrow(/GitHub GraphQL error \(no data\)/);
+  });
+
   it("succeeds and logs to stderr when data is present but errors[] is non-empty", async () => {
     process.env["GH_TOKEN"] = "tok";
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -300,6 +312,17 @@ describe("graphqlWithRateLimit — header parsing", () => {
     const result = await graphqlWithRateLimit("{ q }");
     expect(result.rateLimit).toBeUndefined();
   });
+
+  it("ignores invalid retry-after values", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "retry-after": "-1" }),
+      json: () => Promise.resolve({ data: {} }),
+    });
+    const result = await graphqlWithRateLimit("{ q }");
+    expect(result.retryAfterSeconds).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -340,6 +363,13 @@ describe("rest", () => {
     );
   });
 
+  it("sends a JSON request body when provided", async () => {
+    mockFetch.mockResolvedValue(jsonOk({ ok: true }));
+    await rest("POST", "/repos/o/r/dispatches", { event_type: "test" });
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBe(JSON.stringify({ event_type: "test" }));
+  });
+
   it("retries rest on 401 and succeeds after token refresh", async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -352,6 +382,25 @@ describe("rest", () => {
     const result = await rest<{ merged: boolean }>("PUT", "/repos/o/r/pulls/1/merge");
     expect(result).toEqual({ merged: true });
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("records retry attempt metadata when a retried rest request still fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        text: () => Promise.resolve("Unauthorized"),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        text: () => Promise.resolve("server error"),
+      });
+
+    await expect(rest("GET", "/repos/o/r")).rejects.toThrow(/500/);
   });
 });
 
@@ -393,6 +442,43 @@ describe("restText — redirect handling", () => {
     expect(text).toBe("direct log content");
   });
 
+  it("handles direct text responses with invalid content-length", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "not-a-number" }),
+      text: () => Promise.resolve("direct log content"),
+    });
+    await expect(restText("/repos/o/r/actions/jobs/1/logs")).resolves.toBe("direct log content");
+  });
+
+  it("handles redirect target responses with valid content-length", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: "https://storage.example.com/logs/job-1.txt" }),
+        text: () => Promise.resolve(""),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-length": "11" }),
+        text: () => Promise.resolve("hello world"),
+      });
+    await expect(restText("/repos/o/r/actions/jobs/1/logs")).resolves.toBe("hello world");
+  });
+
+  it("falls through redirects with no location and throws the original response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 302,
+      headers: new Headers(),
+      text: () => Promise.resolve("missing location"),
+    });
+    await expect(restText("/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(/failed: 302/);
+  });
+
   it("throws when redirect target returns non-2xx", async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -410,6 +496,18 @@ describe("restText — redirect handling", () => {
     await expect(restText("/repos/o/r/actions/jobs/1/logs")).rejects.toThrow(
       /redirect target.*failed: 403/,
     );
+  });
+
+  it("logs and attempts invalid redirect locations without URL parsing", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 302,
+      headers: new Headers({ location: "%%%" }),
+      text: () => Promise.resolve(""),
+    });
+    mockFetch.mockRejectedValueOnce(new TypeError("Invalid URL"));
+
+    await expect(restText("/repos/o/r/actions/jobs/1/logs")).rejects.toThrow("Invalid URL");
   });
 
   it("throws on non-2xx non-redirect responses", async () => {

--- a/src/index.mock.test.mts
+++ b/src/index.mock.test.mts
@@ -55,6 +55,26 @@ describe("index — error exit", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
+  it("formats non-Error causes", async () => {
+    const err = new Error("outer");
+    err.cause = "plain cause";
+    mockMain.mockRejectedValueOnce(err);
+    await loadIndex();
+    expect(stderrSpy.mock.calls[0][0]).toBe("pr-shepherd error: outer (cause: plain cause)\n");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("falls back to the cause message when an Error has no stack", async () => {
+    const cause = new Error("stackless cause");
+    cause.stack = undefined;
+    const err = new Error("outer");
+    err.cause = cause;
+    mockMain.mockRejectedValueOnce(err);
+    await loadIndex();
+    expect(stderrSpy.mock.calls[0][0]).toContain("(cause: stackless cause)");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
   it("does not recurse infinitely for circular cause chains", async () => {
     const err = new Error("outer");
     err.cause = err;

--- a/src/log/setup.test.mts
+++ b/src/log/setup.test.mts
@@ -1,23 +1,137 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetRepoInfo, mockInitLog, mockAppendEntry, mockBuildSessionHeader, mockFormatOutput } =
+  vi.hoisted(() => ({
+    mockGetRepoInfo: vi.fn(),
+    mockInitLog: vi.fn(),
+    mockAppendEntry: vi.fn(),
+    mockBuildSessionHeader: vi.fn(),
+    mockFormatOutput: vi.fn(),
+  }));
 
 vi.mock("../github/client.mts", () => ({
-  getRepoInfo: vi.fn().mockRejectedValue(new Error("not in a git repo")),
+  getRepoInfo: mockGetRepoInfo,
 }));
 
 vi.mock("./log-file.mts", () => ({
-  initLog: vi.fn().mockResolvedValue(null),
-  appendEntry: vi.fn(),
+  initLog: mockInitLog,
+  appendEntry: mockAppendEntry,
 }));
 
 vi.mock("./session.mts", () => ({
-  buildSessionHeader: vi.fn().mockReturnValue({ markdown: "## header\n" }),
-  formatOutputEntry: vi.fn().mockReturnValue("### Output\n"),
+  buildSessionHeader: mockBuildSessionHeader,
+  formatOutputEntry: mockFormatOutput,
 }));
+
+let originalWrite: typeof process.stdout.write;
+
+async function freshSetupLog() {
+  vi.resetModules();
+  const mod = await import("./setup.mts");
+  return mod.setupLog;
+}
+
+beforeEach(() => {
+  originalWrite = process.stdout.write;
+  mockGetRepoInfo.mockReset().mockResolvedValue({ owner: "acme", name: "widgets" });
+  mockInitLog.mockReset().mockResolvedValue({ path: "/tmp/shepherd.md" });
+  mockAppendEntry.mockReset();
+  mockBuildSessionHeader.mockReset().mockReturnValue({ markdown: "## header\n" });
+  mockFormatOutput.mockReset().mockReturnValue("### Output\n");
+});
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+});
 
 describe("setupLog", () => {
   it("returns without throwing when getRepoInfo fails", async () => {
-    vi.resetModules();
-    const { setupLog } = await import("./setup.mts");
+    mockGetRepoInfo.mockRejectedValueOnce(new Error("not in a git repo"));
+    const setupLog = await freshSetupLog();
+
+    await expect(setupLog(["node", "bin/index.mjs", "check"])).resolves.toBeUndefined();
+
+    expect(mockInitLog).not.toHaveBeenCalled();
+  });
+
+  it("returns without installing stdout tee when initLog returns null", async () => {
+    mockInitLog.mockResolvedValueOnce(null);
+    const setupLog = await freshSetupLog();
+
+    await setupLog(["node", "bin/index.mjs", "check"]);
+
+    expect(process.stdout.write).toBe(originalWrite);
+    expect(mockAppendEntry).not.toHaveBeenCalled();
+  });
+
+  it("writes the session header and tees text output", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    originalWrite = writeSpy as unknown as typeof process.stdout.write;
+    const setupLog = await freshSetupLog();
+
+    await setupLog(["node", "bin/index.mjs", "check", "--format", "json"]);
+    process.stdout.write("hello");
+
+    expect(mockBuildSessionHeader).toHaveBeenCalledWith([
+      "node",
+      "bin/index.mjs",
+      "check",
+      "--format",
+      "json",
+    ]);
+    expect(mockFormatOutput).toHaveBeenCalledWith("hello", "json");
+    expect(mockAppendEntry).toHaveBeenCalledWith("## header\n");
+    expect(mockAppendEntry).toHaveBeenCalledWith("### Output\n");
+    expect(writeSpy).toHaveBeenCalledWith("hello", undefined, undefined);
+  });
+
+  it("detects inline JSON format and converts Uint8Array chunks", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    originalWrite = writeSpy as unknown as typeof process.stdout.write;
+    const setupLog = await freshSetupLog();
+
+    await setupLog(["node", "bin/index.mjs", "check", "--format=json"]);
+    process.stdout.write(Buffer.from("hello"));
+
+    expect(mockFormatOutput).toHaveBeenCalledWith("hello", "json");
+  });
+
+  it("does not append empty output and ignores append errors", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    originalWrite = writeSpy as unknown as typeof process.stdout.write;
+    mockAppendEntry
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error("disk full");
+      });
+    const setupLog = await freshSetupLog();
+
+    await setupLog(["node", "bin/index.mjs", "check"]);
+    process.stdout.write("");
+    process.stdout.write("visible", () => undefined);
+
+    expect(mockFormatOutput).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith("", undefined, undefined);
+    expect(writeSpy).toHaveBeenCalledWith("visible", expect.any(Function));
+  });
+
+  it("is a no-op after the first successful call", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    originalWrite = writeSpy as unknown as typeof process.stdout.write;
+    const setupLog = await freshSetupLog();
+
+    await setupLog(["node", "bin/index.mjs", "check"]);
+    await setupLog(["node", "bin/index.mjs", "check"]);
+
+    expect(mockGetRepoInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows errors while installing the stdout tee", async () => {
+    mockBuildSessionHeader.mockImplementationOnce(() => {
+      throw new Error("header failed");
+    });
+    const setupLog = await freshSetupLog();
+
     await expect(setupLog(["node", "bin/index.mjs", "check"])).resolves.toBeUndefined();
   });
 });

--- a/src/reporters/agent.test.mts
+++ b/src/reporters/agent.test.mts
@@ -134,6 +134,15 @@ describe("toAgentCheck", () => {
     expect(result.conclusion).toBe("CANCELLED");
   });
 
+  it("rejects skipped and neutral checks before projecting to agent output", () => {
+    expect(() => toAgentCheck({ ...makeCheck("run-1"), conclusion: "SKIPPED" })).toThrow(
+      "Unexpected conclusion SKIPPED",
+    );
+    expect(() => toAgentCheck({ ...makeCheck("run-2"), conclusion: "NEUTRAL" })).toThrow(
+      "Unexpected conclusion NEUTRAL",
+    );
+  });
+
   it("includes detailsUrl when runId is null", () => {
     const result = toAgentCheck(makeCheck(null, "external-check"));
     expect(result.runId).toBeNull();

--- a/src/suggestions/parse.test.mts
+++ b/src/suggestions/parse.test.mts
@@ -70,6 +70,16 @@ describe("parseSuggestion", () => {
     expect(parseSuggestion(body)).toEqual({ lines: ["foo"] });
   });
 
+  it("returns null when inline-close fallback cannot match the final line", () => {
+    const body = "```suggestion\nfoo";
+    expect(parseSuggestion(body)).toBeNull();
+  });
+
+  it("preserves unprefixed lines inside a quoted block", () => {
+    const body = ["> ```suggestion", "> prefixed", "not prefixed", "> ```"].join("\n");
+    expect(parseSuggestion(body)).toEqual({ lines: ["prefixed", "not prefixed"] });
+  });
+
   it("preserves a nested ```suggestion substring in the body content (issue #68)", () => {
     // The old regex stopped at the inner ``` and silently truncated the body.
     // The new line-based parser treats mid-line ``` as content, not a closer.

--- a/src/suggestions/patch.test.mts
+++ b/src/suggestions/patch.test.mts
@@ -157,6 +157,21 @@ describe("buildUnifiedDiff", () => {
     expect(patch).toContain("\\ No newline at end of file\n");
   });
 
+  it("emits no-newline marker when the last line appears in before-context", () => {
+    const content = "a\nb";
+    const patch = buildUnifiedDiff({
+      path: "f.ts",
+      originalContent: content,
+      startLine: 3,
+      endLine: 2,
+      replacementLines: ["c"],
+      context: 1,
+    });
+    expect(patch).toContain(" b\n");
+    expect(patch).toContain("\\ No newline at end of file\n");
+    expect(patch).toContain("+c\n");
+  });
+
   it("emits no-newline marker for after-context lines when last line is in after-context", () => {
     // File has no trailing newline; last line falls in the after-context of the hunk
     const content = "a\nb\nc"; // 3 lines, no trailing newline

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,7 +9,15 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       include: ['src/**/*.mts'],
-      exclude: ['src/**/*.{test,mock.test}.mts'],
+      exclude: [
+        'src/**/*.{test,mock.test}.mts',
+        'src/types.mts',
+        'src/types/**/*.mts',
+        'src/github/batch-raw-types.mts',
+      ],
+      thresholds: {
+        lines: 100,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- Require 100% project and patch coverage in Codecov with zero threshold.
- Enforce 100% line coverage locally through Vitest coverage thresholds.
- Add targeted tests across CLI, formatter, iterate, GitHub, config, logging, reporter, comment, and suggestion paths so the local coverage gate passes.
- Strip branch records from the uploaded LCOV after Vitest so Codecov project coverage reflects the enforced whole-project line coverage metric.

## Validation
- npm run test:coverage
- rg ^BR coverage/lcov.info (no matches)
- npm run typecheck
- npm run lint
- npm run format:check

## Notes
- Type-only modules are excluded from coverage instrumentation so the uploaded project coverage reflects executable code.

## Shepherd Journal
- Rejected [PRRT_kwDOSGizTs6B4xIp](https://github.com/jonathanong/pr-shepherd/pull/200#discussion_r3237352599): the requested project target of `auto` conflicts with the explicit requirement for whole-project coverage to be 100%. This PR keeps `codecov/project` at `target: 100%` and aligns the uploaded LCOV with the enforced line-coverage metric.
