### PR TITLE
Add pr-shepherd poll command + flexible skill strategies (#219, #220)

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -8,7 +8,7 @@ The default output format is Markdown — what you see when running `pr-shepherd
 
 Instruction wording is runtime-specific. Claude-compatible output schedules exactly one next session-only iteration after a fresh delay between 30 seconds and 4 minutes, then ends the turn. Codex-compatible output sleeps inline for that delay, then reruns the configured pr-shepherd command. The action data and section structure are otherwise the same.
 
-Non-terminal outputs are single-shot by design: do not run `while true`/polling loops, and do not reschedule more than one follow-up per tick.
+Three iteration strategies are valid: (a) inline sleep + rerun (Codex default); (b) scheduled session-only follow-up (Claude default); (c) the blocking `pr-shepherd poll` command, which loops with `--interval`/`--timeout` until a non-WAIT action appears. Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 
 Command examples use the default npm spelling (`npx pr-shepherd`). Repos can set `cli.runner` to `auto`, `npx`, `pnpm`, `yarn`, or `bun`; generated text and JSON argv then use the selected runner (for example `pnpm exec pr-shepherd`, `yarn run pr-shepherd`, or `bunx pr-shepherd`) everywhere a pr-shepherd follow-up command is emitted.
 
@@ -79,7 +79,7 @@ When the current command includes a ready-delay override, the rerun command pres
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
-**What the skill does:** Follow `## Instructions`. For the Claude-compatible output shown above, schedule exactly one next session-only iteration and end the turn; Codex-compatible output sleeps inline and reruns the same command. Do not convert this into a polling loop.
+**What the skill does:** Follow `## Instructions`. For the Claude-compatible output shown above, schedule exactly one next session-only iteration and end the turn; Codex-compatible output sleeps inline and reruns the same command. Alternatively, run `<runner> pr-shepherd poll <N>` to block until the action is non-WAIT (bounded by `--timeout`).
 
 ---
 
@@ -108,7 +108,7 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review. Single-shot continuation: schedule one session-only follow-up task to run `npx pr-shepherd 42` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
 ```
 
-**What the skill does:** Follow `## Instructions`. For the Claude-compatible output shown above, schedule exactly one next session-only iteration and end the turn; Codex-compatible output sleeps inline and reruns the same command. Do not run this as a polling loop.
+**What the skill does:** Follow `## Instructions`. For the Claude-compatible output shown above, schedule exactly one next session-only iteration and end the turn; Codex-compatible output sleeps inline and reruns the same command. Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 
 ---
 
@@ -371,7 +371,7 @@ The `resolve:` command at the bottom of `## Post-fix push` includes both IDs:
 
 Both IDs stay in `--resolve-thread-ids` — `commit-suggestion` no longer resolves threads automatically. If a patch failed to apply and was handled manually instead, the ID still belongs in `--resolve-thread-ids`.
 
-**What the skill does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed. See `## Instructions` in the output for the exact steps. This output is designed for a single re-entry tick; do not wrap it in shell polling loops.
+**What the skill does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed. See `## Instructions` in the output for the exact steps. This output is designed for a single re-entry tick; do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 
 ---
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -8,6 +8,7 @@ pr-shepherd [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
 pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # legacy alias for pr-shepherd [PR]
+pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd log-file
 pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]
 ```
@@ -259,6 +260,33 @@ See [actions.md](actions.md) for all five actions and their complete output shap
 Both `--format=text` (default Markdown) and `--format=json` carry equivalent information — every field exposed in JSON has a corresponding Markdown representation, and vice versa.
 
 Exit codes: `0` wait/mark_ready · `1` fix_code · `2` cancel · `3` escalate
+
+### pr-shepherd poll [PR]
+
+Loops `pr-shepherd [PR]` every `--interval` seconds until the action is non-WAIT or `--timeout` elapses. Useful for agents that cannot reliably schedule their own follow-up ticks.
+
+| Flag                    | Default | Description                                                                 |
+| ----------------------- | ------- | --------------------------------------------------------------------------- |
+| `--interval <duration>` | `30s`   | Sleep between ticks. Accepts `30s`, `2m`, `1h`, or bare integers (seconds). |
+| `--timeout <duration>`  | `5m`    | Maximum wall-clock wait. Returns the last WAIT result on timeout.           |
+
+All `pr-shepherd [PR]` flags (`--ready-delay`, `--stall-timeout`, `--no-auto-mark-ready`, `--no-auto-cancel-actionable`, `--verbose`, `--format`) are forwarded to each tick.
+
+Stdout is the final tick's output only; per-tick WAIT progress is written to stderr (TTY-gated; always on when `--verbose` is set).
+
+Exit codes: `0` wait/mark_ready · `1` fix_code · `2` cancel · `3` escalate
+
+**Notes:**
+
+- A long poll session is equivalent to N separately-scheduled ticks, including stall-guard behavior. The stall guard may escalate before `--timeout` fires if CI is stuck.
+- `mark_ready` exits the loop — the CLI already mutated state. Re-invoke if you want to continue.
+
+```sh
+<runner> pr-shepherd poll 42                        # poll PR #42 every 30s for up to 5m
+<runner> pr-shepherd poll 42 --interval 1m          # check every minute
+<runner> pr-shepherd poll 42 --timeout 15m          # wait up to 15 minutes
+<runner> pr-shepherd poll --format=json             # infer PR, emit JSON on final tick
+```
 
 ### pr-shepherd log-file
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,7 +21,13 @@ Use the skill inside a `/goal`:
 /goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
 ```
 
-The goal loop handles recurrence. Each tick the skill runs one iterate cycle and prints the output. For non-terminal actions, the CLI's `## Instructions` tell Claude to schedule exactly one next session-only iteration after a fresh 30s-4m delay and end the turn. Claude should not sleep inline, create a recurring cron, or execute a polling loop. `[CANCEL]` and `[ESCALATE]` stop the goal.
+The goal loop handles recurrence. Each tick the skill runs one iterate cycle and prints the output. For non-terminal actions, the CLI's `## Instructions` nudge the iteration strategy. Pick one:
+
+- **Scheduled wakeup** (recommended for Claude) — schedule exactly one next session-only iteration after a fresh 30s–4m delay, then end the turn.
+- **Blocking poll** — run `<runner> pr-shepherd poll <N>` to loop internally until a non-WAIT action appears (bounded by `--timeout`, default 5m).
+- **Inline sleep** (Codex default) — sleep inline for a fresh 30s–4m delay, then rerun.
+
+Do not combine strategies and do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`. `[CANCEL]` and `[ESCALATE]` stop the goal regardless of strategy.
 
 ## Codex
 
@@ -62,7 +68,7 @@ Use the skill inside a `/goal`:
 /goal $pr-shepherd 42
 ```
 
-Codex runs the same skill — one tick per goal iteration. The CLI detects Codex via `CODEX_CI=1` or `AGENT=codex` and adapts its `## Instructions` wording so Codex sleeps inline for a fresh 30s-4m delay before rerunning. If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking the CLI:
+Codex runs the same skill — one tick per goal iteration. The CLI detects Codex via `CODEX_CI=1` or `AGENT=codex` and adapts its `## Instructions` wording to prefer inline sleep before rerunning. Alternatively, Codex can run `<runner> pr-shepherd poll <N>` to block until a non-WAIT action appears. If Codex is not already setting `CODEX_CI=1`, set `AGENT=codex` before invoking the CLI:
 
 ```sh
 export AGENT=codex

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -4,7 +4,13 @@
 
 ## Overview
 
-pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. There is no recurring cron or fixed-interval `/loop` scheduler. Each non-terminal action is a single tick. Claude schedules exactly one next session-only iteration per non-terminal tick; Codex sleeps inline for a fresh 30s-4m delay and reruns the iterate command. Do not wrap this in `while true`, fixed-interval sleep loops, or other polling loops.
+pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. Three iteration strategies are valid:
+
+- **Scheduled wakeup + one tick** (Claude default) — schedule a single session-only follow-up task after a fresh 30s–4m delay, then end the turn.
+- **Inline sleep + rerun** (Codex default) — sleep inline for a fresh 30s–4m delay, then rerun the iterate command.
+- **Blocking poll** — run `<runner> pr-shepherd poll <PR>` to loop internally until a non-WAIT action appears (bounded by `--timeout`, default 5m).
+
+Each non-terminal action is a single tick (or a bounded poll session). Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 
 Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with `/goal /pr-shepherd:pr-shepherd`; Codex users invoke it with `/goal $pr-shepherd`.
 
@@ -27,7 +33,12 @@ Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with
    The output begins with `# PR #N [ACTION]` and ends with a numbered `## Instructions` block. The skill follows those instructions exactly.
 
 3. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`)
-   The `## Instructions` tell the active goal how to continue. Claude schedules one next session-only follow-up task and ends the turn. Codex sleeps inline for a fresh 30s-4m delay, then reruns `<runner> pr-shepherd <PR>`. Do this **once only**. Never execute `while true` or any equivalent polling loop.
+   The `## Instructions` tell the active goal how to continue. Pick one strategy:
+   - Claude: schedule one next session-only follow-up task and end the turn.
+   - Codex: sleep inline for a fresh 30s–4m delay, then rerun `<runner> pr-shepherd <PR>`.
+   - Either: run `<runner> pr-shepherd poll <PR>` to block until the action is non-WAIT.
+
+   Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 
 4. **Terminal actions**
    - `[CANCEL]` — PR is merged/closed, or the ready-delay has elapsed. Goal stops.
@@ -38,18 +49,20 @@ For the full decision tree see [iterate-flow.md](iterate-flow.md). For the merma
 ## Sequence diagram
 
 ```
-User                    Active Goal             shepherd iterate
+User                    Active Goal             shepherd iterate / poll
  |                          |                        |
  |-- /goal /pr-shepherd --> |                        |
  |                          |-- pr-shepherd <PR> --> |
+ |                          |    (or poll <PR>)       |
  |                          |                        |-- GraphQL fetch
  |                          |                        |-- classify
  |                          |                        |-- dispatch
  |                          |<-- [ACTION] + ## Instructions
  |                          |                        |
  |  [if non-terminal]       |                        |
- |                          |-- schedule next tick   |  (Claude)
- |                          |-- sleep + rerun inline |  (Codex)
+ |                          |-- schedule next tick   |  (Claude: one-tick)
+ |                          |-- sleep + rerun inline |  (Codex: one-tick)
+ |                          |-- poll loops + sleep   |  (poll mode: internal)
  |                          |-- pr-shepherd <PR> --> |
  |                          |                        |
  |  [if cancel/escalate]    |                        |

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -45,4 +45,11 @@ One-tick dispatcher for iterating a PR to completion.
 5. **Stop conditions:**
    - Stop when the CLI emits `[CANCEL]` (ready-delay completed, or PR merged/closed).
    - Stop when the CLI emits `[ESCALATE]`, including `stall-timeout` for repeated unchanged CI failures.
-   - All other actions (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) are non-terminal: follow the `## Instructions`. For Claude, schedule exactly one next session-only iteration and end the turn; do not sleep inline and do not create a recurring cron or polling loop (`while true`, repeated polling, etc.).
+
+6. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) — follow the `## Instructions` in the output. Pick one iteration strategy; the CLI's instructions already nudge the runtime-appropriate default:
+   - **Blocking poll** — rerun as `<runner> pr-shepherd poll <N>` (default interval 30s, timeout 5m). Holds the agent turn until the action is non-WAIT or the timeout fires. Simplest when the agent cannot reliably schedule its own follow-up.
+   - **Scheduled wakeup + one tick** — schedule a single session-only follow-up task to rerun `<runner> pr-shepherd <N>` after a fresh 30s–4m delay, then end the turn. Recommended for Claude.
+   - **Inline sleep + rerun** — sleep inline for a fresh 30s–4m delay, then rerun. Recommended for Codex when scheduling is unavailable.
+   - **Manual hand-off** — print the output and stop; the user re-invokes when ready.
+
+   Do not combine strategies (e.g., poll AND schedule a wakeup). Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -47,9 +47,8 @@ One-tick dispatcher for iterating a PR to completion.
    - Stop when the CLI emits `[ESCALATE]`, including `stall-timeout` for repeated unchanged CI failures.
 
 6. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) — follow the `## Instructions` in the output. Pick one iteration strategy; the CLI's instructions already nudge the runtime-appropriate default:
-   - **Blocking poll** — rerun as `<runner> pr-shepherd poll <N>` (default interval 30s, timeout 5m). Holds the agent turn until the action is non-WAIT or the timeout fires. Simplest when the agent cannot reliably schedule its own follow-up.
+   - **Blocking poll** — rerun as `<runner> pr-shepherd poll <N> [--interval <duration>] [--timeout <duration>]` (defaults: interval 30s, timeout 5m). Holds the agent turn until the action is non-WAIT or the timeout fires. Simplest when the agent cannot reliably schedule its own follow-up.
    - **Scheduled wakeup + one tick** — schedule a single session-only follow-up task to rerun `<runner> pr-shepherd <N>` after a fresh 30s–4m delay, then end the turn. Recommended for Claude.
    - **Inline sleep + rerun** — sleep inline for a fresh 30s–4m delay, then rerun. Recommended for Codex when scheduling is unavailable.
-   - **Manual hand-off** — print the output and stop; the user re-invokes when ready.
 
    Do not combine strategies (e.g., poll AND schedule a wakeup). Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -14,6 +14,9 @@
  *   pr-shepherd iterate [PR] [--format text|json] [--ready-delay Nm]
  *                              [--stall-timeout <duration>] [--no-auto-mark-ready]
  *                              [--no-auto-cancel-actionable]
+ *   pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--format text|json] [--ready-delay Nm]
+ *                         [--stall-timeout <duration>] [--no-auto-mark-ready]
+ *                         [--no-auto-cancel-actionable]
  *   pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]
  */
 
@@ -25,6 +28,7 @@ import { parseCommonArgs, getFlag, hasFlag, parseList } from "./cli/args.mts";
 import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./cli/default-iterate.mts";
 import { formatFetchResult, formatMutateResult } from "./cli/formatters.mts";
 import { handleClean, handleCommitSuggestion, handleIterate } from "./cli/handlers.mts";
+import { handlePoll } from "./cli/poll-handler.mts";
 import { setupLog } from "./log/setup.mts";
 
 // ---------------------------------------------------------------------------
@@ -66,13 +70,16 @@ export async function main(argv: string[]): Promise<void> {
     case "iterate":
       await handleIterate(args.slice(1));
       break;
+    case "poll":
+      await handlePoll(args.slice(1));
+      break;
     case "clean":
       await handleClean(args.slice(1));
       break;
     default:
       process.stderr.write(`Unknown subcommand: ${subcommand ?? "(none)"}\n`);
       process.stderr.write(
-        "Usage: pr-shepherd <resolve|commit-suggestion|iterate|log-file|clean> [options]\n" +
+        "Usage: pr-shepherd <resolve|commit-suggestion|iterate|poll|log-file|clean> [options]\n" +
           "       pr-shepherd --version | -v\n",
       );
       process.exitCode = 1;

--- a/src/cli-parser.poll.mock.test.mts
+++ b/src/cli-parser.poll.mock.test.mts
@@ -97,12 +97,13 @@ describe("main — poll subcommand", () => {
     expect(parsed.action).toBe("cancel");
   });
 
-  it("sets SHEPHERD_POLL_VERBOSE when --verbose is passed", async () => {
+  it("accepts --verbose without error", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
 
     await main(["node", "shepherd", "poll", "42", "--verbose"]);
 
-    expect(process.env["SHEPHERD_POLL_VERBOSE"]).toBe("1");
+    expect(process.exitCode).not.toBe(1);
+    expect(mockRunIterate).toHaveBeenCalledTimes(1);
   });
 
   it("rejects an invalid --interval value", async () => {

--- a/src/cli-parser.poll.mock.test.mts
+++ b/src/cli-parser.poll.mock.test.mts
@@ -1,0 +1,123 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
+  return { ...actual, runIterate: vi.fn() };
+});
+vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
+vi.mock("./commands/resolve.mts", () => ({
+  runResolveFetch: vi.fn(),
+  runResolveMutate: vi.fn(),
+}));
+vi.mock("./commands/commit-suggestion.mts", () => ({ runCommitSuggestion: vi.fn() }));
+vi.mock("./github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
+}));
+
+import { main } from "./cli-parser.mts";
+import { runIterate } from "./commands/iterate/index.mts";
+import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
+
+const mockRunIterate = vi.mocked(runIterate);
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+function getStdout(): string {
+  return stdoutSpy.mock.calls.map((c: unknown[]) => c[0]).join("");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  process.exitCode = undefined;
+  delete process.env["SHEPHERD_POLL_VERBOSE"];
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+  delete process.env["SHEPHERD_POLL_VERBOSE"];
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+describe("main — poll subcommand", () => {
+  it("routes 'poll' to runPoll and emits cancel result", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
+
+    await main(["node", "shepherd", "poll", "42"]);
+
+    expect(mockRunIterate).toHaveBeenCalledTimes(1);
+    expect(getStdout()).toContain("[CANCEL]");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("routes 'poll' with wait then cancel — uses fake timers for sleep", async () => {
+    mockRunIterate
+      .mockResolvedValueOnce(makeIterateResult("wait"))
+      .mockResolvedValue(makeIterateResult("cancel"));
+
+    const promise = main([
+      "node",
+      "shepherd",
+      "poll",
+      "42",
+      "--interval",
+      "30s",
+      "--timeout",
+      "300s",
+    ]);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await promise;
+
+    expect(mockRunIterate).toHaveBeenCalledTimes(2);
+    expect(getStdout()).toContain("[CANCEL]");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("accepts --interval and --timeout as minute durations", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
+
+    await main(["node", "shepherd", "poll", "42", "--interval", "1m", "--timeout", "5m"]);
+
+    expect(mockRunIterate).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits JSON output when --format=json", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
+
+    await main(["node", "shepherd", "poll", "42", "--format=json"]);
+
+    const out = getStdout();
+    const parsed = JSON.parse(out);
+    expect(parsed.action).toBe("cancel");
+  });
+
+  it("sets SHEPHERD_POLL_VERBOSE when --verbose is passed", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
+
+    await main(["node", "shepherd", "poll", "42", "--verbose"]);
+
+    expect(process.env["SHEPHERD_POLL_VERBOSE"]).toBe("1");
+  });
+
+  it("rejects an invalid --interval value", async () => {
+    await main(["node", "shepherd", "poll", "42", "--interval", "bad"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("invalid --interval"));
+    expect(mockRunIterate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid --timeout value", async () => {
+    await main(["node", "shepherd", "poll", "42", "--timeout", "xyz"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("invalid --timeout"));
+    expect(mockRunIterate).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -18,6 +18,8 @@ const FLAGS_WITH_VALUES = new Set([
   "--resolve-thread-ids",
   "--minimize-comment-ids",
   "--dismiss-review-ids",
+  "--interval",
+  "--timeout",
 ]);
 
 // Boolean flags that do NOT consume the next argument. Any --flag not in this

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { validateSecondsDurationFlag } from "./duration-flag.mts";
+import { parseDurationToSeconds } from "./exit-codes.mts";
+
+describe("validateSecondsDurationFlag", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    stderrSpy.mockRestore();
+  });
+
+  it("returns undefined when the flag is absent", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", null, false)).toBeUndefined();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing separate value", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", null, true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("requires a value"));
+  });
+
+  it("rejects the next flag as a value", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "--timeout", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("requires a value"));
+  });
+
+  it("rejects malformed durations", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "soon", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("invalid --interval"));
+  });
+
+  it("accepts bare integer (seconds)", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "30", true)).toBe("30");
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts Ns suffix", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "30s", true)).toBe("30s");
+  });
+
+  it("accepts Nm suffix", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "5m", true)).toBe("5m");
+  });
+
+  it("accepts Nh suffix", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "1h", true)).toBe("1h");
+  });
+
+  it("returns trimmed value", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", " 30s ", true)).toBe("30s");
+  });
+});
+
+describe("parseDurationToSeconds", () => {
+  it("parses bare integer as seconds", () => {
+    expect(parseDurationToSeconds("30", 60)).toBe(30);
+  });
+
+  it("parses Ns suffix", () => {
+    expect(parseDurationToSeconds("45s", 60)).toBe(45);
+  });
+
+  it("parses Nsec suffix", () => {
+    expect(parseDurationToSeconds("10sec", 60)).toBe(10);
+  });
+
+  it("parses Nseconds suffix", () => {
+    expect(parseDurationToSeconds("20seconds", 60)).toBe(20);
+  });
+
+  it("parses Nm suffix as minutes", () => {
+    expect(parseDurationToSeconds("5m", 60)).toBe(300);
+  });
+
+  it("parses Nmin suffix as minutes", () => {
+    expect(parseDurationToSeconds("2min", 60)).toBe(120);
+  });
+
+  it("parses Nh suffix as hours", () => {
+    expect(parseDurationToSeconds("1h", 60)).toBe(3600);
+  });
+
+  it("parses Nhours suffix as hours", () => {
+    expect(parseDurationToSeconds("2hours", 60)).toBe(7200);
+  });
+
+  it("returns default for invalid input", () => {
+    expect(parseDurationToSeconds("notaduration", 30)).toBe(30);
+  });
+
+  it("treats bare integer with no unit as seconds (not minutes)", () => {
+    expect(parseDurationToSeconds("60", 0)).toBe(60);
+  });
+});

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -39,6 +39,17 @@ describe("validateSecondsDurationFlag", () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("invalid --interval"));
   });
 
+  it("rejects zero", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "0", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("invalid --interval"));
+  });
+
+  it("rejects 0s", () => {
+    expect(validateSecondsDurationFlag("cmd", "--interval", "0s", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+  });
+
   it("accepts bare integer (seconds)", () => {
     expect(validateSecondsDurationFlag("cmd", "--interval", "30", true)).toBe("30");
     expect(stderrSpy).not.toHaveBeenCalled();

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -112,4 +112,9 @@ describe("parseDurationToSeconds", () => {
   it("treats bare integer with no unit as seconds (not minutes)", () => {
     expect(parseDurationToSeconds("60", 0)).toBe(60);
   });
+
+  it("returns default when integer overflows to Infinity", () => {
+    const huge = "9".repeat(400);
+    expect(parseDurationToSeconds(huge, 30)).toBe(30);
+  });
 });

--- a/src/cli/default-iterate.mts
+++ b/src/cli/default-iterate.mts
@@ -57,7 +57,7 @@ function writeDefaultUsageError(arg: string): void {
   process.stderr.write(`Unknown subcommand: ${arg}\n`);
   process.stderr.write(
     "Usage: pr-shepherd [PR] [options]\n" +
-      "       pr-shepherd <resolve|commit-suggestion|iterate|log-file> [options]\n" +
+      "       pr-shepherd <resolve|commit-suggestion|iterate|poll|log-file|clean> [options]\n" +
       "       pr-shepherd --version | -v\n",
   );
   process.exitCode = 1;

--- a/src/cli/duration-flag.mts
+++ b/src/cli/duration-flag.mts
@@ -18,7 +18,7 @@ export function validateSecondsDurationFlag(
     process.exitCode = 1;
     return null;
   }
-  if (!/^\d+(?:s|sec|seconds?|m|min|minutes?|h|hours?)?$/.test(trimmed)) {
+  if (!/^[1-9]\d*(?:s|sec|seconds?|m|min|minutes?|h|hours?)?$/.test(trimmed)) {
     process.stderr.write(
       `${command}: invalid ${flag}: ${value}. Expected a duration like 30s, 5m, 1h, or bare seconds (e.g. 30).\n`,
     );

--- a/src/cli/duration-flag.mts
+++ b/src/cli/duration-flag.mts
@@ -1,3 +1,33 @@
+export function validateSecondsDurationFlag(
+  command: string,
+  flag: string,
+  value: string | null,
+  presentAsSeparateArg: boolean,
+): string | undefined | null {
+  if (value === null) {
+    if (presentAsSeparateArg) {
+      process.stderr.write(`${command}: ${flag} requires a value (e.g. ${flag} 30s)\n`);
+      process.exitCode = 1;
+      return null;
+    }
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.startsWith("--")) {
+    process.stderr.write(`${command}: ${flag} requires a value (e.g. ${flag} 30s)\n`);
+    process.exitCode = 1;
+    return null;
+  }
+  if (!/^\d+(?:s|sec|seconds?|m|min|minutes?|h|hours?)?$/.test(trimmed)) {
+    process.stderr.write(
+      `${command}: invalid ${flag}: ${value}. Expected a duration like 30s, 5m, 1h, or bare seconds (e.g. 30).\n`,
+    );
+    process.exitCode = 1;
+    return null;
+  }
+  return trimmed;
+}
+
 export function validateDurationFlag(
   command: string,
   flag: string,

--- a/src/cli/exit-codes.mts
+++ b/src/cli/exit-codes.mts
@@ -10,6 +10,16 @@ export function parseDurationToMinutes(s: string, defaultMinutes?: number): numb
   return n;
 }
 
+export function parseDurationToSeconds(s: string, defaultSeconds: number): number {
+  const m = /^(\d+)(s|sec|seconds?|m|min|minutes?|h|hours?)?$/.exec(s.trim());
+  if (!m) return defaultSeconds;
+  const n = parseInt(m[1]!, 10);
+  const unit = m[2] ?? "s";
+  if (unit.startsWith("h")) return n * 3600;
+  if (unit.startsWith("m")) return n * 60;
+  return n;
+}
+
 export function statusToExitCode(status: string): number {
   switch (status) {
     case "MERGED":

--- a/src/cli/exit-codes.mts
+++ b/src/cli/exit-codes.mts
@@ -14,6 +14,7 @@ export function parseDurationToSeconds(s: string, defaultSeconds: number): numbe
   const m = /^(\d+)(s|sec|seconds?|m|min|minutes?|h|hours?)?$/.exec(s.trim());
   if (!m) return defaultSeconds;
   const n = parseInt(m[1]!, 10);
+  if (!Number.isFinite(n)) return defaultSeconds;
   const unit = m[2] ?? "s";
   if (unit.startsWith("h")) return n * 3600;
   if (unit.startsWith("m")) return n * 60;

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -3,8 +3,8 @@ import { runIterate } from "../commands/iterate/index.mts";
 import { runClean, type CleanVariant } from "../commands/clean.mts";
 import { loadConfig } from "../config/load.mts";
 import { detectAgentRuntime } from "../agent-runtime.mts";
-import { parseCommonArgs, getFlag, hasFlag } from "./args.mts";
-import { parseDurationToMinutes, iterateActionToExitCode } from "./exit-codes.mts";
+import { parseCommonArgs, getFlag } from "./args.mts";
+import { iterateActionToExitCode } from "./exit-codes.mts";
 import {
   formatCommitSuggestionResult,
   formatCleanResult,
@@ -12,7 +12,7 @@ import {
   projectIterateLean,
   projectIterateVerbose,
 } from "./formatters.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
+import { parseIterateFlags } from "./iterate-flags.mts";
 
 const CLEAN_VARIANTS = new Set<string>(["pr", "branch", "current", "repo", "all"]);
 
@@ -124,37 +124,23 @@ export async function handleCommitSuggestion(args: string[]): Promise<void> {
 export async function handleIterate(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
   const runtime = detectAgentRuntime();
-
-  const readyDelayStr = getFlag(extra, "--ready-delay");
-  const readyDelaySuffix = validateDurationFlag(
-    "pr-shepherd",
-    "--ready-delay",
-    readyDelayStr,
-    hasFlag(extra, "--ready-delay"),
-  );
-  if (readyDelaySuffix === null) return;
   const cfg = loadConfig();
-  const readyDelaySeconds =
-    parseDurationToMinutes(readyDelaySuffix ?? "", cfg.watch.readyDelayMinutes) * 60;
-  const noAutoMarkReady = hasFlag(extra, "--no-auto-mark-ready");
-  const noAutoCancelActionable = hasFlag(extra, "--no-auto-cancel-actionable");
-  const stallTimeoutStr = getFlag(extra, "--stall-timeout");
-  const stallTimeoutSeconds = stallTimeoutStr
-    ? parseDurationToMinutes(stallTimeoutStr, cfg.iterate.stallTimeoutMinutes) * 60
-    : cfg.iterate.stallTimeoutMinutes * 60;
+
+  const flags = parseIterateFlags(extra, cfg);
+  if (flags.readyDelaySuffix === null) return;
 
   const result = await runIterate({
     ...globalOpts,
     prNumber,
-    readyDelaySeconds,
-    stallTimeoutSeconds,
-    noAutoMarkReady,
-    noAutoCancelActionable,
+    readyDelaySeconds: flags.readyDelaySeconds,
+    stallTimeoutSeconds: flags.stallTimeoutSeconds,
+    noAutoMarkReady: flags.noAutoMarkReady,
+    noAutoCancelActionable: flags.noAutoCancelActionable,
   });
 
   const projectionOpts = {
     runtime,
-    readyDelaySuffix,
+    readyDelaySuffix: flags.readyDelaySuffix ?? undefined,
     runner: cfg.cli?.runner,
   };
   if (globalOpts.format === "json") {

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -4,15 +4,9 @@ import { runClean, type CleanVariant } from "../commands/clean.mts";
 import { loadConfig } from "../config/load.mts";
 import { detectAgentRuntime } from "../agent-runtime.mts";
 import { parseCommonArgs, getFlag } from "./args.mts";
-import { iterateActionToExitCode } from "./exit-codes.mts";
-import {
-  formatCommitSuggestionResult,
-  formatCleanResult,
-  formatIterateResult,
-  projectIterateLean,
-  projectIterateVerbose,
-} from "./formatters.mts";
+import { formatCommitSuggestionResult, formatCleanResult } from "./formatters.mts";
 import { parseIterateFlags } from "./iterate-flags.mts";
+import { emitIterateResult } from "./iterate-emitter.mts";
 
 const CLEAN_VARIANTS = new Set<string>(["pr", "branch", "current", "repo", "all"]);
 
@@ -138,20 +132,11 @@ export async function handleIterate(args: string[]): Promise<void> {
     noAutoCancelActionable: flags.noAutoCancelActionable,
   });
 
-  const projectionOpts = {
+  emitIterateResult(result, {
+    format: globalOpts.format,
+    verbose: globalOpts.verbose ?? false,
     runtime,
     readyDelaySuffix: flags.readyDelaySuffix ?? undefined,
     runner: cfg.cli?.runner,
-  };
-  if (globalOpts.format === "json") {
-    const output = globalOpts.verbose
-      ? projectIterateVerbose(result, projectionOpts)
-      : projectIterateLean(result, projectionOpts);
-    process.stdout.write(`${JSON.stringify(output)}\n`);
-  } else {
-    const text = formatIterateResult(result, { verbose: globalOpts.verbose, ...projectionOpts });
-    process.stdout.write(`${text}\n`);
-  }
-
-  process.exitCode = iterateActionToExitCode(result.action);
+  });
 }

--- a/src/cli/iterate-emitter.mts
+++ b/src/cli/iterate-emitter.mts
@@ -1,0 +1,31 @@
+import type { IterateResult } from "../types.mts";
+import type { AgentRuntime } from "../agent-runtime.mts";
+import type { CliRunner } from "./runner.mts";
+import { iterateActionToExitCode } from "./exit-codes.mts";
+import { formatIterateResult, projectIterateLean, projectIterateVerbose } from "./formatters.mts";
+
+export interface EmitIterateResultOpts {
+  format: "text" | "json";
+  verbose: boolean;
+  runtime: AgentRuntime;
+  readyDelaySuffix?: string;
+  runner?: CliRunner;
+}
+
+export function emitIterateResult(result: IterateResult, opts: EmitIterateResultOpts): void {
+  const projectionOpts = {
+    runtime: opts.runtime,
+    readyDelaySuffix: opts.readyDelaySuffix,
+    runner: opts.runner,
+  };
+  if (opts.format === "json") {
+    const output = opts.verbose
+      ? projectIterateVerbose(result, projectionOpts)
+      : projectIterateLean(result, projectionOpts);
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } else {
+    const text = formatIterateResult(result, { verbose: opts.verbose, ...projectionOpts });
+    process.stdout.write(`${text}\n`);
+  }
+  process.exitCode = iterateActionToExitCode(result.action);
+}

--- a/src/cli/iterate-flags.mts
+++ b/src/cli/iterate-flags.mts
@@ -1,0 +1,40 @@
+import type { loadConfig } from "../config/load.mts";
+import { getFlag, hasFlag } from "./args.mts";
+import { parseDurationToMinutes } from "./exit-codes.mts";
+import { validateDurationFlag } from "./duration-flag.mts";
+
+export interface IterateFlags {
+  readyDelaySuffix: string | undefined | null;
+  readyDelaySeconds: number;
+  stallTimeoutSeconds: number;
+  noAutoMarkReady: boolean;
+  noAutoCancelActionable: boolean;
+}
+
+export function parseIterateFlags(
+  extra: string[],
+  cfg: ReturnType<typeof loadConfig>,
+): IterateFlags {
+  const readyDelayStr = getFlag(extra, "--ready-delay");
+  const readyDelaySuffix = validateDurationFlag(
+    "pr-shepherd",
+    "--ready-delay",
+    readyDelayStr,
+    hasFlag(extra, "--ready-delay"),
+  );
+  const readyDelaySeconds =
+    parseDurationToMinutes(readyDelaySuffix ?? "", cfg.watch.readyDelayMinutes) * 60;
+  const noAutoMarkReady = hasFlag(extra, "--no-auto-mark-ready");
+  const noAutoCancelActionable = hasFlag(extra, "--no-auto-cancel-actionable");
+  const stallTimeoutStr = getFlag(extra, "--stall-timeout");
+  const stallTimeoutSeconds = stallTimeoutStr
+    ? parseDurationToMinutes(stallTimeoutStr, cfg.iterate.stallTimeoutMinutes) * 60
+    : cfg.iterate.stallTimeoutMinutes * 60;
+  return {
+    readyDelaySuffix,
+    readyDelaySeconds,
+    stallTimeoutSeconds,
+    noAutoMarkReady,
+    noAutoCancelActionable,
+  };
+}

--- a/src/cli/iterate-flags.test.mts
+++ b/src/cli/iterate-flags.test.mts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
+vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
+
+import { parseIterateFlags } from "./iterate-flags.mts";
+
+function defaultConfig() {
+  return {
+    watch: { readyDelayMinutes: 10 },
+    iterate: { stallTimeoutMinutes: 30 },
+  };
+}
+
+beforeEach(() => {
+  process.exitCode = undefined;
+  mockLoadConfig.mockReturnValue(defaultConfig());
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe("parseIterateFlags", () => {
+  it("returns defaults when no flags given", () => {
+    const flags = parseIterateFlags([], defaultConfig());
+    expect(flags.readyDelaySuffix).toBeUndefined();
+    expect(flags.readyDelaySeconds).toBe(600); // 10m * 60
+    expect(flags.stallTimeoutSeconds).toBe(1800); // 30m * 60
+    expect(flags.noAutoMarkReady).toBe(false);
+    expect(flags.noAutoCancelActionable).toBe(false);
+  });
+
+  it("parses --ready-delay", () => {
+    const flags = parseIterateFlags(["--ready-delay", "15m"], defaultConfig());
+    expect(flags.readyDelaySuffix).toBe("15m");
+    expect(flags.readyDelaySeconds).toBe(900);
+  });
+
+  it("parses --stall-timeout", () => {
+    const flags = parseIterateFlags(["--stall-timeout", "1h"], defaultConfig());
+    expect(flags.stallTimeoutSeconds).toBe(3600);
+  });
+
+  it("parses --no-auto-mark-ready", () => {
+    const flags = parseIterateFlags(["--no-auto-mark-ready"], defaultConfig());
+    expect(flags.noAutoMarkReady).toBe(true);
+  });
+
+  it("parses --no-auto-cancel-actionable", () => {
+    const flags = parseIterateFlags(["--no-auto-cancel-actionable"], defaultConfig());
+    expect(flags.noAutoCancelActionable).toBe(true);
+  });
+
+  it("returns null readyDelaySuffix on malformed --ready-delay", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const flags = parseIterateFlags(["--ready-delay", "bad"], defaultConfig());
+    expect(flags.readyDelaySuffix).toBeNull();
+    stderrSpy.mockRestore();
+  });
+});

--- a/src/cli/poll-handler.mts
+++ b/src/cli/poll-handler.mts
@@ -1,0 +1,75 @@
+import { runPoll } from "../commands/poll.mts";
+import { loadConfig } from "../config/load.mts";
+import { detectAgentRuntime } from "../agent-runtime.mts";
+import { parseCommonArgs, getFlag, hasFlag } from "./args.mts";
+import { parseDurationToSeconds, iterateActionToExitCode } from "./exit-codes.mts";
+import { formatIterateResult, projectIterateLean, projectIterateVerbose } from "./formatters.mts";
+import { validateSecondsDurationFlag } from "./duration-flag.mts";
+import { parseIterateFlags } from "./iterate-flags.mts";
+
+const DEFAULT_POLL_INTERVAL_SECONDS = 30;
+const DEFAULT_POLL_TIMEOUT_SECONDS = 300;
+
+export async function handlePoll(args: string[]): Promise<void> {
+  const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
+  const runtime = detectAgentRuntime();
+  const cfg = loadConfig();
+
+  const flags = parseIterateFlags(extra, cfg);
+  if (flags.readyDelaySuffix === null) return;
+
+  const intervalStr = getFlag(extra, "--interval");
+  const intervalSuffix = validateSecondsDurationFlag(
+    "pr-shepherd poll",
+    "--interval",
+    intervalStr,
+    hasFlag(extra, "--interval"),
+  );
+  if (intervalSuffix === null) return;
+  const intervalSeconds = parseDurationToSeconds(
+    intervalSuffix ?? "",
+    DEFAULT_POLL_INTERVAL_SECONDS,
+  );
+
+  const timeoutStr = getFlag(extra, "--timeout");
+  const timeoutSuffix = validateSecondsDurationFlag(
+    "pr-shepherd poll",
+    "--timeout",
+    timeoutStr,
+    hasFlag(extra, "--timeout"),
+  );
+  if (timeoutSuffix === null) return;
+  const timeoutSeconds = parseDurationToSeconds(timeoutSuffix ?? "", DEFAULT_POLL_TIMEOUT_SECONDS);
+
+  if (globalOpts.verbose) {
+    process.env["SHEPHERD_POLL_VERBOSE"] = "1";
+  }
+
+  const result = await runPoll({
+    ...globalOpts,
+    prNumber,
+    readyDelaySeconds: flags.readyDelaySeconds,
+    stallTimeoutSeconds: flags.stallTimeoutSeconds,
+    noAutoMarkReady: flags.noAutoMarkReady,
+    noAutoCancelActionable: flags.noAutoCancelActionable,
+    intervalSeconds,
+    timeoutSeconds,
+  });
+
+  const projectionOpts = {
+    runtime,
+    readyDelaySuffix: flags.readyDelaySuffix ?? undefined,
+    runner: cfg.cli?.runner,
+  };
+  if (globalOpts.format === "json") {
+    const output = globalOpts.verbose
+      ? projectIterateVerbose(result, projectionOpts)
+      : projectIterateLean(result, projectionOpts);
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } else {
+    const text = formatIterateResult(result, { verbose: globalOpts.verbose, ...projectionOpts });
+    process.stdout.write(`${text}\n`);
+  }
+
+  process.exitCode = iterateActionToExitCode(result.action);
+}

--- a/src/cli/poll-handler.mts
+++ b/src/cli/poll-handler.mts
@@ -2,10 +2,10 @@ import { runPoll } from "../commands/poll.mts";
 import { loadConfig } from "../config/load.mts";
 import { detectAgentRuntime } from "../agent-runtime.mts";
 import { parseCommonArgs, getFlag, hasFlag } from "./args.mts";
-import { parseDurationToSeconds, iterateActionToExitCode } from "./exit-codes.mts";
-import { formatIterateResult, projectIterateLean, projectIterateVerbose } from "./formatters.mts";
+import { parseDurationToSeconds } from "./exit-codes.mts";
 import { validateSecondsDurationFlag } from "./duration-flag.mts";
 import { parseIterateFlags } from "./iterate-flags.mts";
+import { emitIterateResult } from "./iterate-emitter.mts";
 
 const DEFAULT_POLL_INTERVAL_SECONDS = 30;
 const DEFAULT_POLL_TIMEOUT_SECONDS = 300;
@@ -41,10 +41,6 @@ export async function handlePoll(args: string[]): Promise<void> {
   if (timeoutSuffix === null) return;
   const timeoutSeconds = parseDurationToSeconds(timeoutSuffix ?? "", DEFAULT_POLL_TIMEOUT_SECONDS);
 
-  if (globalOpts.verbose) {
-    process.env["SHEPHERD_POLL_VERBOSE"] = "1";
-  }
-
   const result = await runPoll({
     ...globalOpts,
     prNumber,
@@ -56,20 +52,11 @@ export async function handlePoll(args: string[]): Promise<void> {
     timeoutSeconds,
   });
 
-  const projectionOpts = {
+  emitIterateResult(result, {
+    format: globalOpts.format,
+    verbose: globalOpts.verbose ?? false,
     runtime,
     readyDelaySuffix: flags.readyDelaySuffix ?? undefined,
     runner: cfg.cli?.runner,
-  };
-  if (globalOpts.format === "json") {
-    const output = globalOpts.verbose
-      ? projectIterateVerbose(result, projectionOpts)
-      : projectIterateLean(result, projectionOpts);
-    process.stdout.write(`${JSON.stringify(output)}\n`);
-  } else {
-    const text = formatIterateResult(result, { verbose: globalOpts.verbose, ...projectionOpts });
-    process.stdout.write(`${text}\n`);
-  }
-
-  process.exitCode = iterateActionToExitCode(result.action);
+  });
 }

--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -10,10 +10,15 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function writeTickProgress(tick: number, elapsedSeconds: number, intervalSeconds: number): void {
-  if (process.stderr.isTTY || process.env["SHEPHERD_POLL_VERBOSE"] === "1") {
+function writeTickProgress(
+  tick: number,
+  elapsedSeconds: number,
+  sleepSeconds: number,
+  verbose: boolean,
+): void {
+  if (process.stderr.isTTY || verbose) {
     process.stderr.write(
-      `[poll tick ${tick} / +${elapsedSeconds}s] WAIT — sleeping ${intervalSeconds}s\n`,
+      `[poll tick ${tick} / +${elapsedSeconds}s] WAIT — sleeping ${sleepSeconds}s\n`,
     );
   }
 }
@@ -25,6 +30,7 @@ export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> 
   const start = Date.now();
   let tick = 0;
   let lastResult: IterateResult | undefined;
+  const verbose = opts.verbose === true;
 
   while (true) {
     tick += 1;
@@ -32,9 +38,11 @@ export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> 
     if (lastResult.action !== "wait") return lastResult;
 
     const elapsedMs = Date.now() - start;
-    if (elapsedMs + intervalMs >= timeoutMs) return lastResult;
+    const remainingMs = timeoutMs - elapsedMs;
+    if (remainingMs <= 0) return lastResult;
 
-    writeTickProgress(tick, Math.round(elapsedMs / 1000), intervalSeconds);
-    await sleep(intervalMs);
+    const nextSleepMs = Math.min(intervalMs, remainingMs);
+    writeTickProgress(tick, Math.round(elapsedMs / 1000), Math.round(nextSleepMs / 1000), verbose);
+    await sleep(nextSleepMs);
   }
 }

--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -1,0 +1,40 @@
+import { runIterate } from "./iterate/index.mts";
+import type { IterateCommandOptions, IterateResult } from "../types.mts";
+
+export interface PollCommandOptions extends IterateCommandOptions {
+  intervalSeconds: number;
+  timeoutSeconds: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function writeTickProgress(tick: number, elapsedSeconds: number, intervalSeconds: number): void {
+  if (process.stderr.isTTY || process.env["SHEPHERD_POLL_VERBOSE"] === "1") {
+    process.stderr.write(
+      `[poll tick ${tick} / +${elapsedSeconds}s] WAIT — sleeping ${intervalSeconds}s\n`,
+    );
+  }
+}
+
+export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> {
+  const { intervalSeconds, timeoutSeconds, ...iterateOpts } = opts;
+  const intervalMs = intervalSeconds * 1000;
+  const timeoutMs = timeoutSeconds * 1000;
+  const start = Date.now();
+  let tick = 0;
+  let lastResult: IterateResult | undefined;
+
+  while (true) {
+    tick += 1;
+    lastResult = await runIterate(iterateOpts);
+    if (lastResult.action !== "wait") return lastResult;
+
+    const elapsedMs = Date.now() - start;
+    if (elapsedMs + intervalMs >= timeoutMs) return lastResult;
+
+    writeTickProgress(tick, Math.round(elapsedMs / 1000), intervalSeconds);
+    await sleep(intervalMs);
+  }
+}

--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -23,10 +23,12 @@ function writeTickProgress(
   }
 }
 
+const MAX_TIMER_MS = 2 ** 31 - 1;
+
 export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> {
   const { intervalSeconds, timeoutSeconds, ...iterateOpts } = opts;
-  const intervalMs = intervalSeconds * 1000;
-  const timeoutMs = timeoutSeconds * 1000;
+  const intervalMs = Math.min(intervalSeconds * 1000, MAX_TIMER_MS);
+  const timeoutMs = Math.min(timeoutSeconds * 1000, MAX_TIMER_MS);
   const start = Date.now();
   let tick = 0;
   let lastResult: IterateResult | undefined;

--- a/src/commands/poll.runpoll-clamps-oversized-timer.mock.test.mts
+++ b/src/commands/poll.runpoll-clamps-oversized-timer.mock.test.mts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import { describe, it, expect, vi } from "vitest";
+import {
+  mockRunIterate,
+  makeWaitResult,
+  makeCancelResult,
+  registerPollHooks,
+} from "./poll.test-support.mts";
+import { runPoll } from "./poll.mts";
+
+registerPollHooks();
+
+const MAX_TIMER_MS = 2 ** 31 - 1;
+
+describe("runPoll — clamps oversized timer values", () => {
+  it("clamps a huge interval to MAX_TIMER_MS so setTimeout does not wrap to 1ms", async () => {
+    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+
+    // 1000h = 3,600,000,000 ms, which exceeds MAX_TIMER_MS
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 1000 * 3600,
+      timeoutSeconds: 1000 * 3600 * 2,
+    });
+
+    // Advancing by MAX_TIMER_MS should unblock the sleep since the interval is clamped
+    await vi.advanceTimersByTimeAsync(MAX_TIMER_MS);
+    const result = await pollPromise;
+
+    expect(result.action).toBe("cancel");
+    expect(mockRunIterate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/commands/poll.runpoll-loops-on-wait-then-stops.mock.test.mts
+++ b/src/commands/poll.runpoll-loops-on-wait-then-stops.mock.test.mts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+import { describe, it, expect, vi } from "vitest";
+import {
+  mockRunIterate,
+  makeWaitResult,
+  makeCancelResult,
+  registerPollHooks,
+} from "./poll.test-support.mts";
+import { runPoll } from "./poll.mts";
+
+registerPollHooks();
+
+describe("runPoll — loops on wait then stops", () => {
+  it("calls runIterate 3 times when it returns wait twice then cancel", async () => {
+    mockRunIterate
+      .mockResolvedValueOnce(makeWaitResult())
+      .mockResolvedValueOnce(makeWaitResult())
+      .mockResolvedValue(makeCancelResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    // advance past each sleep
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const result = await pollPromise;
+
+    expect(result.action).toBe("cancel");
+    expect(mockRunIterate).toHaveBeenCalledTimes(3);
+  });
+
+  it("forwards iterate opts to each runIterate call", async () => {
+    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "json",
+      readyDelaySeconds: 600,
+      stallTimeoutSeconds: 1800,
+      noAutoMarkReady: true,
+      noAutoCancelActionable: true,
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await pollPromise;
+
+    expect(mockRunIterate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prNumber: 42,
+        format: "json",
+        readyDelaySeconds: 600,
+        stallTimeoutSeconds: 1800,
+        noAutoMarkReady: true,
+        noAutoCancelActionable: true,
+      }),
+    );
+  });
+});

--- a/src/commands/poll.runpoll-stops-on-cancel.mock.test.mts
+++ b/src/commands/poll.runpoll-stops-on-cancel.mock.test.mts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import { mockRunIterate, makeCancelResult, registerPollHooks } from "./poll.test-support.mts";
+import { runPoll } from "./poll.mts";
+
+registerPollHooks();
+
+describe("runPoll — stops on cancel", () => {
+  it("returns the cancel result immediately without sleeping", async () => {
+    mockRunIterate.mockResolvedValue(makeCancelResult());
+
+    const result = await runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    expect(result.action).toBe("cancel");
+    expect(mockRunIterate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/poll.runpoll-stops-on-mark-ready.mock.test.mts
+++ b/src/commands/poll.runpoll-stops-on-mark-ready.mock.test.mts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import { mockRunIterate, makeMarkReadyResult, registerPollHooks } from "./poll.test-support.mts";
+import { runPoll } from "./poll.mts";
+
+registerPollHooks();
+
+describe("runPoll — stops on mark_ready", () => {
+  it("returns the mark_ready result immediately without sleeping", async () => {
+    mockRunIterate.mockResolvedValue(makeMarkReadyResult());
+
+    const result = await runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    expect(result.action).toBe("mark_ready");
+    expect(mockRunIterate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -34,10 +34,9 @@ describe("runPoll — tick progress logging", () => {
     Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
   });
 
-  it("writes progress when SHEPHERD_POLL_VERBOSE=1 even on non-TTY", async () => {
+  it("writes progress when verbose:true even on non-TTY", async () => {
     const originalIsTTY = process.stderr.isTTY;
     Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
-    process.env["SHEPHERD_POLL_VERBOSE"] = "1";
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
@@ -45,6 +44,7 @@ describe("runPoll — tick progress logging", () => {
     const pollPromise = runPoll({
       prNumber: 42,
       format: "text",
+      verbose: true,
       intervalSeconds: 30,
       timeoutSeconds: 300,
     });
@@ -55,7 +55,6 @@ describe("runPoll — tick progress logging", () => {
     expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(true);
 
     stderrSpy.mockRestore();
-    delete process.env["SHEPHERD_POLL_VERBOSE"];
     Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
   });
 });

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import { describe, it, expect, vi } from "vitest";
+import {
+  mockRunIterate,
+  makeWaitResult,
+  makeCancelResult,
+  registerPollHooks,
+} from "./poll.test-support.mts";
+import { runPoll } from "./poll.mts";
+
+registerPollHooks();
+
+describe("runPoll — tick progress logging", () => {
+  it("writes progress to stderr on TTY when looping", async () => {
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await pollPromise;
+
+    expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(true);
+
+    stderrSpy.mockRestore();
+    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+  });
+
+  it("writes progress when SHEPHERD_POLL_VERBOSE=1 even on non-TTY", async () => {
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+    process.env["SHEPHERD_POLL_VERBOSE"] = "1";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await pollPromise;
+
+    expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(true);
+
+    stderrSpy.mockRestore();
+    delete process.env["SHEPHERD_POLL_VERBOSE"];
+    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+  });
+});

--- a/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
+++ b/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
@@ -6,11 +6,10 @@ import { runPoll } from "./poll.mts";
 registerPollHooks();
 
 describe("runPoll — timeout returns final wait", () => {
-  it("returns the last wait result when timeout would be exceeded", async () => {
+  it("returns the last wait result when timeout is exhausted", async () => {
     mockRunIterate.mockResolvedValue(makeWaitResult());
 
-    // interval=30s, timeout=60s → after first wait: elapsed~0ms, next tick would put us at ~30s;
-    // after second wait: elapsed~30s, next tick would put us at ~60s >= 60s, so loop exits.
+    // interval=30s, timeout=60s → tick1 at t=0 (sleep 30s), tick2 at t=30s (sleep 30s), tick3 at t=60s (remaining=0 → return)
     const pollPromise = runPoll({
       prNumber: 42,
       format: "text",
@@ -18,12 +17,11 @@ describe("runPoll — timeout returns final wait", () => {
       timeoutSeconds: 60,
     });
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(60_000);
 
     const result = await pollPromise;
 
     expect(result.action).toBe("wait");
-    // exactly 2 calls: first tick (elapsed~0, 0+30<60 → sleep), second tick (elapsed~30, 30+30>=60 → return)
-    expect(mockRunIterate).toHaveBeenCalledTimes(2);
+    expect(mockRunIterate).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
+++ b/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { describe, it, expect, vi } from "vitest";
+import { mockRunIterate, makeWaitResult, registerPollHooks } from "./poll.test-support.mts";
+import { runPoll } from "./poll.mts";
+
+registerPollHooks();
+
+describe("runPoll — timeout returns final wait", () => {
+  it("returns the last wait result when timeout would be exceeded", async () => {
+    mockRunIterate.mockResolvedValue(makeWaitResult());
+
+    // interval=30s, timeout=60s → after first wait: elapsed~0ms, next tick would put us at ~30s;
+    // after second wait: elapsed~30s, next tick would put us at ~60s >= 60s, so loop exits.
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 60,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const result = await pollPromise;
+
+    expect(result.action).toBe("wait");
+    // exactly 2 calls: first tick (elapsed~0, 0+30<60 → sleep), second tick (elapsed~30, 30+30>=60 → return)
+    expect(mockRunIterate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/commands/poll.test-support.mts
+++ b/src/commands/poll.test-support.mts
@@ -1,0 +1,86 @@
+import { vi, beforeEach, afterEach } from "vitest";
+import type { IterateResult } from "../types.mts";
+
+vi.mock("./iterate/index.mts", () => ({ runIterate: vi.fn() }));
+
+import { runIterate } from "./iterate/index.mts";
+
+const mockRunIterate = vi.mocked(runIterate);
+
+function makeWaitResult(overrides: Partial<IterateResult> = {}): IterateResult {
+  return {
+    action: "wait",
+    pr: 42,
+    repo: "owner/repo",
+    status: "IN_PROGRESS",
+    state: "OPEN",
+    mergeStateStatus: "BLOCKED",
+    mergeStatus: "BLOCKED",
+    reviewDecision: "REVIEW_REQUIRED",
+    blockingBotReviewInProgress: false,
+    isDraft: false,
+    shouldCancel: false,
+    remainingSeconds: 0,
+    summary: { passing: 2, failing: 0, inProgress: 1, skipped: 0, filtered: 0 },
+    baseBranch: "main",
+    checks: [],
+    log: "WAIT: 2 passing, 1 in-progress",
+    ...overrides,
+  } as unknown as IterateResult;
+}
+
+function makeCancelResult(): IterateResult {
+  return {
+    action: "cancel",
+    pr: 42,
+    repo: "owner/repo",
+    status: "READY",
+    state: "MERGED",
+    mergeStateStatus: "CLEAN",
+    mergeStatus: "CLEAN",
+    reviewDecision: "APPROVED",
+    blockingBotReviewInProgress: false,
+    isDraft: false,
+    shouldCancel: true,
+    remainingSeconds: 0,
+    summary: { passing: 3, failing: 0, inProgress: 0, skipped: 0, filtered: 0 },
+    baseBranch: "main",
+    checks: [],
+    reason: "merged",
+    log: "CANCEL: PR #42 is merged — stopping",
+  } as unknown as IterateResult;
+}
+
+function makeMarkReadyResult(): IterateResult {
+  return {
+    action: "mark_ready",
+    pr: 42,
+    repo: "owner/repo",
+    status: "READY",
+    state: "OPEN",
+    mergeStateStatus: "CLEAN",
+    mergeStatus: "CLEAN",
+    reviewDecision: "APPROVED",
+    blockingBotReviewInProgress: false,
+    isDraft: false,
+    shouldCancel: false,
+    remainingSeconds: 0,
+    summary: { passing: 3, failing: 0, inProgress: 0, skipped: 0, filtered: 0 },
+    baseBranch: "main",
+    checks: [],
+    markedReady: true,
+    log: "MARKED READY: PR #42 converted from draft to ready for review",
+  } as unknown as IterateResult;
+}
+
+function registerPollHooks(): void {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+}
+
+export { mockRunIterate, makeWaitResult, makeCancelResult, makeMarkReadyResult, registerPollHooks };


### PR DESCRIPTION
## Summary

- Adds `pr-shepherd poll [PR] [--interval 30s] [--timeout 5m]` — a blocking command that loops `runIterate` every `--interval` seconds until the action is non-WAIT or `--timeout` fires. Stdout shows only the final tick; WAIT progress is written to stderr (TTY-gated, or always with `--verbose`).
- Updates `SKILL.md` to enumerate three iteration strategies (blocking poll / scheduled wakeup / inline sleep) rather than mandating one, fixing Codex Spark's habit of ignoring the instruction.
- Updates `docs/actions.md`, `docs/cli-usage.md`, `docs/watch-loop.md`, `docs/skills.md` to reflect the new command and soften the "no polling loops" admonitions to "no *unbounded* loops outside `pr-shepherd poll`".

## Test plan

- [x] Unit tests for `runPoll`: stops on cancel, mark_ready, loops on wait, timeout, tick progress, forwarded flags
- [x] All existing tests still pass
- [x] `npm run typecheck` clean
- [x] `npx oxlint` clean (all new files under 200 lines)
- [x] `npm run format:check` clean

Closes #219, closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- [IC_kwDOSGizTs8AAAABCh_8jQ](https://github.com/jonathanong/pr-shepherd/pull/221#issuecomment-4464835725) (CodeRabbit): Rate-limit warning only, no code feedback. Minimized — no code changes needed.
- [PRRT_kwDOSGizTs6CgpK3](https://github.com/jonathanong/pr-shepherd/pull/221#discussion_r3251718060) (Codex, zero interval): Already fixed in the same commit batch — `validateSecondsDurationFlag` regex changed from `\d+` to `[1-9]\d*`, rejecting 0, 0s, 0m, 0h. Resolved.
- [PRRT_kwDOSGizTs6CgpK7](https://github.com/jonathanong/pr-shepherd/pull/221#discussion_r3251718066) (Codex, non-finite timeout): Fixed — added `Number.isFinite(n)` guard in `parseDurationToSeconds` so overflow-to-Infinity inputs fall back to the default. Covered by regression test. Resolved.