### PR TITLE
Make pr-shepherd skill poll-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Example Workflow:
 
 The CLI emits unified recheck instructions. Generated commands use `cli.runner` from `.pr-shepherdrc.yml`: `auto` (default), `npx`, `pnpm`, `yarn`, or `bun`.
 
-At a high level, the skill invokes `pr-shepherd <PR>` through the selected package runner, which provides actionable feedback directly to the agent:
+At a high level, the skill invokes `pr-shepherd poll <PR>` through the selected package runner, which provides actionable feedback directly to the agent:
 
 ```
-> npx pr-shepherd 123
+> npx pr-shepherd poll 123
 
 # PR #123 [FIX_CODE]
 
@@ -61,7 +61,7 @@ _(schematic — actual steps depend on PR state)_
 4. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`.
 5. Run the `resolve:` command above, substituting `"$HEAD_SHA"`.
 6. Add or update a `## Shepherd Journal` section in the PR description for any large decisions made, appending under the existing heading if it already exists.
-7. CI needs time to run on the new push. Schedule one session-only follow-up task to run `npx pr-shepherd 123` to recheck once after a fresh delay between 30 seconds and 4 minutes, then end this turn. Do not sleep or rerun inline.
+7. CI needs time to run on the new push. Run `npx pr-shepherd poll 123` again to continue until Shepherd returns `[CANCEL]` or `[ESCALATE]`.
 ```
 
 On every iteration, a command is returned to instruct the agent exactly what to do. No guessing, no thinking, as few agentic turns as possible:
@@ -97,7 +97,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling the reusable command until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling `pr-shepherd poll` until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 - Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
@@ -114,7 +114,7 @@ Recommendations:
 
 ### Iterate a PR to completion
 
-One-tick dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section telling the agent how to run the next tick; the loop continues until `[CANCEL]` or `[ESCALATE]`.
+Poll dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section; the skill follows it, then invokes `pr-shepherd poll` again until `[CANCEL]` or `[ESCALATE]`.
 
 Claude Code (via `pr-shepherd` skill):
 
@@ -127,8 +127,8 @@ Claude Code (via `pr-shepherd` skill):
 Codex or direct CLI:
 
 ```sh
-npx pr-shepherd 42
-npx pr-shepherd 42 --ready-delay 15m
+npx pr-shepherd poll 42
+npx pr-shepherd poll 42 --ready-delay 15m
 npx pr-shepherd iterate 42               # legacy-compatible spelling
 ```
 
@@ -219,12 +219,12 @@ The plugin only installs the skill; it does not install the CLI into target repo
 Iterate a PR from Codex with the target repository's package runner:
 
 ```bash
-<runner> pr-shepherd iterate 42
+<runner> pr-shepherd poll 42
 ```
 
-For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd iterate 42`. For Bun repos (with `bun.lock` or `bun.lockb`), use `bunx pr-shepherd iterate 42`. For npm repos, use `npx pr-shepherd iterate 42`.
+For example, a repo like `~/filaments` that declares `packageManager: "pnpm@..."` and has `pnpm-lock.yaml` should use `pnpm exec pr-shepherd poll 42`. For Bun repos (with `bun.lock` or `bun.lockb`), use `bunx pr-shepherd poll 42`. For npm repos, use `npx pr-shepherd poll 42`.
 
-Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. Continue until Shepherd emits `[CANCEL]` or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `pr-shepherd iterate 42` remains supported for existing workflows.
+Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. Continue invoking `pr-shepherd poll` until Shepherd emits `[CANCEL]` or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures). `pr-shepherd iterate 42` remains supported for existing workflows.
 
 ### As a global CLI
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -171,7 +171,7 @@ If a patch fails to apply (drift since the suggestion was written), apply the fi
 
 ### pr-shepherd [PR]
 
-One iterate tick: classifies current PR state and emits a single action. The skill calls this on each tick and follows the `## Instructions` section verbatim. `pr-shepherd iterate [PR]` remains supported as a legacy alias. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
+One iterate tick: classifies current PR state and emits a single action. `pr-shepherd iterate [PR]` remains supported as a legacy alias for direct CLI workflows; the shipped skill invokes `pr-shepherd poll [PR]` and follows each returned `## Instructions` section. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
 
 ```sh
 pr-shepherd 42

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 [← README](../README.md)
 
-One skill is shipped for both Claude Code and Codex: `pr-shepherd`. It is a thin one-tick dispatcher — it runs `<runner> pr-shepherd <PR>` and follows the `## Instructions` embedded in the output. All policy, state transitions, and per-action guidance live in the CLI output, not in the skill.
+One skill is shipped for both Claude Code and Codex: `pr-shepherd`. It is a thin poll dispatcher — it runs `<runner> pr-shepherd poll <PR>` and follows the `## Instructions` embedded in the output. All policy, state transitions, and per-action guidance live in the CLI output, not in the skill.
 
 ## Claude Code
 
@@ -21,13 +21,7 @@ Use the skill inside a `/goal`:
 /goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
 ```
 
-The goal loop handles recurrence. Each tick the skill runs one iterate cycle and prints the output. For non-terminal actions, follow the CLI's `## Instructions`. Pick one iteration strategy:
-
-- **Scheduled wakeup** — schedule exactly one next session-only iteration after a fresh 30s–4m delay, then end the turn.
-- **Blocking poll** — run `<runner> pr-shepherd poll <N>` to loop internally until a non-WAIT action appears (bounded by `--timeout`, default 5m).
-- **Inline sleep** — sleep inline for a fresh 30s–4m delay, then rerun.
-
-Do not combine strategies and do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`. `[CANCEL]` and `[ESCALATE]` stop the goal regardless of strategy.
+The goal loop handles recurrence. The skill invokes `<runner> pr-shepherd poll <N>` and prints the output. For non-terminal actions, follow the CLI's `## Instructions`, then invoke `<runner> pr-shepherd poll <N>` again. `[CANCEL]` and `[ESCALATE]` stop the goal.
 
 ## Codex
 
@@ -68,7 +62,7 @@ Use the skill inside a `/goal`:
 /goal $pr-shepherd 42
 ```
 
-Codex runs the same skill — one tick per goal iteration. Alternatively, Codex can run `<runner> pr-shepherd poll <N>` to block until a non-WAIT action appears.
+Codex runs the same skill: invoke `<runner> pr-shepherd poll <N>`, follow the output, and continue until `[CANCEL]` or `[ESCALATE]`.
 
 ## Resolve without iterating
 

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -4,13 +4,9 @@
 
 ## Overview
 
-pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. Three iteration strategies are valid:
+pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. The skill always invokes `<runner> pr-shepherd poll <PR>`, which loops internally while the PR is in `[WAIT]` and returns whenever an actionable or terminal state appears.
 
-- **Scheduled wakeup + one tick** — schedule a single session-only follow-up task after a fresh 30s–4m delay, then end the turn.
-- **Inline sleep + rerun** — sleep inline for a fresh 30s–4m delay, then rerun the iterate command.
-- **Blocking poll** — run `<runner> pr-shepherd poll <PR>` to loop internally until a non-WAIT action appears (bounded by `--timeout`, default 5m).
-
-Each non-terminal action is a single tick (or a bounded poll session). Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
+Each non-terminal action is followed by another `<runner> pr-shepherd poll <PR>` invocation. Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 
 Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with `/goal /pr-shepherd:pr-shepherd`; Codex users invoke it with `/goal $pr-shepherd`.
 
@@ -23,22 +19,17 @@ Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with
    /goal $pr-shepherd <PR>              # Codex
    ```
 
-   The skill resolves the PR number, picks the package runner, and runs one iterate tick:
+   The skill resolves the PR number, picks the package runner, and runs poll:
 
    ```bash
-   <runner> pr-shepherd <PR>
+   <runner> pr-shepherd poll <PR>
    ```
 
 2. **CLI emits an action with `## Instructions`**
    The output begins with `# PR #N [ACTION]` and ends with a numbered `## Instructions` block. The skill follows those instructions exactly.
 
 3. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`)
-   The `## Instructions` tell the active goal how to continue. Pick one strategy:
-   - Schedule one next session-only follow-up task and end the turn.
-   - Sleep inline for a fresh 30s–4m delay, then rerun `<runner> pr-shepherd <PR>`.
-   - Run `<runner> pr-shepherd poll <PR>` to block until the action is non-WAIT.
-
-   Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
+   The active goal follows the `## Instructions` and then invokes `<runner> pr-shepherd poll <PR>` again. `[FIX_CODE]` output must be handled before the next poll invocation.
 
 4. **Terminal actions**
    - `[CANCEL]` — PR is merged/closed, or the ready-delay has elapsed. Goal stops.
@@ -52,18 +43,15 @@ For the full decision tree see [iterate-flow.md](iterate-flow.md). For the merma
 User                    Active Goal             shepherd iterate / poll
  |                          |                        |
  |-- /goal /pr-shepherd --> |                        |
- |                          |-- pr-shepherd <PR> --> |
- |                          |    (or poll <PR>)       |
+ |                          |-- poll <PR> ---------> |
  |                          |                        |-- GraphQL fetch
  |                          |                        |-- classify
  |                          |                        |-- dispatch
  |                          |<-- [ACTION] + ## Instructions
  |                          |                        |
  |  [if non-terminal]       |                        |
- |                          |-- schedule next tick   |  (one-tick strategy)
- |                          |-- sleep + rerun inline |  (inline strategy)
- |                          |-- poll loops + sleep   |  (poll mode: internal)
- |                          |-- pr-shepherd <PR> --> |
+ |                          |-- follow instructions  |
+ |                          |-- poll <PR> ---------> |
  |                          |                        |
  |  [if cancel/escalate]    |                        |
  |                          |   goal ends            |
@@ -73,12 +61,11 @@ User                    Active Goal             shepherd iterate / poll
  |                          |-- commit               |
  |                          |-- push                 |
  |                          |-- resolve threads      |
- |                          |-- schedule or sleep    |
- |                          |-- pr-shepherd <PR> --> |
+ |                          |-- poll <PR> ---------> |
 ```
 
 ## Notes
 
-- The iterate loop does not have a fixed cadence. Each non-terminal tick uses a fresh delay (30s-4m), adapting to CI latency automatically.
+- Poll uses `--interval` and `--timeout` for WAIT-state rechecks. Defaults are 30 seconds and 5 minutes.
 - Code changes (`fix_code`, rebase) are handled inline by the active goal — no subagent is spawned.
 - The ready-delay (default 10 minutes) is read from `watch.readyDelayMinutes` in `.pr-shepherdrc.yml`. See [ready-delay.md](ready-delay.md) and [configuration.md](configuration.md).

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -24,7 +24,7 @@ Poll dispatcher for iterating a PR to completion.
    - Prefer `package.json` `packageManager`: `pnpm@...` → `pnpm exec`, `yarn@...` → `yarn run`, `bun@...` → `bunx`, `npm@...` → `npx`.
    - If `packageManager` is absent, use lockfiles: `pnpm-lock.yaml` → `pnpm exec`, `yarn.lock` → `yarn run`, `bun.lock` / `bun.lockb` → `bunx`, `package-lock.json` or no signal → `npx`.
 
-3. **Run `pr-shepherd poll`, nothing else:**
+3. **Run `pr-shepherd poll`:**
 
    If the package is missing in the target repository, first check `gh pr view <N> --json state --jq .state`. If it prints `MERGED` or `CLOSED`, report `PR #N is already merged/closed. Nothing to do.` and stop. Otherwise, tell the user to install pr-shepherd with the matching dev-dependency command: `pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, `bun add -d pr-shepherd`, or `npm install --save-dev pr-shepherd`.
 

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: ["Bash", "Read", "Grep", "Edit", "Write", "Glob", "Skill"]
 
 # pr-shepherd
 
-One-tick dispatcher for iterating a PR to completion.
+Poll dispatcher for iterating a PR to completion.
 
 ## Arguments: $ARGUMENTS
 
@@ -20,40 +20,30 @@ One-tick dispatcher for iterating a PR to completion.
    - Otherwise, infer: `gh pr view --json number --jq .number`
    - If no PR found, report an error and stop.
 
-2. **Short-circuit if merged or closed:**
-
-   ```bash
-   gh pr view <N> --json state --jq '.state'
-   ```
-
-   If `MERGED` or `CLOSED`, output: `PR #N is already merged/closed. Nothing to do.` and stop.
-
-3. **Select the package runner** from the target repository root:
+2. **Select the package runner** from the target repository root:
    - Prefer `package.json` `packageManager`: `pnpm@...` → `pnpm exec`, `yarn@...` → `yarn run`, `bun@...` → `bunx`, `npm@...` → `npx`.
    - If `packageManager` is absent, use lockfiles: `pnpm-lock.yaml` → `pnpm exec`, `yarn.lock` → `yarn run`, `bun.lock` / `bun.lockb` → `bunx`, `package-lock.json` or no signal → `npx`.
 
-4. **Run one iterate tick:**
+3. **Run `pr-shepherd poll`, nothing else:**
 
    If the package is missing in the target repository, tell the user to install pr-shepherd with the matching dev-dependency command: `pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, `bun add -d pr-shepherd`, or `npm install --save-dev pr-shepherd`.
 
    ```bash
-   <runner> pr-shepherd <N>
+   <runner> pr-shepherd poll <N>
    ```
+
+   Preserve any supported flags from `$ARGUMENTS` after the PR number or URL, such as `--ready-delay 15m`, `--interval 1m`, or `--timeout 15m`.
 
    Print the full output. Follow the `## Instructions` section exactly.
 
-5. **Persistence:** Do not stop polling/iterating unless directed by the human or until the CLI returns a terminal state (`[CANCEL]` or `[ESCALATE]`). Every other action — `[WAIT]`, `[MARK_READY]`, `[FIX_CODE]` — is non-terminal and must be followed by another tick via one of the strategies below.
+4. **Persistence:** Continuously call `<runner> pr-shepherd poll <N>` until the CLI returns `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action is non-terminal:
+   - `[WAIT]`: call `<runner> pr-shepherd poll <N>` again.
+   - `[MARK_READY]`: call `<runner> pr-shepherd poll <N>` again.
+   - `[FIX_CODE]`: follow the output's `## Instructions`, then call `<runner> pr-shepherd poll <N>` again.
 
-6. **Stop conditions (terminal states):**
+   Treat nonzero poll exit codes as state, not command failure: `1` means `[FIX_CODE]`, `2` means `[CANCEL]`, and `3` means `[ESCALATE]`.
+
+5. **Stop conditions (terminal states):**
    - Stop when the CLI emits `[CANCEL]` (ready-delay completed, or PR merged/closed).
    - Stop when the CLI emits `[ESCALATE]`, including `stall-timeout` for repeated unchanged CI failures.
    - **Do NOT merge the pull request** unless the human has explicitly requested or allowed it.
-
-7. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) — follow the `## Instructions` in the output. Pick one iteration strategy:
-   - **Blocking poll** — rerun as `<runner> pr-shepherd poll <N> [--interval <duration>] [--timeout <duration>]` (defaults: interval 30s, timeout 5m). Holds the agent turn until the action is non-WAIT or the timeout fires. Simplest when the agent cannot reliably schedule its own follow-up.
-   - **Scheduled wakeup + one tick** — schedule a single session-only follow-up task to rerun `<runner> pr-shepherd <N>` after a fresh 30s–4m delay, then end the turn.
-   - **Inline sleep + rerun** — sleep inline for a fresh 30s–4m delay, then rerun.
-
-   **Never write a custom polling loop** (shell `while`/`until` loops, script files that loop over pr-shepherd output, etc.). Custom loops poll only for terminal states and silently skip `[FIX_CODE]` handling — actionable review threads, failing checks, and resolve commands get missed. Use `pr-shepherd poll` for WAIT-state waiting; it exits on any non-WAIT action so the caller handles `[FIX_CODE]` and other actionable outputs normally.
-
-   Do not combine strategies (e.g., poll AND schedule a wakeup). Remember step 5 — every non-terminal output requires a follow-up tick.

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -20,19 +20,18 @@ Poll dispatcher for iterating a PR to completion.
    - Otherwise, infer: `gh pr view --json number --jq .number`
    - If no PR found, report an error and stop.
 
-2. **Select the package runner** from the target repository root:
-   - Prefer `package.json` `packageManager`: `pnpm@...` → `pnpm exec`, `yarn@...` → `yarn run`, `bun@...` → `bunx`, `npm@...` → `npx`.
-   - If `packageManager` is absent, use lockfiles: `pnpm-lock.yaml` → `pnpm exec`, `yarn.lock` → `yarn run`, `bun.lock` / `bun.lockb` → `bunx`, `package-lock.json` or no signal → `npx`.
+2. **Pick a package runner** from the target repository root:
+   - Choose the runner that resolves the repository's local `pr-shepherd` package, such as `npx`, `pnpm exec`, `yarn run`, or `bunx`.
 
 3. **Run `pr-shepherd poll`:**
 
-   If the package is missing in the target repository, first check `gh pr view <N> --json state --jq .state`. If it prints `MERGED` or `CLOSED`, report `PR #N is already merged/closed. Nothing to do.` and stop. Otherwise, tell the user to install pr-shepherd with the matching dev-dependency command: `pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, `bun add -d pr-shepherd`, or `npm install --save-dev pr-shepherd`.
+   If the package is missing in the target repository, first check `gh pr view <N> --json state --jq .state`. If it prints `MERGED` or `CLOSED`, report `PR #N is already merged/closed. Nothing to do.` and stop. Otherwise, tell the user to install `pr-shepherd` as a dev dependency with the repository's package manager.
 
    ```bash
    <runner> pr-shepherd poll <N>
    ```
 
-   Preserve any supported flags from `$ARGUMENTS` after the PR number or URL, such as `--ready-delay 15m`, `--interval 1m`, or `--timeout 15m`.
+   Do not pass `$ARGUMENTS` through as extra flags. If you need to inspect supported options, run `<runner> pr-shepherd poll --help`.
 
    Print the full output. Follow the `## Instructions` section exactly for the current action. When those instructions tell you to stop and recheck with `pr-shepherd <N>` after a delay, use `<runner> pr-shepherd poll <N>` as the next invocation instead; do not also run the one-shot command.
 

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -26,7 +26,7 @@ Poll dispatcher for iterating a PR to completion.
 
 3. **Run `pr-shepherd poll`, nothing else:**
 
-   If the package is missing in the target repository, tell the user to install pr-shepherd with the matching dev-dependency command: `pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, `bun add -d pr-shepherd`, or `npm install --save-dev pr-shepherd`.
+   If the package is missing in the target repository, first check `gh pr view <N> --json state --jq .state`. If it prints `MERGED` or `CLOSED`, report `PR #N is already merged/closed. Nothing to do.` and stop. Otherwise, tell the user to install pr-shepherd with the matching dev-dependency command: `pnpm add -D pr-shepherd`, `yarn add -D pr-shepherd`, `bun add -d pr-shepherd`, or `npm install --save-dev pr-shepherd`.
 
    ```bash
    <runner> pr-shepherd poll <N>
@@ -34,14 +34,14 @@ Poll dispatcher for iterating a PR to completion.
 
    Preserve any supported flags from `$ARGUMENTS` after the PR number or URL, such as `--ready-delay 15m`, `--interval 1m`, or `--timeout 15m`.
 
-   Print the full output. Follow the `## Instructions` section exactly.
+   Print the full output. Follow the `## Instructions` section exactly for the current action. When those instructions tell you to stop and recheck with `pr-shepherd <N>` after a delay, use `<runner> pr-shepherd poll <N>` as the next invocation instead; do not also run the one-shot command.
 
 4. **Persistence:** Continuously call `<runner> pr-shepherd poll <N>` until the CLI returns `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action is non-terminal:
    - `[WAIT]`: call `<runner> pr-shepherd poll <N>` again.
    - `[MARK_READY]`: call `<runner> pr-shepherd poll <N>` again.
    - `[FIX_CODE]`: follow the output's `## Instructions`, then call `<runner> pr-shepherd poll <N>` again.
 
-   Treat nonzero poll exit codes as state, not command failure: `1` means `[FIX_CODE]`, `2` means `[CANCEL]`, and `3` means `[ESCALATE]`.
+   Treat a nonzero poll exit code as PR state only when the output contains a matching `# PR #N [ACTION]` heading. Exit code `1` can also mean a command or validation failure; if there is no `[FIX_CODE]` heading, surface the error and stop instead of looping.
 
 5. **Stop conditions (terminal states):**
    - Stop when the CLI emits `[CANCEL]` (ready-delay completed, or PR merged/closed).

--- a/src/cli-parser.main-help.mock.test.mts
+++ b/src/cli-parser.main-help.mock.test.mts
@@ -12,16 +12,32 @@ function getStdout(): string {
 describe("main — top-level help", () => {
   it("prints usage to stdout and exits 0 for --help", async () => {
     await main(["node", "shepherd", "--help"]);
-    expect(getStdout()).toContain("Usage:");
-    expect(getStdout()).toContain("pr-shepherd");
+    const out = getStdout();
+    expect(out).toContain("Usage:");
+    expect(out).toContain("pr-shepherd [PR]");
+    expect(out).toContain("pr-shepherd iterate");
+    expect(out).toContain("pr-shepherd poll");
+    expect(out).toContain("pr-shepherd resolve");
+    expect(out).toContain("pr-shepherd commit-suggestion");
+    expect(out).toContain("pr-shepherd clean <pr|branch|current|repo|all>");
+    expect(out).toContain("pr-shepherd log-file");
+    expect(out).toContain("pr [number]");
+    expect(out).toContain("branch [name]");
+    expect(out).toContain("current");
+    expect(out).toContain("repo");
+    expect(out).toContain("all");
+    expect(out).toContain("Exit codes for iterate and poll:");
     expect(process.exitCode).toBeUndefined();
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 
   it("prints usage to stdout and exits 0 for -h", async () => {
     await main(["node", "shepherd", "-h"]);
-    expect(getStdout()).toContain("Usage:");
-    expect(getStdout()).toContain("pr-shepherd");
+    const out = getStdout();
+    expect(out).toContain("Usage:");
+    expect(out).toContain("Commands:");
+    expect(out).toContain("Common flags:");
+    expect(out).toContain("Clean variants:");
     expect(process.exitCode).toBeUndefined();
     expect(stderrSpy).not.toHaveBeenCalled();
   });

--- a/src/cli-parser.subcommand-help.mock.test.mts
+++ b/src/cli-parser.subcommand-help.mock.test.mts
@@ -55,18 +55,35 @@ const SUBCOMMANDS = [
   "log-file",
 ] as const;
 
+const HELP_EXPECTATIONS: Record<(typeof SUBCOMMANDS)[number], string[]> = {
+  resolve: ["Modes:", "--resolve-thread-ids", "--require-sha", "Exit code:"],
+  "commit-suggestion": ["Preconditions:", "--thread-id", "--description", "Exit codes:"],
+  iterate: ["Actions:", "FIX_CODE", "--stall-timeout", "Exit codes:"],
+  poll: ["Poll flags:", "--interval", "--timeout", "Forwarded iterate flags:"],
+  clean: ["Variants:", "pr [number]", "branch [name]", "--dry-run"],
+  "log-file": ["Environment:", "PR_SHEPHERD_LOG_DISABLED", "PR_SHEPHERD_STATE_DIR"],
+};
+
 for (const sub of SUBCOMMANDS) {
   describe(`${sub} --help / -h`, () => {
     it(`prints usage for '${sub} --help' and exits 0`, async () => {
       await main(["node", "shepherd", sub, "--help"]);
-      expect(getStdout()).toContain("Usage:");
+      const out = getStdout();
+      expect(out).toContain("Usage:");
+      for (const expected of HELP_EXPECTATIONS[sub]) {
+        expect(out).toContain(expected);
+      }
       expect(process.exitCode).toBeUndefined();
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 
     it(`prints usage for '${sub} -h' and exits 0`, async () => {
       await main(["node", "shepherd", sub, "-h"]);
-      expect(getStdout()).toContain("Usage:");
+      const out = getStdout();
+      expect(out).toContain("Usage:");
+      for (const expected of HELP_EXPECTATIONS[sub]) {
+        expect(out).toContain(expected);
+      }
       expect(process.exitCode).toBeUndefined();
       expect(stderrSpy).not.toHaveBeenCalled();
     });
@@ -84,6 +101,8 @@ describe("default iterate path (pr 123 --help)", () => {
   it("prints iterate usage to stdout and exits 0 for '123 --help'", async () => {
     await main(["node", "shepherd", "123", "--help"]);
     expect(getStdout()).toContain("Usage:");
+    expect(getStdout()).toContain("Actions:");
+    expect(getStdout()).toContain("pr-shepherd iterate");
     expect(process.exitCode).toBeUndefined();
     expect(stderrSpy).not.toHaveBeenCalled();
     expect(mockRunIterate).not.toHaveBeenCalled();
@@ -92,6 +111,8 @@ describe("default iterate path (pr 123 --help)", () => {
   it("prints iterate usage to stdout and exits 0 for '123 -h'", async () => {
     await main(["node", "shepherd", "123", "-h"]);
     expect(getStdout()).toContain("Usage:");
+    expect(getStdout()).toContain("Actions:");
+    expect(getStdout()).toContain("pr-shepherd iterate");
     expect(process.exitCode).toBeUndefined();
     expect(stderrSpy).not.toHaveBeenCalled();
     expect(mockRunIterate).not.toHaveBeenCalled();

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -57,8 +57,8 @@ Run one iterate tick for a pull request. This is an alias for 'pr-shepherd [PR]'
 The output contains one action and an action-specific ## Instructions section.
 
 Usage:
-  pr-shepherd [PR] [--format text|json] [--verbose] [iterate-flags]
-  pr-shepherd iterate [PR] [--format text|json] [--verbose] [iterate-flags]
+  pr-shepherd [PR] [iterate-flags]
+  pr-shepherd iterate [PR] [iterate-flags]
 
 Iterate flags:
   --ready-delay <duration>       Settle window before a clean PR cancels. Example: 15m.
@@ -89,8 +89,7 @@ Poll exits as soon as iterate returns MARK_READY, FIX_CODE, CANCEL, or ESCALATE,
 returns the last WAIT result.
 
 Usage:
-  pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--format text|json]
-                         [--verbose] [iterate-flags]
+  pr-shepherd poll [PR] [poll-flags] [iterate-flags]
 
 Poll flags:
   --interval <duration>          Sleep between WAIT ticks. Default: 30s.

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -1,0 +1,160 @@
+export const COMMAND_USAGE = {
+  resolve: `pr-shepherd resolve
+
+Fetch actionable review items or apply GitHub review-state mutations after fixes.
+
+Usage:
+  pr-shepherd resolve [PR] [--fetch] [--format text|json]
+  pr-shepherd resolve [PR] --resolve-thread-ids A,B [--minimize-comment-ids X,Y]
+                            [--dismiss-review-ids Q] [--message MSG]
+                            [--require-sha SHA] [--format text|json]
+
+Modes:
+  fetch                Default when no mutation IDs are provided. Fetches review threads,
+                       comments, first-look items, and instructions.
+  mutate               Runs when any mutation ID flag is present. Resolves threads,
+                       minimizes comments/review summaries, and dismisses reviews.
+
+Flags:
+  --fetch                         Force fetch mode.
+  --resolve-thread-ids <ids>      Comma-separated review thread IDs to resolve.
+  --minimize-comment-ids <ids>    Comma-separated issue/review comment IDs to minimize.
+  --dismiss-review-ids <ids>      Comma-separated CHANGES_REQUESTED review IDs to dismiss.
+  --message <text>                Dismiss message. Required with --dismiss-review-ids.
+  --require-sha <sha>             Wait until GitHub reports this PR head SHA before mutating.
+  --format text|json              Output format. Default: text.
+  --help, -h                      Print this help and exit before GitHub I/O.
+
+PR may be a number or GitHub pull request URL. When omitted, the current branch PR is inferred.
+Exit code: 0 on success; 1 on validation, lookup, or mutation failure.`,
+
+  "commit-suggestion": `pr-shepherd commit-suggestion
+
+Build a patch and commit instructions for one GitHub review thread containing a suggestion block.
+The command does not edit files or mutate git history.
+
+Usage:
+  pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG
+                                      [--description DESC] [--format text|json]
+
+Flags:
+  --thread-id <id>       Review thread ID containing exactly one suggestion to apply. Required.
+  --message <text>       Suggested commit subject. Required and must be non-empty.
+  --description <text>   Optional longer commit body.
+  --format text|json     Output format. Default: text.
+  --help, -h             Print this help and exit before GitHub, git, config, or log I/O.
+
+Preconditions:
+  The current branch must match the PR head ref, and local HEAD must match the PR head SHA.
+
+Exit codes:
+  0  suggestion patch and instructions produced
+  1  validation, lookup, precondition, or suggestion parsing failure`,
+
+  iterate: `pr-shepherd iterate
+
+Run one iterate tick for a pull request. This is an alias for 'pr-shepherd [PR]'.
+The output contains one action and an action-specific ## Instructions section.
+
+Usage:
+  pr-shepherd [PR] [--format text|json] [--verbose] [iterate-flags]
+  pr-shepherd iterate [PR] [--format text|json] [--verbose] [iterate-flags]
+
+Iterate flags:
+  --ready-delay <duration>       Settle window before a clean PR cancels. Example: 15m.
+  --stall-timeout <duration>     Escalate repeated unchanged failures after this duration.
+  --no-auto-mark-ready           Do not convert draft PRs to ready for review.
+  --no-auto-cancel-actionable    Do not cancel in-progress runs before actionable fixes.
+  --format text|json             Output Markdown text or JSON. Default: text.
+  --verbose                      Include verbose iterate fields.
+  --help, -h                     Print this help and exit before GitHub, git, config, or log I/O.
+
+Actions:
+  WAIT        No immediate code action; recheck later or use pr-shepherd poll.
+  MARK_READY  Draft PR was marked ready for review.
+  FIX_CODE    Apply fixes, commit, push, and run the printed resolve command.
+  CANCEL      Terminal state: merged/closed or ready-delay elapsed.
+  ESCALATE    Terminal state requiring human direction.
+
+Exit codes:
+  0  WAIT or MARK_READY
+  1  FIX_CODE, or a command/validation error
+  2  CANCEL
+  3  ESCALATE`,
+
+  poll: `pr-shepherd poll
+
+Run iterate repeatedly while the action is WAIT. Print only the final tick to stdout.
+Poll exits as soon as iterate returns MARK_READY, FIX_CODE, CANCEL, or ESCALATE, or when timeout
+returns the last WAIT result.
+
+Usage:
+  pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--format text|json]
+                         [--verbose] [iterate-flags]
+
+Poll flags:
+  --interval <duration>          Sleep between WAIT ticks. Default: 30s.
+  --timeout <duration>           Maximum wall-clock wait. Default: 5m.
+
+Forwarded iterate flags:
+  --ready-delay <duration>       Settle window before a clean PR cancels. Example: 15m.
+  --stall-timeout <duration>     Escalate repeated unchanged failures after this duration.
+  --no-auto-mark-ready           Do not convert draft PRs to ready for review.
+  --no-auto-cancel-actionable    Do not cancel in-progress runs before actionable fixes.
+  --format text|json             Output Markdown text or JSON. Default: text.
+  --verbose                      Include verbose iterate fields and always print poll progress.
+  --help, -h                     Print this help and exit before GitHub, git, config, or log I/O.
+
+Durations accept seconds, minutes, or hours: 30s, 2m, 1h, or bare seconds.
+WAIT progress is written to stderr when stderr is a TTY or --verbose is set.
+
+Exit codes:
+  0  WAIT timeout or MARK_READY
+  1  FIX_CODE, or a command/validation error
+  2  CANCEL
+  3  ESCALATE`,
+
+  clean: `pr-shepherd clean
+
+Remove pr-shepherd state files from PR_SHEPHERD_STATE_DIR.
+
+Usage:
+  pr-shepherd clean pr [number] [--dry-run] [--format text|json]
+  pr-shepherd clean branch [name] [--dry-run] [--format text|json]
+  pr-shepherd clean current [--dry-run] [--format text|json]
+  pr-shepherd clean repo [--dry-run] [--format text|json]
+  pr-shepherd clean all [--dry-run] [--format text|json]
+
+Variants:
+  pr [number]          Remove state for one PR. Defaults to current branch PR.
+  branch [name]        Resolve a branch to its open PR, then remove that PR's state.
+                       Defaults to current branch.
+  current              Alias for branch against the current branch.
+  repo                 Remove all state for the current repository, including worktree logs.
+  all                  Remove all pr-shepherd state.
+
+Flags:
+  --dry-run            Preview paths without removing them.
+  --format text|json   Output format. Default: text.
+  --help, -h           Print this help and exit before any cleanup.
+
+Exit code: 0 on success; 1 on validation or cleanup failure.`,
+
+  "log-file": `pr-shepherd log-file
+
+Print the per-worktree append-only debug log path for the current repository.
+The log is created by the first non-help pr-shepherd command that initializes logging.
+
+Usage:
+  pr-shepherd log-file [--format text|json]
+
+Flags:
+  --format text|json   Print a raw path or {"path": "..."} JSON. Default: text.
+  --help, -h           Print this help and exit before logging setup.
+
+Environment:
+  PR_SHEPHERD_LOG_DISABLED=1 disables logging.
+  PR_SHEPHERD_STATE_DIR overrides the base state directory.
+
+Exit code: 0 on success; 1 if repository identity cannot be resolved.`,
+} as const;

--- a/src/cli/help-top-page.mts
+++ b/src/cli/help-top-page.mts
@@ -49,9 +49,11 @@ Clean variants:
   all                  Remove all pr-shepherd state.
 
 Exit codes for iterate and poll:
-  0  wait or mark_ready
-  1  fix_code, or a command/validation error
-  2  cancel
-  3  escalate
+  0  WAIT or MARK_READY
+  1  FIX_CODE, or a command/validation error
+  2  CANCEL
+  3  ESCALATE
+
+Durations accept seconds, minutes, or hours: 30s, 2m, 1h, or bare seconds.
 
 Run 'pr-shepherd <command> --help' for command-specific details.`;

--- a/src/cli/help-top-page.mts
+++ b/src/cli/help-top-page.mts
@@ -1,0 +1,57 @@
+export const TOP_USAGE = `pr-shepherd
+
+Autonomous PR CI monitor and review-comment resolver for agentic coding tools.
+
+Usage:
+  pr-shepherd --version | -v
+  pr-shepherd --help | -h
+  pr-shepherd [PR] [flags]
+  pr-shepherd iterate [PR] [flags]
+  pr-shepherd poll [PR] [poll-flags] [iterate-flags]
+  pr-shepherd resolve [PR] [resolve-flags]
+  pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [flags]
+  pr-shepherd clean <pr|branch|current|repo|all> [value] [flags]
+  pr-shepherd log-file [--format text|json]
+
+Commands:
+  [PR]                 Run one iterate tick. This is the default command.
+  iterate              Alias for the default one-tick iterate command.
+  poll                 Re-run iterate while the action is WAIT, then print the final tick.
+  resolve              Fetch actionable review items, or resolve/minimize/dismiss IDs.
+  commit-suggestion    Convert one GitHub suggestion thread into a patch and commit instructions.
+  clean                Remove pr-shepherd state files.
+  log-file             Print the per-worktree debug log path.
+
+PR argument:
+  PR may be a number such as 42 or a GitHub pull request URL.
+  When omitted, pr-shepherd infers the current branch's pull request.
+
+Common flags:
+  --format text|json   Output Markdown text or JSON. Default: text.
+  --verbose            Include verbose iterate fields and poll progress.
+  --help, -h           Print help and exit before any GitHub, git, config, or log I/O.
+
+Iterate flags:
+  --ready-delay <duration>       Settle window before a clean PR cancels. Example: 15m.
+  --stall-timeout <duration>     Escalate repeated unchanged failures after this duration.
+  --no-auto-mark-ready           Do not convert draft PRs to ready for review.
+  --no-auto-cancel-actionable    Do not cancel in-progress runs before actionable fixes.
+
+Poll flags:
+  --interval <duration>          Sleep between WAIT ticks. Default: 30s.
+  --timeout <duration>           Maximum poll wall-clock wait. Default: 5m.
+
+Clean variants:
+  pr [number]          Remove state for one PR. Defaults to current branch PR.
+  branch [name]        Remove state for a branch's PR. Defaults to current branch.
+  current              Alias for branch against the current branch.
+  repo                 Remove all state for the current repository.
+  all                  Remove all pr-shepherd state.
+
+Exit codes for iterate and poll:
+  0  wait or mark_ready
+  1  fix_code, or a command/validation error
+  2  cancel
+  3  escalate
+
+Run 'pr-shepherd <command> --help' for command-specific details.`;

--- a/src/cli/help.mts
+++ b/src/cli/help.mts
@@ -1,48 +1,10 @@
 import { hasFlag } from "./args.mts";
+import { COMMAND_USAGE } from "./help-command-pages.mts";
+import { TOP_USAGE } from "./help-top-page.mts";
 
 export const USAGE = {
-  top:
-    "Usage:\n" +
-    "  pr-shepherd --version | -v\n" +
-    "  pr-shepherd [PR] [--format text|json] [--ready-delay Nm]\n" +
-    "                 [--stall-timeout <duration>] [--no-auto-mark-ready]\n" +
-    "                 [--no-auto-cancel-actionable]\n" +
-    "  pr-shepherd resolve [PR] [--fetch] [--resolve-thread-ids A,B] [--minimize-comment-ids X,Y]\n" +
-    "                           [--dismiss-review-ids Q] [--message MSG] [--require-sha SHA]\n" +
-    "  pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [--description DESC]\n" +
-    "                                     [--format text|json]\n" +
-    "  pr-shepherd iterate [PR] [--format text|json] [--ready-delay Nm]\n" +
-    "                             [--stall-timeout <duration>] [--no-auto-mark-ready]\n" +
-    "                             [--no-auto-cancel-actionable]\n" +
-    "  pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--format text|json] [--ready-delay Nm]\n" +
-    "                        [--stall-timeout <duration>] [--no-auto-mark-ready]\n" +
-    "                        [--no-auto-cancel-actionable]\n" +
-    "  pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]\n" +
-    "  pr-shepherd log-file [--format text|json]",
-
-  resolve:
-    "Usage: pr-shepherd resolve [PR] [--fetch] [--resolve-thread-ids A,B]\n" +
-    "                               [--minimize-comment-ids X,Y] [--dismiss-review-ids Q]\n" +
-    "                               [--message MSG] [--require-sha SHA]",
-
-  "commit-suggestion":
-    "Usage: pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG\n" +
-    "                                          [--description DESC] [--format text|json]",
-
-  iterate:
-    "Usage: pr-shepherd iterate [PR] [--format text|json] [--ready-delay Nm]\n" +
-    "                                [--stall-timeout <duration>] [--no-auto-mark-ready]\n" +
-    "                                [--no-auto-cancel-actionable]",
-
-  poll:
-    "Usage: pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--format text|json]\n" +
-    "                             [--ready-delay Nm] [--stall-timeout <duration>]\n" +
-    "                             [--no-auto-mark-ready] [--no-auto-cancel-actionable]",
-
-  clean:
-    "Usage: pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]",
-
-  "log-file": "Usage: pr-shepherd log-file [--format text|json]",
+  top: TOP_USAGE,
+  ...COMMAND_USAGE,
 } as const;
 
 /** Prints usage for `key` to stdout and returns true if `--help` or `-h` is in args. */


### PR DESCRIPTION
## Summary
- update the pr-shepherd skill to invoke `pr-shepherd poll` as the only iteration entrypoint
- expand CLI help output for top-level and subcommands
- update docs to describe poll-first skill usage

## Tests
- npm run lint
- npm test
- npm run typecheck
- npm run format:check