### PR TITLE
⚡ Bolt: Optimize Array.prototype.includes inside filter to Set.has in check.mts

### DIFF
--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -67,7 +67,10 @@ export async function runCheck(
   let autoResolveErrors: string[] = [];
   if (opts.autoResolve && outdated.length > 0) {
     const { resolved: resolvedIds, errors } = await autoResolveOutdated(outdated.map((t) => t.id));
-    autoResolved = outdated.filter((t) => resolvedIds.includes(t.id));
+    // ⚡ Bolt optimization: Use a Set for O(1) lookups instead of Array.prototype.includes
+    // This reduces the time complexity of the filter operation from O(N*M) to O(N+M)
+    const resolvedIdsSet = new Set(resolvedIds);
+    autoResolved = outdated.filter((t) => resolvedIdsSet.has(t.id));
     autoResolveErrors = errors;
   }
 

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -67,9 +67,7 @@ export async function runCheck(
   let autoResolveErrors: string[] = [];
   if (opts.autoResolve && outdated.length > 0) {
     const { resolved: resolvedIds, errors } = await autoResolveOutdated(outdated.map((t) => t.id));
-    // ⚡ Bolt optimization: Use a Set for O(1) lookups instead of Array.prototype.includes
-    // This reduces the time complexity of the filter operation from O(N*M) to O(N+M)
-    const resolvedIdsSet = new Set(resolvedIds);
+    const resolvedIdsSet = new Set(resolvedIds); // ⚡ Bolt optimization: O(1) lookup
     autoResolved = outdated.filter((t) => resolvedIdsSet.has(t.id));
     autoResolveErrors = errors;
   }


### PR DESCRIPTION
Replaced an O(N * M) Array.prototype.includes inside a filter operation with an O(N + M) Set.prototype.has lookup for resolved thread IDs.

---
*PR created automatically by Jules for task [8131485488637122067](https://jules.google.com/task/8131485488637122067) started by @jonathanong*