### PR TITLE
Clarify escalate manual handoff for fix-thrash

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -403,7 +403,7 @@ Ambiguous state that requires human judgement — iteration stops and surfaces d
 
 **Triggers:** `fix-thrash`
 
-Same thread(s) reached the automated attempt limit — treat this as a manual handoff. Apply the fix by hand, then rerun /pr-shepherd:pr-shepherd.
+Same thread(s) reached the automated attempt limit — treat this as a manual handoff. Apply the fix by hand.
 
 ## Items needing attention
 
@@ -419,7 +419,7 @@ After completing manual fixes (and pushing if required), rerun `/pr-shepherd:pr-
 
 ## Instructions
 
-1. Stop — the PR needs human direction before iterating can resume.
+1. Stop — the PR needs human direction before iterating can resume. This is a manual handoff; do not continue automated fix attempts.
 ```
 
 The block after the base-fields line (separated by a blank line) is `escalate.humanMessage` in JSON — ready to print verbatim.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -382,7 +382,7 @@ Ambiguous state that requires human judgement — iteration stops and surfaces d
 **Trigger:** Any of:
 
 - **`stall-timeout`** — the iterate result has not materially changed for `config.iterate.stallTimeoutMinutes` minutes (default 30). Catches loops where the same failing test, transient error, or pending state repeats indefinitely without progress. The timer resets whenever the HEAD SHA, failing-check set, or actionable item IDs change. Override with `--stall-timeout <duration>` (e.g. `--stall-timeout 1h`).
-- **`fix-thrash`** — same thread dispatched ≥ `config.iterate.fixAttemptsPerThread` times (default 3) without resolving.
+- **`fix-thrash`** — same thread dispatched ≥ `config.iterate.fixAttemptsPerThread` times (default 3) without resolving. This is a manual handoff: automated fixes pause.
 - **`pr-level-changes-requested`** — reviewer requested changes but left no inline threads, comments, or CI failures to act on (not triggered when merge conflicts are present).
 - **`thread-missing-location`** — an actionable review thread has no file or line reference, so the code location cannot be found automatically.
 - **`base-branch-unknown`** — the GraphQL batch did not yield a usable base branch name: the derived value was empty or contained unsafe characters. Preempts any `[FIX_CODE]` that would require a push, since rebasing onto the wrong base is worse than pausing iteration.
@@ -399,11 +399,11 @@ Ambiguous state that requires human judgement — iteration stops and surfaces d
 **status** `UNRESOLVED_COMMENTS` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
 **summary** 0 passing
 
-⚠️ /pr-shepherd:pr-shepherd paused — needs human direction
+⚠️ /pr-shepherd:pr-shepherd paused — manual intervention required
 
 **Triggers:** `fix-thrash`
 
-Same thread(s) attempted multiple times without resolution — fix manually then rerun /pr-shepherd:pr-shepherd
+Same thread(s) reached the automated attempt limit — treat this as a manual handoff. Apply the fix by hand, then rerun /pr-shepherd:pr-shepherd.
 
 ## Items needing attention
 
@@ -415,7 +415,7 @@ Same thread(s) attempted multiple times without resolution — fix manually then
 
 ---
 
-After fixing manually, rerun `/pr-shepherd:pr-shepherd 42` to resume.
+After completing manual fixes (and pushing if required), rerun `/pr-shepherd:pr-shepherd 42` to resume.
 
 ## Instructions
 

--- a/src/cli-parser.iterate-fixtures.mts
+++ b/src/cli-parser.iterate-fixtures.mts
@@ -65,7 +65,7 @@ export function makeIterateResult(action: IterateResult["action"] = "wait"): Ite
         ambiguousComments: [],
         changesRequestedReviews: [],
         suggestion: "check manually",
-        humanMessage: "⚠️ /pr-shepherd:pr-shepherd paused — needs human direction",
+        humanMessage: "⚠️ /pr-shepherd:pr-shepherd paused — manual intervention required",
       },
     };
   }

--- a/src/cli-parser.iterate.main-iterate-text-format.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate-text-format.mock.test.mts
@@ -44,7 +44,7 @@ describe("main — iterate text format", () => {
     const out = getStdout();
     expect(out).toMatch(/^# PR #42 \[ESCALATE\]\n/);
     expect(out).toContain("**status** `IN_PROGRESS`");
-    expect(out).toContain("⚠️ /pr-shepherd:pr-shepherd paused — needs human direction");
+    expect(out).toContain("⚠️ /pr-shepherd:pr-shepherd paused — manual intervention required");
     expect(out).toContain("## Instructions");
     expect(out).toContain("1. Stop — the PR needs human direction before iterating can resume.");
   });

--- a/src/cli-parser.iterate.main-iterate-text-format.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate-text-format.mock.test.mts
@@ -46,7 +46,9 @@ describe("main — iterate text format", () => {
     expect(out).toContain("**status** `IN_PROGRESS`");
     expect(out).toContain("⚠️ /pr-shepherd:pr-shepherd paused — manual intervention required");
     expect(out).toContain("## Instructions");
-    expect(out).toContain("1. Stop — the PR needs human direction before iterating can resume.");
+    expect(out).toContain(
+      "1. Stop — the PR needs human direction before iterating can resume. This is a manual handoff; do not continue automated fix attempts.",
+    );
   });
   it("wait: instructions use Claude one-shot scheduling wording with rerun command", async () => {
     const result = makeIterateResult("wait");
@@ -84,7 +86,9 @@ describe("main — iterate text format", () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("escalate"));
     await main(["node", "shepherd", "iterate", "42"]);
     const out = getStdout();
-    expect(out).toContain("1. Stop — the PR needs human direction before iterating can resume.");
+    expect(out).toContain(
+      "1. Stop — the PR needs human direction before iterating can resume. This is a manual handoff; do not continue automated fix attempts.",
+    );
     expect(out).not.toContain("CronList");
   });
   it("## Checks section is absent when checks is empty", async () => {

--- a/src/cli/iterate-instructions.mts
+++ b/src/cli/iterate-instructions.mts
@@ -34,7 +34,9 @@ export function buildSimpleIterateInstructions(
     case "cancel":
       return ["Stop — the active goal is complete."];
     case "escalate":
-      return ["Stop — the PR needs human direction before iterating can resume."];
+      return [
+        "Stop — the PR needs human direction before iterating can resume. This is a manual handoff; do not continue automated fix attempts.",
+      ];
   }
 }
 

--- a/src/commands/iterate.escalate.escalate-message-helpers.mock.test.mts
+++ b/src/commands/iterate.escalate.escalate-message-helpers.mock.test.mts
@@ -64,7 +64,9 @@ describe("escalate message helpers", () => {
 
     expect(message).toContain("comment `c-ambiguous`");
     expect(message).toContain("Please consider the whole design");
-    expect(buildEscalateSuggestion([])).toBe("Ambiguous state — inspect the PR and act manually");
+    expect(buildEscalateSuggestion([])).toBe(
+      "Ambiguous state — automated handling cannot proceed safely. Inspect the PR and act manually.",
+    );
   });
 
   it("renders thread/review item fallbacks, thrash attempts, and singular stall wording", () => {

--- a/src/commands/iterate/escalate.mts
+++ b/src/commands/iterate/escalate.mts
@@ -153,7 +153,7 @@ export function buildEscalateSuggestion(triggers: EscalateTrigger[], detail?: st
     return `Could not determine the PR's base branch${reason} — automated rebases are paused because branch safety is unclear. Run the rebase manually against the PR's real target branch.`;
   }
   if (triggers.includes("fix-thrash")) {
-    return "Same thread(s) reached the automated attempt limit — treat this as a manual handoff. Apply the fix by hand, then rerun /pr-shepherd:pr-shepherd.";
+    return "Same thread(s) reached the automated attempt limit — treat this as a manual handoff. Apply the fix by hand.";
   }
   if (triggers.includes("pr-level-changes-requested")) {
     return "Reviewer requested changes but left no inline comments — read the review and act manually.";

--- a/src/commands/iterate/escalate.mts
+++ b/src/commands/iterate/escalate.mts
@@ -98,7 +98,7 @@ export function buildEscalateHumanMessage(
   pr: number,
 ): string {
   const lines: string[] = [];
-  lines.push("⚠️ /pr-shepherd:pr-shepherd paused — needs human direction");
+  lines.push("⚠️ /pr-shepherd:pr-shepherd paused — manual intervention required");
   lines.push("");
   lines.push(`**Triggers:** ${escalate.triggers.map((t) => `\`${t}\``).join(", ")}`);
   lines.push("");
@@ -137,27 +137,29 @@ export function buildEscalateHumanMessage(
   lines.push("");
   lines.push("---");
   lines.push("");
-  lines.push(`After fixing manually, rerun \`/pr-shepherd:pr-shepherd ${pr}\` to resume.`);
+  lines.push(
+    `After completing manual fixes (and pushing if required), rerun \`/pr-shepherd:pr-shepherd ${pr}\` to resume.`,
+  );
   return lines.join("\n");
 }
 
 export function buildEscalateSuggestion(triggers: EscalateTrigger[], detail?: string): string {
   if (triggers.includes("stall-timeout")) {
     const mins = detail ?? "30";
-    return `No progress detected for ${mins} minute${parseInt(mins, 10) === 1 ? "" : "s"} — state has not changed. Inspect the PR and resume manually once the blocking issue is resolved.`;
+    return `No progress detected for ${mins} minute${parseInt(mins, 10) === 1 ? "" : "s"} — state has not changed. This is a manual checkpoint: inspect the PR and apply a manual fix before resuming.`;
   }
   if (triggers.includes("base-branch-unknown")) {
     const reason = detail ? ` (${detail})` : "";
-    return `Could not determine the PR's base branch${reason} — refusing to emit a rebase that could force-push onto the wrong base. Run the rebase manually against the PR's real target branch.`;
+    return `Could not determine the PR's base branch${reason} — automated rebases are paused because branch safety is unclear. Run the rebase manually against the PR's real target branch.`;
   }
   if (triggers.includes("fix-thrash")) {
-    return "Same thread(s) attempted multiple times without resolution — fix manually then rerun /pr-shepherd:pr-shepherd";
+    return "Same thread(s) reached the automated attempt limit — treat this as a manual handoff. Apply the fix by hand, then rerun /pr-shepherd:pr-shepherd.";
   }
   if (triggers.includes("pr-level-changes-requested")) {
-    return "Reviewer requested changes but left no inline comments — read the review and act manually";
+    return "Reviewer requested changes but left no inline comments — read the review and act manually.";
   }
   if (triggers.includes("thread-missing-location")) {
-    return "Review thread has no file/line reference — cannot locate code to edit automatically";
+    return "Review thread has no file/line reference — automated location routing failed and manual handling is required.";
   }
-  return "Ambiguous state — inspect the PR and act manually";
+  return "Ambiguous state — automated handling cannot proceed safely. Inspect the PR and act manually.";
 }


### PR DESCRIPTION
## Summary

- Clarify \/pr-shepherd escalate output and instructions for /manual handoffs.
- Make explicit that escalations require manual fixes and no further automated attempts.
- Keep output + docs aligned and update tests/fixtures that assert prompt text.

## Verification
- Updated escalate suggestion text and human-message text.
- Updated instructions output copy.
- Updated related tests and fixtures for message assertions.
- / checks passed on pre-push hook.
