### PR TITLE
Default pr-shepherd to poll; dot-per-tick progress

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,18 +5,5 @@
     "radix": "error",
     "max-lines": ["error", 200]
   },
-  "overrides": [
-    {
-      "files": [
-        "*.test.mts",
-        "*.test.*.mts",
-        "*.mock.test.mts",
-        "*.mock.test.*.mts",
-        "*.test-support.mts"
-      ],
-      "rules": {
-        "no-unused-vars": "off"
-      }
-    }
-  ]
+  "overrides": []
 }

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Example Workflow:
 
 The CLI emits unified recheck instructions. Generated commands call `pr-shepherd` directly.
 
-At a high level, the skill invokes `pr-shepherd poll <PR>`, which provides actionable feedback directly to the agent:
+At a high level, the skill invokes `pr-shepherd <PR>` (which polls by default), providing actionable feedback directly to the agent:
 
 ```text
-> pr-shepherd poll 123
+> pr-shepherd 123
 
 # PR #123 [FIX_CODE]
 
@@ -61,7 +61,7 @@ _(schematic — actual steps depend on PR state)_
 4. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`.
 5. Run the `resolve:` command above, substituting `"$HEAD_SHA"`.
 6. Add or update a `## Shepherd Journal` section in the PR description for any large decisions made, appending under the existing heading if it already exists.
-7. CI needs time to run on the new push. Run `pr-shepherd poll 123` again to continue until Shepherd returns `[CANCEL]` or `[ESCALATE]`.
+7. CI needs time to run on the new push. Run `pr-shepherd 123` again to continue until Shepherd returns `[CANCEL]` or `[ESCALATE]`.
 ```
 
 On every iteration, a command is returned to instruct the agent exactly what to do. No guessing, no thinking, as few agentic turns as possible:
@@ -97,7 +97,7 @@ Some other workflow improvements:
 
 Recommendations:
 
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling `pr-shepherd poll` until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
+- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling `pr-shepherd <PR>` until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures).
 - Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
 - Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
 - Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
@@ -114,7 +114,7 @@ Recommendations:
 
 ### Iterate a PR to completion
 
-Poll dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section; the skill follows it, then invokes `pr-shepherd poll` again until `[CANCEL]` or `[ESCALATE]`.
+Poll dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section; the skill follows it, then invokes `pr-shepherd <PR>` again until `[CANCEL]` or `[ESCALATE]`.
 
 Claude Code (via `pr-shepherd` skill):
 
@@ -128,9 +128,9 @@ Codex or direct CLI:
 
 ```sh
 pr-shepherd 42
+pr-shepherd 42 --interval 45 --timeout 4m
 pr-shepherd 42 --ready-delay 15m
-pr-shepherd poll 42
-pr-shepherd iterate 42               # legacy-compatible spelling
+pr-shepherd iterate 42               # single tick
 ```
 
 ## Iterate decision loop

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Codex or direct CLI:
 
 ```sh
 pr-shepherd 42
-pr-shepherd 42 --interval 45 --timeout 4m
+pr-shepherd 42 --interval 45s --timeout 4m
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42               # single tick
 ```

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -175,7 +175,7 @@ Poll: loops iterate ticks until the action is non-WAIT or `--timeout` elapses. T
 
 ```sh
 pr-shepherd 42
-pr-shepherd 42 --interval 45 --timeout 4m    # custom cadence
+pr-shepherd 42 --interval 45s --timeout 4m    # custom cadence
 pr-shepherd 42 --ready-delay 15m             # override ready-delay for this run
 pr-shepherd iterate 42                       # single tick only
 ```

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -4,10 +4,10 @@
 
 ```
 pr-shepherd -v|--version
-pr-shepherd [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
+pr-shepherd [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
-pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # legacy alias for pr-shepherd [PR]
+pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # single tick
 pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd log-file
 pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]
@@ -171,12 +171,13 @@ If a patch fails to apply (drift since the suggestion was written), apply the fi
 
 ### pr-shepherd [PR]
 
-One iterate tick: classifies current PR state and emits a single action. `pr-shepherd iterate [PR]` remains supported as a legacy alias for direct CLI workflows; the shipped skill invokes `pr-shepherd poll [PR]` and follows each returned `## Instructions` section. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
+Poll: loops iterate ticks until the action is non-WAIT or `--timeout` elapses. This is the default command — `pr-shepherd 42` is equivalent to `pr-shepherd poll 42`. `pr-shepherd iterate [PR]` runs a single tick. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
 
 ```sh
 pr-shepherd 42
-pr-shepherd 42 --ready-delay 15m          # override ready-delay for this run
-pr-shepherd iterate 42                    # legacy alias
+pr-shepherd 42 --interval 45 --timeout 4m    # custom cadence
+pr-shepherd 42 --ready-delay 15m             # override ready-delay for this run
+pr-shepherd iterate 42                       # single tick only
 ```
 
 **Flags:**
@@ -206,7 +207,7 @@ WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
 
 The `## Instructions` recheck command is the same regardless of calling agent. If the current command used `--ready-delay`, the rerun command includes the same flag.
 
-This is a one-shot loop contract: do not translate it into shell-level polling (`while true`, fixed-interval sleeps, etc.).
+The `pr-shepherd [PR]` default command polls, so callers get the loop automatically. Use `pr-shepherd iterate [PR]` for a single tick.
 
 Example for `[FIX_CODE]` (richest action):
 
@@ -272,7 +273,7 @@ Loops `pr-shepherd [PR]` every `--interval` seconds until the action is non-WAIT
 
 All `pr-shepherd [PR]` flags (`--ready-delay`, `--stall-timeout`, `--no-auto-mark-ready`, `--no-auto-cancel-actionable`, `--verbose`, `--format`) are forwarded to each tick.
 
-Stdout is the final tick's output only; per-tick WAIT progress is written to stderr (TTY-gated; always on when `--verbose` is set).
+Stdout is the final tick's output only; each WAIT tick writes a single dot to stderr. `--verbose` emits the detailed per-tick line instead.
 
 Exit codes: `0` wait/mark_ready · `1` fix_code · `2` cancel · `3` escalate
 

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -20,20 +20,20 @@ Poll dispatcher for iterating a PR to completion.
    - Otherwise, infer: `gh pr view --json number --jq .number`
    - If no PR found, report an error and stop.
 
-2. **Run `pr-shepherd poll`:**
+2. **Run `pr-shepherd`:**
 
    ```bash
-   pr-shepherd poll <N>
+   pr-shepherd <N> --interval 45 --timeout 4m
    ```
 
-   Do not pass `$ARGUMENTS` through as extra flags. If you need to inspect supported options, run `pr-shepherd poll --help`.
+   Do not pass `$ARGUMENTS` through as extra flags. If you need to inspect supported options, run `pr-shepherd --help`.
 
-   Print the full output. Follow the `## Instructions` section exactly for the current action. When those instructions tell you to stop and recheck with `pr-shepherd <N>` after a delay, use `pr-shepherd poll <N>` as the next invocation instead; do not also run the one-shot command.
+   Print the full output. Follow the `## Instructions` section exactly for the current action.
 
-3. **Persistence:** Continuously call `pr-shepherd poll <N>` until the CLI returns `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action is non-terminal:
-   - `[WAIT]`: call `pr-shepherd poll <N>` again.
-   - `[MARK_READY]`: call `pr-shepherd poll <N>` again.
-   - `[FIX_CODE]`: follow the output's `## Instructions`, then call `pr-shepherd poll <N>` again.
+3. **Persistence:** Continuously call `pr-shepherd <N> --interval 45 --timeout 4m` until the CLI returns `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action is non-terminal:
+   - `[WAIT]`: call `pr-shepherd <N> --interval 45 --timeout 4m` again.
+   - `[MARK_READY]`: call `pr-shepherd <N> --interval 45 --timeout 4m` again.
+   - `[FIX_CODE]`: follow the output's `## Instructions`, then call `pr-shepherd <N> --interval 45 --timeout 4m` again.
 
    Treat a nonzero poll exit code as PR state only when the output contains a matching `# PR #N [ACTION]` heading. Exit code `1` can also mean a command or validation failure; if there is no `[FIX_CODE]` heading, surface the error and stop instead of looping.
 

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -23,17 +23,17 @@ Poll dispatcher for iterating a PR to completion.
 2. **Run `pr-shepherd`:**
 
    ```bash
-   pr-shepherd <N> --interval 45 --timeout 4m
+   pr-shepherd <N> --interval 45s --timeout 4m
    ```
 
    Do not pass `$ARGUMENTS` through as extra flags. If you need to inspect supported options, run `pr-shepherd --help`.
 
    Print the full output. Follow the `## Instructions` section exactly for the current action.
 
-3. **Persistence:** Continuously call `pr-shepherd <N> --interval 45 --timeout 4m` until the CLI returns `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action is non-terminal:
-   - `[WAIT]`: call `pr-shepherd <N> --interval 45 --timeout 4m` again.
-   - `[MARK_READY]`: call `pr-shepherd <N> --interval 45 --timeout 4m` again.
-   - `[FIX_CODE]`: follow the output's `## Instructions`, then call `pr-shepherd <N> --interval 45 --timeout 4m` again.
+3. **Persistence:** Continuously call `pr-shepherd <N> --interval 45s --timeout 4m` until the CLI returns `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action is non-terminal:
+   - `[WAIT]`: call `pr-shepherd <N> --interval 45s --timeout 4m` again.
+   - `[MARK_READY]`: call `pr-shepherd <N> --interval 45s --timeout 4m` again.
+   - `[FIX_CODE]`: follow the output's `## Instructions`, then call `pr-shepherd <N> --interval 45s --timeout 4m` again.
 
    Treat a nonzero poll exit code as PR state only when the output contains a matching `# PR #N [ACTION]` heading. Exit code `1` can also mean a command or validation failure; if there is no `[FIX_CODE]` heading, surface the error and stop instead of looping.
 

--- a/src/checks/classify.test.mts
+++ b/src/checks/classify.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { classifyChecks, getCiVerdict } from "./classify.mts";
 import type { CheckRun } from "../types.mts";

--- a/src/checks/triage.fetchstartupfailurechecks.mock.test.mts
+++ b/src/checks/triage.fetchstartupfailurechecks.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.fetchstartupfailurechecks.warns-when-startup-failure-pagination-reaches-the-cap.mock.test.mts
+++ b/src/checks/triage.fetchstartupfailurechecks.warns-when-startup-failure-pagination-reaches-the-cap.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.mergestartupfailurechecks.mock.test.mts
+++ b/src/checks/triage.mergestartupfailurechecks.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, makeCheck, mergeStartupFailureChecks } from "./triage.test-support.mts";
 
 registerHooks();

--- a/src/checks/triage.test-support.mts
+++ b/src/checks/triage.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Stub fetch globally so http.mts uses our mock.

--- a/src/checks/triage.triagefailingchecks-batch.mock.test.mts
+++ b/src/checks/triage.triagefailingchecks-batch.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.triagefailingchecks-cancelled-short-circuits.mock.test.mts
+++ b/src/checks/triage.triagefailingchecks-cancelled-short-circuits.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.triagefailingchecks-failedstep-non-success-conclusions.mock.test.mts
+++ b/src/checks/triage.triagefailingchecks-failedstep-non-success-conclusions.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.triagefailingchecks-failedstep.mock.test.mts
+++ b/src/checks/triage.triagefailingchecks-failedstep.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.triagefailingchecks-job-info.mock.test.mts
+++ b/src/checks/triage.triagefailingchecks-job-info.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/checks/triage.triagefailingchecks-no-runid.mock.test.mts
+++ b/src/checks/triage.triagefailingchecks-no-runid.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/cli-parser.clean.mock.test.mts
+++ b/src/cli-parser.clean.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import {
   registerHooks,

--- a/src/cli-parser.clean.test-support.mts
+++ b/src/cli-parser.clean.test-support.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/clean.mts", () => ({

--- a/src/cli-parser.commit-suggestion.main-commit-suggestion.mock.test.mts
+++ b/src/cli-parser.commit-suggestion.main-commit-suggestion.mock.test.mts
@@ -1,11 +1,9 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   SUGGESTION_RESULT,
   getStdout,
   mockRunCommitSuggestion,
-  runCommitSuggestion,
   stderrSpy,
 } from "./cli-parser.commit-suggestion.test-support.mts";
 import { main } from "./cli-parser.mts";

--- a/src/cli-parser.commit-suggestion.test-support.mts
+++ b/src/cli-parser.commit-suggestion.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
 vi.mock("./commands/resolve.mts", () => ({

--- a/src/cli-parser.iterate-fix.main-iterate-text-format-fix-code-and-checks.fix-code-renders.mock.test.mts
+++ b/src/cli-parser.iterate-fix.main-iterate-text-format-fix-code-and-checks.fix-code-renders.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   getStdout,

--- a/src/cli-parser.iterate-fix.main-iterate-text-format-fix-code-and-checks.mock.test.mts
+++ b/src/cli-parser.iterate-fix.main-iterate-text-format-fix-code-and-checks.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   getStdout,

--- a/src/cli-parser.iterate-fix.multi-paragraph-thread-body.mock.test.mts
+++ b/src/cli-parser.iterate-fix.multi-paragraph-thread-body.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   getStdout,

--- a/src/cli-parser.iterate-fix.test-support.mts
+++ b/src/cli-parser.iterate-fix.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
 vi.mock("./commands/resolve.mts", () => ({

--- a/src/cli-parser.iterate-fix.thread-url-heading.mock.test.mts
+++ b/src/cli-parser.iterate-fix.thread-url-heading.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerHooks,
   getStdout,

--- a/src/cli-parser.iterate-summary.mock.test.mts
+++ b/src/cli-parser.iterate-summary.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
@@ -42,6 +41,7 @@ function makeFixCodeResult(): IterateResult & { action: "fix_code" } {
     remainingSeconds: 60,
     summary: { passing: 0, skipped: 0, filtered: 0, inProgress: 1 },
     baseBranch: "main",
+    branchProtection: null,
     checks: [],
     action: "fix_code",
     fix: {

--- a/src/cli-parser.iterate.main-iterate-text-format.branch-protection-header.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate-text-format.branch-protection-header.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { registerHooks, getStdout, mockRunIterate } from "./cli-parser.iterate.test-support.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";

--- a/src/cli-parser.iterate.main-iterate-text-format.lean-mode-summary-shows-non-zero-skipped-filtered-and-in-progress-counts.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate-text-format.lean-mode-summary-shows-non-zero-skipped-filtered-and-in-progress-counts.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, getStdout, mockRunIterate } from "./cli-parser.iterate.test-support.mts";
 import { formatIterateResult } from "./cli/iterate-formatter.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";

--- a/src/cli-parser.iterate.main-iterate-text-format.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate-text-format.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, getStdout, mockRunIterate } from "./cli-parser.iterate.test-support.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 import { main } from "./cli-parser.mts";

--- a/src/cli-parser.iterate.main-iterate.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate.mock.test.mts
@@ -1,11 +1,9 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   registerHooks,
   getStderr,
   getStdout,
   mockRunIterate,
-  runIterate,
 } from "./cli-parser.iterate.test-support.mts";
 import { makeIterateResult } from "./cli-parser.iterate-fixtures.mts";
 import { main } from "./cli-parser.mts";

--- a/src/cli-parser.iterate.main-iterate.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate.mock.test.mts
@@ -54,7 +54,7 @@ describe("main — default (poll)", () => {
       .mockResolvedValueOnce(makeIterateResult("wait"))
       .mockResolvedValue(makeIterateResult("cancel"));
 
-    const promise = main(["node", "shepherd", "42", "--interval", "45", "--timeout", "4m"]);
+    const promise = main(["node", "shepherd", "42", "--interval", "45s", "--timeout", "4m"]);
     await vi.advanceTimersByTimeAsync(45_000);
     await promise;
 

--- a/src/cli-parser.iterate.main-iterate.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate.mock.test.mts
@@ -12,34 +12,68 @@ import { main } from "./cli-parser.mts";
 
 registerHooks();
 
-describe("main — iterate", () => {
-  it("defaults to iterate when no subcommand is given", async () => {
-    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+describe("main — default (poll)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("defaults to poll when no subcommand is given", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
     await main(["node", "shepherd"]);
     expect(mockRunIterate).toHaveBeenCalledTimes(1);
     expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: undefined }));
-    expect(process.exitCode).toBe(0);
+    expect(process.exitCode).toBe(2);
   });
 
-  it("defaults to iterate when the first argument is a PR number", async () => {
-    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+  it("defaults to poll when the first argument is a PR number", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
     await main(["node", "shepherd", "42", "--format=json"]);
     expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 42 }));
     expect(JSON.parse(getStdout().trimEnd()).pr).toBe(42);
   });
 
-  it("defaults to iterate when the first argument is a PR URL", async () => {
-    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+  it("defaults to poll when the first argument is a PR URL", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
     await main(["node", "shepherd", "https://github.com/owner/repo/pull/42"]);
     expect(mockRunIterate).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 42 }));
   });
 
-  it("defaults to iterate when the first argument is an iterate flag", async () => {
-    mockRunIterate.mockResolvedValue(makeIterateResult("wait"));
+  it("defaults to poll when the first argument is a poll/iterate flag", async () => {
+    mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
     await main(["node", "shepherd", "--ready-delay", "15m"]);
     expect(mockRunIterate).toHaveBeenCalledWith(
       expect.objectContaining({ readyDelaySeconds: 15 * 60 }),
     );
+  });
+
+  it("accepts --interval and --timeout on the default path", async () => {
+    mockRunIterate
+      .mockResolvedValueOnce(makeIterateResult("wait"))
+      .mockResolvedValue(makeIterateResult("cancel"));
+
+    const promise = main(["node", "shepherd", "42", "--interval", "45", "--timeout", "4m"]);
+    await vi.advanceTimersByTimeAsync(45_000);
+    await promise;
+
+    expect(mockRunIterate).toHaveBeenCalledTimes(2);
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("loops on wait then stops on cancel — exits 2", async () => {
+    mockRunIterate
+      .mockResolvedValueOnce(makeIterateResult("wait"))
+      .mockResolvedValue(makeIterateResult("cancel"));
+
+    const promise = main(["node", "shepherd", "42", "--interval", "30s", "--timeout", "300s"]);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await promise;
+
+    expect(mockRunIterate).toHaveBeenCalledTimes(2);
+    expect(getStdout()).toContain("[CANCEL]");
+    expect(process.exitCode).toBe(2);
   });
 
   it("rejects unknown flag-first default invocations", async () => {
@@ -49,13 +83,15 @@ describe("main — iterate", () => {
     expect(getStderr()).toContain("Unknown subcommand: --formt");
   });
 
-  it("rejects extra positional arguments in default iterate form", async () => {
+  it("rejects extra positional arguments in default poll form", async () => {
     await main(["node", "shepherd", "42", "resolve"]);
     expect(process.exitCode).toBe(1);
     expect(mockRunIterate).not.toHaveBeenCalled();
     expect(getStderr()).toContain("Unknown subcommand: resolve");
   });
+});
 
+describe("main — iterate subcommand", () => {
   it("exits with iterateActionToExitCode(fix_code)=1", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("fix_code"));
     await main(["node", "shepherd", "iterate", "42"]);

--- a/src/cli-parser.iterate.test-support.mts
+++ b/src/cli-parser.iterate.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));
 vi.mock("./commands/resolve.mts", () => ({

--- a/src/cli-parser.main-help.mock.test.mts
+++ b/src/cli-parser.main-help.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, stderrSpy, stdoutSpy } from "./cli-parser.test-support.mts";
 import { main } from "./cli-parser.mts";
 

--- a/src/cli-parser.main-log-file.mock.test.mts
+++ b/src/cli-parser.main-log-file.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   getStdout,

--- a/src/cli-parser.main-resolve-first-look-rendering.mock.test.mts
+++ b/src/cli-parser.main-resolve-first-look-rendering.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, getStdout, mockRunResolveFetch } from "./cli-parser.test-support.mts";
 import { main } from "./cli-parser.mts";
 

--- a/src/cli-parser.main-resolve.formatfetchresult-includes-commit-suggestion-step-when-enabled-and-sugge.mock.test.mts
+++ b/src/cli-parser.main-resolve.formatfetchresult-includes-commit-suggestion-step-when-enabled-and-sugge.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, mockRunResolveFetch, stdoutSpy } from "./cli-parser.test-support.mts";
 import { main } from "./cli-parser.mts";
 

--- a/src/cli-parser.main-resolve.formatfetchresult-thread-and-comment-with-url-render-link-after-id.mock.test.mts
+++ b/src/cli-parser.main-resolve.formatfetchresult-thread-and-comment-with-url-render-link-after-id.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, mockRunResolveFetch, stdoutSpy } from "./cli-parser.test-support.mts";
 import { main } from "./cli-parser.mts";
 

--- a/src/cli-parser.main-resolve.formatmutateresult-renders-dismissed-reviews-unresolved-unminimized-and-.mock.test.mts
+++ b/src/cli-parser.main-resolve.formatmutateresult-renders-dismissed-reviews-unresolved-unminimized-and-.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   getStdout,

--- a/src/cli-parser.main-resolve.mock.test.mts
+++ b/src/cli-parser.main-resolve.mock.test.mts
@@ -1,12 +1,9 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   getStdout,
   mockRunResolveFetch,
   mockRunResolveMutate,
-  runResolveFetch,
-  runResolveMutate,
   stdoutSpy,
 } from "./cli-parser.test-support.mts";
 import { main } from "./cli-parser.mts";

--- a/src/cli-parser.main-unknown-subcommand.mock.test.mts
+++ b/src/cli-parser.main-unknown-subcommand.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, stderrSpy } from "./cli-parser.test-support.mts";
 import { main } from "./cli-parser.mts";
 

--- a/src/cli-parser.main-version.mock.test.mts
+++ b/src/cli-parser.main-version.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, getStdout } from "./cli-parser.test-support.mts";
 import { readFileSync } from "node:fs";
 import { main } from "./cli-parser.mts";

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -3,7 +3,7 @@
  *
  * Usage:
  *   pr-shepherd --version
- *   pr-shepherd [PR] [--format text|json] [--ready-delay Nm]
+ *   pr-shepherd [PR] [--interval 45s] [--timeout 4m] [--format text|json] [--ready-delay Nm]
  *                  [--stall-timeout <duration>] [--no-auto-mark-ready]
  *                  [--no-auto-cancel-actionable]
  *   pr-shepherd resolve [PR] [--fetch] [--resolve-thread-ids A,B] [--minimize-comment-ids X,Y]
@@ -24,7 +24,7 @@ import { readFileSync } from "node:fs";
 import { runResolveFetch, runResolveMutate } from "./commands/resolve.mts";
 import { runLogFile } from "./commands/log-file.mts";
 import { parseCommonArgs, getFlag, hasFlag, parseList } from "./cli/args.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./cli/default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./cli/default-poll.mts";
 import { USAGE, maybePrintHelp } from "./cli/help.mts";
 import { formatFetchResult, formatMutateResult } from "./cli/formatters.mts";
 import { handleClean, handleCommitSuggestion, handleIterate } from "./cli/handlers.mts";
@@ -58,8 +58,8 @@ export async function main(argv: string[]): Promise<void> {
 
   // Short-circuit all --help/-h before any I/O or logging.
   if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
-    if (isDefaultIterateInvocation(subcommand)) {
-      process.stdout.write(`${USAGE.iterate}\n`);
+    if (isDefaultPollInvocation(subcommand)) {
+      process.stdout.write(`${USAGE.poll}\n`);
     } else {
       const key =
         subcommand != null && (subcommand as string) in USAGE
@@ -73,9 +73,9 @@ export async function main(argv: string[]): Promise<void> {
   // Initialize the per-worktree log and install a stdout tee.
   await setupLog(argv);
 
-  if (isDefaultIterateInvocation(subcommand)) {
-    if (!validateDefaultIterateArgs(args)) return;
-    await handleIterate(args);
+  if (isDefaultPollInvocation(subcommand)) {
+    if (!validateDefaultPollArgs(args)) return;
+    await handlePoll(args);
     return;
   }
 

--- a/src/cli-parser.poll.mock.test.mts
+++ b/src/cli-parser.poll.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/iterate/index.mts", async (importOriginal) => {

--- a/src/cli-parser.resolve-fetch-suggestion.mock.test.mts
+++ b/src/cli-parser.resolve-fetch-suggestion.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/check.mts", () => ({ runCheck: vi.fn() }));

--- a/src/cli-parser.subcommand-help.mock.test.mts
+++ b/src/cli-parser.subcommand-help.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/iterate/index.mts", async (importOriginal) => {

--- a/src/cli-parser.subcommand-help.mock.test.mts
+++ b/src/cli-parser.subcommand-help.mock.test.mts
@@ -97,22 +97,23 @@ for (const sub of SUBCOMMANDS) {
   });
 }
 
-describe("default iterate path (pr 123 --help)", () => {
-  it("prints iterate usage to stdout and exits 0 for '123 --help'", async () => {
+describe("default poll path (pr 123 --help)", () => {
+  it("prints poll usage to stdout and exits 0 for '123 --help'", async () => {
     await main(["node", "shepherd", "123", "--help"]);
     expect(getStdout()).toContain("Usage:");
-    expect(getStdout()).toContain("Actions:");
-    expect(getStdout()).toContain("pr-shepherd iterate");
+    expect(getStdout()).toContain("Poll flags:");
+    expect(getStdout()).toContain("--interval");
+    expect(getStdout()).toContain("--timeout");
     expect(process.exitCode).toBeUndefined();
     expect(stderrSpy).not.toHaveBeenCalled();
     expect(mockRunIterate).not.toHaveBeenCalled();
   });
 
-  it("prints iterate usage to stdout and exits 0 for '123 -h'", async () => {
+  it("prints poll usage to stdout and exits 0 for '123 -h'", async () => {
     await main(["node", "shepherd", "123", "-h"]);
     expect(getStdout()).toContain("Usage:");
-    expect(getStdout()).toContain("Actions:");
-    expect(getStdout()).toContain("pr-shepherd iterate");
+    expect(getStdout()).toContain("Poll flags:");
+    expect(getStdout()).toContain("--interval");
     expect(process.exitCode).toBeUndefined();
     expect(stderrSpy).not.toHaveBeenCalled();
     expect(mockRunIterate).not.toHaveBeenCalled();

--- a/src/cli-parser.test-support.mts
+++ b/src/cli-parser.test-support.mts
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import { readFileSync } from "node:fs";
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./commands/resolve.mts", () => ({
   runResolveFetch: vi.fn(),

--- a/src/cli/args.default-poll-invocation-helpers.test.mts
+++ b/src/cli/args.default-poll-invocation-helpers.test.mts
@@ -1,25 +1,6 @@
 // @ts-nocheck
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
 import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
-import type { ShepherdAction } from "../types.mts";
-
-// ---------------------------------------------------------------------------
-// parseIntStrict
-// ---------------------------------------------------------------------------
 
 describe("default poll invocation helpers", () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;

--- a/src/cli/args.default-poll-invocation-helpers.test.mts
+++ b/src/cli/args.default-poll-invocation-helpers.test.mts
@@ -40,7 +40,7 @@ describe("default poll invocation helpers", () => {
     expect(isDefaultPollInvocation("https://github.com/o/r/pull/42")).toBe(true);
     expect(isDefaultPollInvocation("--format=json")).toBe(true);
     expect(isDefaultPollInvocation("--no-auto-mark-ready")).toBe(true);
-    expect(isDefaultPollInvocation("--interval=45")).toBe(true);
+    expect(isDefaultPollInvocation("--interval=45s")).toBe(true);
     expect(isDefaultPollInvocation("--timeout=4m")).toBe(true);
     expect(isDefaultPollInvocation("resolve")).toBe(false);
   });

--- a/src/cli/args.default-poll-invocation-helpers.test.mts
+++ b/src/cli/args.default-poll-invocation-helpers.test.mts
@@ -14,14 +14,14 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict
 // ---------------------------------------------------------------------------
 
-describe("default iterate invocation helpers", () => {
+describe("default poll invocation helpers", () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -35,36 +35,42 @@ describe("default iterate invocation helpers", () => {
   });
 
   it("recognizes omitted subcommand, PR numbers, PR URLs, and default flags", () => {
-    expect(isDefaultIterateInvocation(undefined)).toBe(true);
-    expect(isDefaultIterateInvocation("42")).toBe(true);
-    expect(isDefaultIterateInvocation("https://github.com/o/r/pull/42")).toBe(true);
-    expect(isDefaultIterateInvocation("--format=json")).toBe(true);
-    expect(isDefaultIterateInvocation("--no-auto-mark-ready")).toBe(true);
-    expect(isDefaultIterateInvocation("resolve")).toBe(false);
+    expect(isDefaultPollInvocation(undefined)).toBe(true);
+    expect(isDefaultPollInvocation("42")).toBe(true);
+    expect(isDefaultPollInvocation("https://github.com/o/r/pull/42")).toBe(true);
+    expect(isDefaultPollInvocation("--format=json")).toBe(true);
+    expect(isDefaultPollInvocation("--no-auto-mark-ready")).toBe(true);
+    expect(isDefaultPollInvocation("--interval=45")).toBe(true);
+    expect(isDefaultPollInvocation("--timeout=4m")).toBe(true);
+    expect(isDefaultPollInvocation("resolve")).toBe(false);
   });
 
-  it("accepts a single PR plus known default iterate flags", () => {
+  it("accepts a single PR plus known default poll flags", () => {
     expect(
-      validateDefaultIterateArgs([
+      validateDefaultPollArgs([
         "42",
         "--format",
         "json",
         "--ready-delay=5m",
         "--stall-timeout",
         "1h",
+        "--interval",
+        "45",
+        "--timeout",
+        "4m",
         "--verbose",
       ]),
     ).toBe(true);
   });
 
-  it("rejects missing values for default iterate value flags", () => {
-    expect(validateDefaultIterateArgs(["42", "--ready-delay"])).toBe(false);
+  it("rejects missing values for default poll value flags", () => {
+    expect(validateDefaultPollArgs(["42", "--ready-delay"])).toBe(false);
     expect(process.exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown subcommand"));
   });
 
   it("rejects duplicate PR-like positionals and unknown args", () => {
-    expect(validateDefaultIterateArgs(["42", "43"])).toBe(false);
-    expect(validateDefaultIterateArgs(["--unknown"])).toBe(false);
+    expect(validateDefaultPollArgs(["42", "43"])).toBe(false);
+    expect(validateDefaultPollArgs(["--unknown"])).toBe(false);
   });
 });

--- a/src/cli/args.default-poll-invocation-helpers.test.mts
+++ b/src/cli/args.default-poll-invocation-helpers.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 

--- a/src/cli/args.getflag.test.mts
+++ b/src/cli/args.getflag.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { getFlag } from "./args.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.getflag.test.mts
+++ b/src/cli/args.getflag.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.getflag.test.mts
+++ b/src/cli/args.getflag.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.hasflag.test.mts
+++ b/src/cli/args.hasflag.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.hasflag.test.mts
+++ b/src/cli/args.hasflag.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { hasFlag } from "./args.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.hasflag.test.mts
+++ b/src/cli/args.hasflag.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.iterateactiontoexitcode.test.mts
+++ b/src/cli/args.iterateactiontoexitcode.test.mts
@@ -1,19 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
+import { describe, it, expect } from "vitest";
+import { iterateActionToExitCode } from "./exit-codes.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.iterateactiontoexitcode.test.mts
+++ b/src/cli/args.iterateactiontoexitcode.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.iterateactiontoexitcode.test.mts
+++ b/src/cli/args.iterateactiontoexitcode.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -165,6 +165,49 @@ export function parseList(value: string | null): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Validate args for default-dispatch paths (e.g. `pr-shepherd [PR] [flags]`).
+ * Returns false (and sets process.exitCode) when an unexpected token is found.
+ * onError is called with the offending arg so callers can print their own
+ * usage message.
+ */
+export function validateDefaultArgs(
+  args: string[],
+  flagsWithValues: ReadonlySet<string>,
+  booleanFlags: ReadonlySet<string>,
+  onError: (arg: string) => void,
+): boolean {
+  let sawPr = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+
+    if (flagsWithValues.has(arg)) {
+      if (i + 1 >= args.length || args[i + 1]!.startsWith("--")) {
+        onError(arg);
+        return false;
+      }
+      i += 1;
+      continue;
+    }
+
+    const inlineFlag = arg.split("=", 1)[0]!;
+    if (flagsWithValues.has(inlineFlag)) continue;
+
+    if (booleanFlags.has(arg)) continue;
+
+    if (parsePrNumber(arg) !== null && !sawPr) {
+      sawPr = true;
+      continue;
+    }
+
+    onError(arg);
+    return false;
+  }
+
+  return true;
+}
+
 export function parseStatusPrNumbers(args: string[]): number[] {
   const prNumbers: number[] = [];
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -165,49 +165,6 @@ export function parseList(value: string | null): string[] {
     .filter(Boolean);
 }
 
-/**
- * Validate args for default-dispatch paths (e.g. `pr-shepherd [PR] [flags]`).
- * Returns false (and sets process.exitCode) when an unexpected token is found.
- * onError is called with the offending arg so callers can print their own
- * usage message.
- */
-export function validateDefaultArgs(
-  args: string[],
-  flagsWithValues: ReadonlySet<string>,
-  booleanFlags: ReadonlySet<string>,
-  onError: (arg: string) => void,
-): boolean {
-  let sawPr = false;
-
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]!;
-
-    if (flagsWithValues.has(arg)) {
-      if (i + 1 >= args.length || args[i + 1]!.startsWith("--")) {
-        onError(arg);
-        return false;
-      }
-      i += 1;
-      continue;
-    }
-
-    const inlineFlag = arg.split("=", 1)[0]!;
-    if (flagsWithValues.has(inlineFlag)) continue;
-
-    if (booleanFlags.has(arg)) continue;
-
-    if (parsePrNumber(arg) !== null && !sawPr) {
-      sawPr = true;
-      continue;
-    }
-
-    onError(arg);
-    return false;
-  }
-
-  return true;
-}
-
 export function parseStatusPrNumbers(args: string[]): number[] {
   const prNumbers: number[] = [];
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/args.parsecommonargs-pr-number-detection.test.mts
+++ b/src/cli/args.parsecommonargs-pr-number-detection.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parsecommonargs-pr-number-detection.test.mts
+++ b/src/cli/args.parsecommonargs-pr-number-detection.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { parseCommonArgs } from "./args.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.parsecommonargs-pr-number-detection.test.mts
+++ b/src/cli/args.parsecommonargs-pr-number-detection.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parsedurationtominutes.test.mts
+++ b/src/cli/args.parsedurationtominutes.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { parseDurationToMinutes } from "./exit-codes.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.parsedurationtominutes.test.mts
+++ b/src/cli/args.parsedurationtominutes.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parsedurationtominutes.test.mts
+++ b/src/cli/args.parsedurationtominutes.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parseintstrict.test.mts
+++ b/src/cli/args.parseintstrict.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parseintstrict.test.mts
+++ b/src/cli/args.parseintstrict.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { parseIntStrict } from "./args.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.parseintstrict.test.mts
+++ b/src/cli/args.parseintstrict.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parselist.test.mts
+++ b/src/cli/args.parselist.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { parseList } from "./args.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.parselist.test.mts
+++ b/src/cli/args.parselist.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parselist.test.mts
+++ b/src/cli/args.parselist.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parsestatusprnumbers.test.mts
+++ b/src/cli/args.parsestatusprnumbers.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.parsestatusprnumbers.test.mts
+++ b/src/cli/args.parsestatusprnumbers.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { parseStatusPrNumbers } from "./args.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.parsestatusprnumbers.test.mts
+++ b/src/cli/args.parsestatusprnumbers.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.statustoexitcode.test.mts
+++ b/src/cli/args.statustoexitcode.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
-import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
+import { describe, it, expect } from "vitest";
+import { statusToExitCode } from "./exit-codes.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.statustoexitcode.test.mts
+++ b/src/cli/args.statustoexitcode.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.statustoexitcode.test.mts
+++ b/src/cli/args.statustoexitcode.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.validatedurationflag.test.mts
+++ b/src/cli/args.validatedurationflag.test.mts
@@ -14,7 +14,6 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.validatedurationflag.test.mts
+++ b/src/cli/args.validatedurationflag.test.mts
@@ -1,20 +1,5 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import {
-  getFlag,
-  hasFlag,
-  parseList,
-  parseStatusPrNumbers,
-  parseCommonArgs,
-  parseIntStrict,
-} from "./args.mts";
-import {
-  parseDurationToMinutes,
-  statusToExitCode,
-  iterateActionToExitCode,
-} from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------
 // parseIntStrict

--- a/src/cli/args.validatedurationflag.test.mts
+++ b/src/cli/args.validatedurationflag.test.mts
@@ -14,7 +14,7 @@ import {
   iterateActionToExitCode,
 } from "./exit-codes.mts";
 import { validateDurationFlag } from "./duration-flag.mts";
-import { isDefaultIterateInvocation, validateDefaultIterateArgs } from "./default-iterate.mts";
+import { isDefaultPollInvocation, validateDefaultPollArgs } from "./default-poll.mts";
 import type { ShepherdAction } from "../types.mts";
 
 // ---------------------------------------------------------------------------

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { validateSecondsDurationFlag } from "./duration-flag.mts";
 import { parseDurationToSeconds } from "./exit-codes.mts";

--- a/src/cli/clean-formatter.test.mts
+++ b/src/cli/clean-formatter.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { formatCleanResult } from "./clean-formatter.mts";
 

--- a/src/cli/default-poll.mts
+++ b/src/cli/default-poll.mts
@@ -1,30 +1,36 @@
 import { parsePrNumber } from "./args.mts";
 import { USAGE } from "./help.mts";
 
-const DEFAULT_ITERATE_FLAGS_WITH_VALUES = new Set(["--format", "--ready-delay", "--stall-timeout"]);
+const DEFAULT_POLL_FLAGS_WITH_VALUES = new Set([
+  "--format",
+  "--ready-delay",
+  "--stall-timeout",
+  "--interval",
+  "--timeout",
+]);
 
-const DEFAULT_ITERATE_BOOLEAN_FLAGS = new Set([
+const DEFAULT_POLL_BOOLEAN_FLAGS = new Set([
   "--verbose",
   "--no-auto-mark-ready",
   "--no-auto-cancel-actionable",
 ]);
 
-export function isDefaultIterateInvocation(subcommand: string | undefined): boolean {
+export function isDefaultPollInvocation(subcommand: string | undefined): boolean {
   if (subcommand === "--help" || subcommand === "-h") return false;
   return (
     subcommand === undefined ||
     parsePrNumber(subcommand) !== null ||
-    isDefaultIterateFlag(subcommand)
+    isDefaultPollFlag(subcommand)
   );
 }
 
-export function validateDefaultIterateArgs(args: string[]): boolean {
+export function validateDefaultPollArgs(args: string[]): boolean {
   let sawPr = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
 
-    if (DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(arg)) {
+    if (DEFAULT_POLL_FLAGS_WITH_VALUES.has(arg)) {
       if (i + 1 >= args.length || args[i + 1]!.startsWith("--")) {
         writeDefaultUsageError(arg);
         return false;
@@ -34,9 +40,9 @@ export function validateDefaultIterateArgs(args: string[]): boolean {
     }
 
     const inlineFlag = arg.split("=", 1)[0]!;
-    if (DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(inlineFlag)) continue;
+    if (DEFAULT_POLL_FLAGS_WITH_VALUES.has(inlineFlag)) continue;
 
-    if (DEFAULT_ITERATE_BOOLEAN_FLAGS.has(arg)) continue;
+    if (DEFAULT_POLL_BOOLEAN_FLAGS.has(arg)) continue;
 
     if (parsePrNumber(arg) !== null && !sawPr) {
       sawPr = true;
@@ -50,9 +56,9 @@ export function validateDefaultIterateArgs(args: string[]): boolean {
   return true;
 }
 
-function isDefaultIterateFlag(arg: string): boolean {
+function isDefaultPollFlag(arg: string): boolean {
   const name = arg.split("=", 1)[0]!;
-  return DEFAULT_ITERATE_FLAGS_WITH_VALUES.has(name) || DEFAULT_ITERATE_BOOLEAN_FLAGS.has(arg);
+  return DEFAULT_POLL_FLAGS_WITH_VALUES.has(name) || DEFAULT_POLL_BOOLEAN_FLAGS.has(arg);
 }
 
 function writeDefaultUsageError(arg: string): void {

--- a/src/cli/default-poll.mts
+++ b/src/cli/default-poll.mts
@@ -18,9 +18,7 @@ const DEFAULT_POLL_BOOLEAN_FLAGS = new Set([
 export function isDefaultPollInvocation(subcommand: string | undefined): boolean {
   if (subcommand === "--help" || subcommand === "-h") return false;
   return (
-    subcommand === undefined ||
-    parsePrNumber(subcommand) !== null ||
-    isDefaultPollFlag(subcommand)
+    subcommand === undefined || parsePrNumber(subcommand) !== null || isDefaultPollFlag(subcommand)
   );
 }
 

--- a/src/cli/default-poll.mts
+++ b/src/cli/default-poll.mts
@@ -1,4 +1,5 @@
-import { parsePrNumber, validateDefaultArgs } from "./args.mts";
+import { parsePrNumber } from "./args.mts";
+import { validateDefaultArgs } from "./validate-default-args.mts";
 import { USAGE } from "./help.mts";
 
 const DEFAULT_POLL_FLAGS_WITH_VALUES = new Set([

--- a/src/cli/default-poll.mts
+++ b/src/cli/default-poll.mts
@@ -1,4 +1,4 @@
-import { parsePrNumber } from "./args.mts";
+import { parsePrNumber, validateDefaultArgs } from "./args.mts";
 import { USAGE } from "./help.mts";
 
 const DEFAULT_POLL_FLAGS_WITH_VALUES = new Set([
@@ -23,35 +23,12 @@ export function isDefaultPollInvocation(subcommand: string | undefined): boolean
 }
 
 export function validateDefaultPollArgs(args: string[]): boolean {
-  let sawPr = false;
-
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]!;
-
-    if (DEFAULT_POLL_FLAGS_WITH_VALUES.has(arg)) {
-      if (i + 1 >= args.length || args[i + 1]!.startsWith("--")) {
-        writeDefaultUsageError(arg);
-        return false;
-      }
-      i += 1;
-      continue;
-    }
-
-    const inlineFlag = arg.split("=", 1)[0]!;
-    if (DEFAULT_POLL_FLAGS_WITH_VALUES.has(inlineFlag)) continue;
-
-    if (DEFAULT_POLL_BOOLEAN_FLAGS.has(arg)) continue;
-
-    if (parsePrNumber(arg) !== null && !sawPr) {
-      sawPr = true;
-      continue;
-    }
-
-    writeDefaultUsageError(arg);
-    return false;
-  }
-
-  return true;
+  return validateDefaultArgs(
+    args,
+    DEFAULT_POLL_FLAGS_WITH_VALUES,
+    DEFAULT_POLL_BOOLEAN_FLAGS,
+    writeDefaultUsageError,
+  );
 }
 
 function isDefaultPollFlag(arg: string): boolean {

--- a/src/cli/first-look.first-look-items-cross-call-site-consistency.test.mts
+++ b/src/cli/first-look.first-look-items-cross-call-site-consistency.test.mts
@@ -1,21 +1,9 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
 import { formatFetchResult } from "./formatters.mts";
 import { formatFixCodeResult } from "./fix-formatter.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 import type { IterateResult } from "../types.mts";
-import {
-  renderAuthor,
-  renderBodyPreview,
-  renderCommentBullet,
-  renderReviewBullet,
-  renderReviewListSection,
-  renderThreadBullet,
-  renderThreadResolutionStatusTag,
-} from "./list-formatters.mts";
-import { renderLineRange, renderSuggestionBlock } from "./suggestion-renderer.mts";
-import { safeFence } from "./fence.mts";
 
 // ---------------------------------------------------------------------------
 // Cross-call-site identity assertion (issue #127 acceptance criterion)

--- a/src/cli/first-look.first-look-items-edited-flag-rendering.test.mts
+++ b/src/cli/first-look.first-look-items-edited-flag-rendering.test.mts
@@ -1,21 +1,9 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
 import { formatFetchResult } from "./formatters.mts";
 import { formatFixCodeResult } from "./fix-formatter.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 import type { IterateResult } from "../types.mts";
-import {
-  renderAuthor,
-  renderBodyPreview,
-  renderCommentBullet,
-  renderReviewBullet,
-  renderReviewListSection,
-  renderThreadBullet,
-  renderThreadResolutionStatusTag,
-} from "./list-formatters.mts";
-import { renderLineRange, renderSuggestionBlock } from "./suggestion-renderer.mts";
-import { safeFence } from "./fence.mts";
 
 // ---------------------------------------------------------------------------
 // Cross-call-site identity assertion (issue #127 acceptance criterion)
@@ -41,22 +29,6 @@ const FL_THREAD_OUTDATED_AUTO: FirstLookThread = {
   autoResolved: true,
 };
 
-const FL_THREAD_RESOLVED: FirstLookThread = {
-  id: "PRRT_fl2",
-  isResolved: true,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/baz.ts",
-  line: 3,
-  startLine: null,
-  author: "bob",
-  authorType: "Unknown" as const,
-  body: "already addressed",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "resolved",
-};
-
 const FL_COMMENT: FirstLookComment = {
   id: "PRRC_fl1",
   isMinimized: true,
@@ -67,15 +39,6 @@ const FL_COMMENT: FirstLookComment = {
   createdAtUnix: 0,
   firstLookStatus: "minimized",
 };
-
-function extractFirstLookSection(output: string): string {
-  const start = output.indexOf("## First-look items");
-  if (start === -1) throw new Error("## First-look items section not found in output");
-  const nextSection = output.indexOf("\n## ", start + 1);
-  return nextSection === -1
-    ? output.slice(start).trimEnd()
-    : output.slice(start, nextSection).trimEnd();
-}
 
 describe("## First-look items — edited flag rendering", () => {
   it("renders [status: outdated, auto-resolved, edited] for an edited+autoResolved thread", () => {

--- a/src/cli/first-look.formatfixcoderesult-fallback-branches.test.mts
+++ b/src/cli/first-look.formatfixcoderesult-fallback-branches.test.mts
@@ -1,21 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
-import { formatFetchResult } from "./formatters.mts";
 import { formatFixCodeResult } from "./fix-formatter.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 import type { IterateResult } from "../types.mts";
-import {
-  renderAuthor,
-  renderBodyPreview,
-  renderCommentBullet,
-  renderReviewBullet,
-  renderReviewListSection,
-  renderThreadBullet,
-  renderThreadResolutionStatusTag,
-} from "./list-formatters.mts";
-import { renderLineRange, renderSuggestionBlock } from "./suggestion-renderer.mts";
-import { safeFence } from "./fence.mts";
 
 // ---------------------------------------------------------------------------
 // Cross-call-site identity assertion (issue #127 acceptance criterion)
@@ -23,59 +9,6 @@ import { safeFence } from "./fence.mts";
 // All three formatters must emit a byte-equal ## First-look items section
 // for the same input.
 // ---------------------------------------------------------------------------
-
-const FL_THREAD_OUTDATED_AUTO: FirstLookThread = {
-  id: "PRRT_fl1",
-  isResolved: false,
-  isOutdated: true,
-  isMinimized: false,
-  path: "src/bar.ts",
-  line: 7,
-  startLine: null,
-  author: "alice",
-  authorType: "Unknown" as const,
-  body: "old comment",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "outdated",
-  autoResolved: true,
-};
-
-const FL_THREAD_RESOLVED: FirstLookThread = {
-  id: "PRRT_fl2",
-  isResolved: true,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/baz.ts",
-  line: 3,
-  startLine: null,
-  author: "bob",
-  authorType: "Unknown" as const,
-  body: "already addressed",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "resolved",
-};
-
-const FL_COMMENT: FirstLookComment = {
-  id: "PRRC_fl1",
-  isMinimized: true,
-  author: "bot",
-  authorType: "Unknown" as const,
-  body: "quota warning",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "minimized",
-};
-
-function extractFirstLookSection(output: string): string {
-  const start = output.indexOf("## First-look items");
-  if (start === -1) throw new Error("## First-look items section not found in output");
-  const nextSection = output.indexOf("\n## ", start + 1);
-  return nextSection === -1
-    ? output.slice(start).trimEnd()
-    : output.slice(start, nextSection).trimEnd();
-}
 
 describe("formatFixCodeResult — fallback branches", () => {
   it("renders missing locations, missing check metadata, cancelled checks, and empty review bodies", () => {

--- a/src/cli/first-look.iterate-fixture-fallback.test.mts
+++ b/src/cli/first-look.iterate-fixture-fallback.test.mts
@@ -1,21 +1,5 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
-import { formatFetchResult } from "./formatters.mts";
-import { formatFixCodeResult } from "./fix-formatter.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
-import type { IterateResult } from "../types.mts";
-import {
-  renderAuthor,
-  renderBodyPreview,
-  renderCommentBullet,
-  renderReviewBullet,
-  renderReviewListSection,
-  renderThreadBullet,
-  renderThreadResolutionStatusTag,
-} from "./list-formatters.mts";
-import { renderLineRange, renderSuggestionBlock } from "./suggestion-renderer.mts";
-import { safeFence } from "./fence.mts";
 
 // ---------------------------------------------------------------------------
 // Cross-call-site identity assertion (issue #127 acceptance criterion)
@@ -23,59 +7,6 @@ import { safeFence } from "./fence.mts";
 // All three formatters must emit a byte-equal ## First-look items section
 // for the same input.
 // ---------------------------------------------------------------------------
-
-const FL_THREAD_OUTDATED_AUTO: FirstLookThread = {
-  id: "PRRT_fl1",
-  isResolved: false,
-  isOutdated: true,
-  isMinimized: false,
-  path: "src/bar.ts",
-  line: 7,
-  startLine: null,
-  author: "alice",
-  authorType: "Unknown" as const,
-  body: "old comment",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "outdated",
-  autoResolved: true,
-};
-
-const FL_THREAD_RESOLVED: FirstLookThread = {
-  id: "PRRT_fl2",
-  isResolved: true,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/baz.ts",
-  line: 3,
-  startLine: null,
-  author: "bob",
-  authorType: "Unknown" as const,
-  body: "already addressed",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "resolved",
-};
-
-const FL_COMMENT: FirstLookComment = {
-  id: "PRRC_fl1",
-  isMinimized: true,
-  author: "bot",
-  authorType: "Unknown" as const,
-  body: "quota warning",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "minimized",
-};
-
-function extractFirstLookSection(output: string): string {
-  const start = output.indexOf("## First-look items");
-  if (start === -1) throw new Error("## First-look items section not found in output");
-  const nextSection = output.indexOf("\n## ", start + 1);
-  return nextSection === -1
-    ? output.slice(start).trimEnd()
-    : output.slice(start, nextSection).trimEnd();
-}
 
 describe("iterate fixture fallback", () => {
   it("falls back to wait for unknown actions at runtime", () => {

--- a/src/cli/first-look.list-and-suggestion-render-helpers.test.mts
+++ b/src/cli/first-look.list-and-suggestion-render-helpers.test.mts
@@ -1,10 +1,4 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
-import { formatFetchResult } from "./formatters.mts";
-import { formatFixCodeResult } from "./fix-formatter.mts";
-import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
-import type { IterateResult } from "../types.mts";
 import {
   renderAuthor,
   renderBodyPreview,
@@ -23,59 +17,6 @@ import { safeFence } from "./fence.mts";
 // All three formatters must emit a byte-equal ## First-look items section
 // for the same input.
 // ---------------------------------------------------------------------------
-
-const FL_THREAD_OUTDATED_AUTO: FirstLookThread = {
-  id: "PRRT_fl1",
-  isResolved: false,
-  isOutdated: true,
-  isMinimized: false,
-  path: "src/bar.ts",
-  line: 7,
-  startLine: null,
-  author: "alice",
-  authorType: "Unknown" as const,
-  body: "old comment",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "outdated",
-  autoResolved: true,
-};
-
-const FL_THREAD_RESOLVED: FirstLookThread = {
-  id: "PRRT_fl2",
-  isResolved: true,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/baz.ts",
-  line: 3,
-  startLine: null,
-  author: "bob",
-  authorType: "Unknown" as const,
-  body: "already addressed",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "resolved",
-};
-
-const FL_COMMENT: FirstLookComment = {
-  id: "PRRC_fl1",
-  isMinimized: true,
-  author: "bot",
-  authorType: "Unknown" as const,
-  body: "quota warning",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "minimized",
-};
-
-function extractFirstLookSection(output: string): string {
-  const start = output.indexOf("## First-look items");
-  if (start === -1) throw new Error("## First-look items section not found in output");
-  const nextSection = output.indexOf("\n## ", start + 1);
-  return nextSection === -1
-    ? output.slice(start).trimEnd()
-    : output.slice(start, nextSection).trimEnd();
-}
 
 describe("list and suggestion render helpers", () => {
   it("renders author, body preview, line ranges, and safe fences", () => {

--- a/src/cli/first-look.review-summaries-edited-since-first-look-fix-formatter-rendering.test.mts
+++ b/src/cli/first-look.review-summaries-edited-since-first-look-fix-formatter-rendering.test.mts
@@ -1,21 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import type { FirstLookThread, FirstLookComment } from "../types/report.mts";
-import { formatFetchResult } from "./formatters.mts";
 import { formatFixCodeResult } from "./fix-formatter.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 import type { IterateResult } from "../types.mts";
-import {
-  renderAuthor,
-  renderBodyPreview,
-  renderCommentBullet,
-  renderReviewBullet,
-  renderReviewListSection,
-  renderThreadBullet,
-  renderThreadResolutionStatusTag,
-} from "./list-formatters.mts";
-import { renderLineRange, renderSuggestionBlock } from "./suggestion-renderer.mts";
-import { safeFence } from "./fence.mts";
 
 // ---------------------------------------------------------------------------
 // Cross-call-site identity assertion (issue #127 acceptance criterion)
@@ -23,59 +9,6 @@ import { safeFence } from "./fence.mts";
 // All three formatters must emit a byte-equal ## First-look items section
 // for the same input.
 // ---------------------------------------------------------------------------
-
-const FL_THREAD_OUTDATED_AUTO: FirstLookThread = {
-  id: "PRRT_fl1",
-  isResolved: false,
-  isOutdated: true,
-  isMinimized: false,
-  path: "src/bar.ts",
-  line: 7,
-  startLine: null,
-  author: "alice",
-  authorType: "Unknown" as const,
-  body: "old comment",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "outdated",
-  autoResolved: true,
-};
-
-const FL_THREAD_RESOLVED: FirstLookThread = {
-  id: "PRRT_fl2",
-  isResolved: true,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/baz.ts",
-  line: 3,
-  startLine: null,
-  author: "bob",
-  authorType: "Unknown" as const,
-  body: "already addressed",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "resolved",
-};
-
-const FL_COMMENT: FirstLookComment = {
-  id: "PRRC_fl1",
-  isMinimized: true,
-  author: "bot",
-  authorType: "Unknown" as const,
-  body: "quota warning",
-  url: "",
-  createdAtUnix: 0,
-  firstLookStatus: "minimized",
-};
-
-function extractFirstLookSection(output: string): string {
-  const start = output.indexOf("## First-look items");
-  if (start === -1) throw new Error("## First-look items section not found in output");
-  const nextSection = output.indexOf("\n## ", start + 1);
-  return nextSection === -1
-    ? output.slice(start).trimEnd()
-    : output.slice(start, nextSection).trimEnd();
-}
 
 describe("## Review summaries (edited since first look) — fix-formatter rendering", () => {
   it("renders the edited-summaries section when editedSummaries is non-empty", () => {

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -53,11 +53,10 @@ Exit codes:
 
   iterate: `pr-shepherd iterate
 
-Run one iterate tick for a pull request. This is an alias for 'pr-shepherd [PR]'.
+Run one iterate tick for a pull request. The no-subcommand form polls; use this subcommand for a single tick.
 The output contains one action and an action-specific ## Instructions section.
 
 Usage:
-  pr-shepherd [PR] [iterate-flags]
   pr-shepherd iterate [PR] [iterate-flags]
 
 Iterate flags:
@@ -101,11 +100,11 @@ Forwarded iterate flags:
   --no-auto-mark-ready           Do not convert draft PRs to ready for review.
   --no-auto-cancel-actionable    Do not cancel in-progress runs before actionable fixes.
   --format text|json             Output Markdown text or JSON. Default: text.
-  --verbose                      Include verbose iterate fields and always print poll progress.
+  --verbose                      Include verbose iterate fields and detailed per-tick lines.
   --help, -h                     Print this help and exit before GitHub, git, config, or log I/O.
 
 Durations accept seconds, minutes, or hours: 30s, 2m, 1h, or bare seconds.
-WAIT progress is written to stderr when stderr is a TTY or --verbose is set.
+Each WAIT tick writes a single dot to stderr; --verbose emits the detailed per-tick line.
 
 Exit codes:
   0  WAIT timeout or MARK_READY

--- a/src/cli/help-top-page.mts
+++ b/src/cli/help-top-page.mts
@@ -5,8 +5,8 @@ Autonomous PR CI monitor and review-comment resolver for agentic coding tools.
 Usage:
   pr-shepherd --version | -v
   pr-shepherd --help | -h
-  pr-shepherd [PR] [flags]
-  pr-shepherd iterate [PR] [flags]
+  pr-shepherd [PR] [poll-flags] [iterate-flags]
+  pr-shepherd iterate [PR] [iterate-flags]
   pr-shepherd poll [PR] [poll-flags] [iterate-flags]
   pr-shepherd resolve [PR] [resolve-flags]
   pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [flags]
@@ -14,8 +14,8 @@ Usage:
   pr-shepherd log-file [--format text|json]
 
 Commands:
-  [PR]                 Run one iterate tick. This is the default command.
-  iterate              Alias for the default one-tick iterate command.
+  [PR]                 Poll until non-WAIT or timeout. This is the default command.
+  iterate              Run one iterate tick (single-tick alias).
   poll                 Re-run iterate while the action is WAIT, then print the final tick.
   resolve              Fetch actionable review items, or resolve/minimize/dismiss IDs.
   commit-suggestion    Convert one GitHub suggestion thread into a patch and commit instructions.
@@ -28,7 +28,7 @@ PR argument:
 
 Common flags:
   --format text|json   Output Markdown text or JSON. Default: text.
-  --verbose            Include verbose iterate fields and poll progress.
+  --verbose            Include verbose iterate fields and detailed poll-tick lines.
   --help, -h           Print help and exit before any GitHub, git, config, or log I/O.
 
 Iterate flags:

--- a/src/cli/iterate-flags.test.mts
+++ b/src/cli/iterate-flags.test.mts
@@ -1,15 +1,24 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock("../config/load.mts", () => ({ loadConfig: mockLoadConfig }));
 
+import type { PrShepherdConfig } from "../config/load.mts";
 import { parseIterateFlags } from "./iterate-flags.mts";
 
-function defaultConfig() {
+function defaultConfig(): PrShepherdConfig {
   return {
     watch: { readyDelayMinutes: 10 },
-    iterate: { stallTimeoutMinutes: 30 },
+    iterate: {
+      fixAttemptsPerThread: 3,
+      stallTimeoutMinutes: 30,
+      minimizeApprovals: false,
+      minimizeComments: "bots",
+    },
+    resolve: { shaPoll: { intervalMs: 2000, maxAttempts: 10 }, fetchReviewSummaries: true },
+    checks: { ciTriggerEvents: ["pull_request"] },
+    mergeStatus: { blockingReviewerLogins: [] },
+    actions: { autoResolveOutdated: false, autoMarkReady: false, commitSuggestions: false },
   };
 }
 

--- a/src/cli/iterate-lean.projectiteratelean.fix-code-empty-payload-omits-all-empty-arrays-in-fix-block.test.mts
+++ b/src/cli/iterate-lean.projectiteratelean.fix-code-empty-payload-omits-all-empty-arrays-in-fix-block.test.mts
@@ -1,7 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  registerHooks,
   makeIterateResult,
   projectIterateLean,
   projectIterateVerbose,

--- a/src/cli/iterate-lean.projectiteratelean.projectiterateverbose-uses-default-options-for-fix-code-and-wait.test.mts
+++ b/src/cli/iterate-lean.projectiteratelean.projectiterateverbose-uses-default-options-for-fix-code-and-wait.test.mts
@@ -1,7 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  registerHooks,
   makeIterateResult,
   projectIterateLean,
   projectIterateVerbose,

--- a/src/cli/iterate-lean.projectiteratelean.test.mts
+++ b/src/cli/iterate-lean.projectiteratelean.test.mts
@@ -1,10 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  registerHooks,
-  makeIterateResult,
-  projectIterateLean,
-} from "./iterate-lean.test-support.mts";
+import { describe, it, expect } from "vitest";
+import { makeIterateResult, projectIterateLean } from "./iterate-lean.test-support.mts";
 
 describe("projectIterateLean", () => {
   // ---------------------------------------------------------------------------

--- a/src/cli/iterate-lean.test-support.mts
+++ b/src/cli/iterate-lean.test-support.mts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-import { describe, it, expect } from "vitest";
 import { projectIterateLean, projectIterateVerbose } from "./iterate-lean.mts";
 import { makeIterateResult } from "../cli-parser.iterate-fixtures.mts";
 

--- a/src/cli/runner.test.mts
+++ b/src/cli/runner.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 
 import { buildPrShepherdCommand, renderShellCommand } from "./runner.mts";

--- a/src/cli/validate-default-args.mts
+++ b/src/cli/validate-default-args.mts
@@ -1,0 +1,43 @@
+import { parsePrNumber } from "./args.mts";
+
+/**
+ * Validate args for default-dispatch paths (e.g. `pr-shepherd [PR] [flags]`).
+ * Returns false when an unexpected token is found; calls onError with the
+ * offending arg so callers can print their own usage message.
+ */
+export function validateDefaultArgs(
+  args: string[],
+  flagsWithValues: ReadonlySet<string>,
+  booleanFlags: ReadonlySet<string>,
+  onError: (arg: string) => void,
+): boolean {
+  let sawPr = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+
+    if (flagsWithValues.has(arg)) {
+      if (i + 1 >= args.length || args[i + 1]!.startsWith("--")) {
+        onError(arg);
+        return false;
+      }
+      i += 1;
+      continue;
+    }
+
+    const inlineFlag = arg.split("=", 1)[0]!;
+    if (flagsWithValues.has(inlineFlag)) continue;
+
+    if (booleanFlags.has(arg)) continue;
+
+    if (parsePrNumber(arg) !== null && !sawPr) {
+      sawPr = true;
+      continue;
+    }
+
+    onError(arg);
+    return false;
+  }
+
+  return true;
+}

--- a/src/commands/check-status.test.mts
+++ b/src/commands/check-status.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, expect, it } from "vitest";
 
 import { computeStatus } from "./check-status.mts";

--- a/src/commands/check.runcheck-blocked-clean-hand-off-to-humans.mock.test.mts
+++ b/src/commands/check.runcheck-blocked-clean-hand-off-to-humans.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-blockedbyfilteredcheck.mock.test.mts
+++ b/src/commands/check.runcheck-blockedbyfilteredcheck.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-computestatus-precedence.mock.test.mts
+++ b/src/commands/check.runcheck-computestatus-precedence.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-first-look-items.mock.test.mts
+++ b/src/commands/check.runcheck-first-look-items.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-first-look-items.re-surfaces-edited-resolved-and-minimized-threads-and-minimized-comments.mock.test.mts
+++ b/src/commands/check.runcheck-first-look-items.re-surfaces-edited-resolved-and-minimized-threads-and-minimized-comments.mock.test.mts
@@ -1,10 +1,8 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
   makeBatchData,
-  markSeen,
   mockFetchPrBatch,
   mockLoadSeenMap,
   mockMarkSeen,

--- a/src/commands/check.runcheck-minimized-thread-filtering.mock.test.mts
+++ b/src/commands/check.runcheck-minimized-thread-filtering.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-no-pr.mock.test.mts
+++ b/src/commands/check.runcheck-no-pr.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, BASE_OPTS, mockGetCurrentPrNumber } from "./check.test-support.mts";
 import { runCheck } from "./check.mts";
 

--- a/src/commands/check.runcheck-ready-mergeability-recheck.mock.test.mts
+++ b/src/commands/check.runcheck-ready-mergeability-recheck.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-reviewsummaries-approvedreviews-pass-through.mock.test.mts
+++ b/src/commands/check.runcheck-reviewsummaries-approvedreviews-pass-through.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-skiptriage.mock.test.mts
+++ b/src/commands/check.runcheck-skiptriage.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
@@ -7,7 +6,6 @@ import {
   makeCheck,
   mockFetchPrBatch,
   mockTriageFailingChecks,
-  triageFailingChecks,
 } from "./check.test-support.mts";
 import { runCheck } from "./check.mts";
 

--- a/src/commands/check.runcheck-startup-failure-workflow-runs.mock.test.mts
+++ b/src/commands/check.runcheck-startup-failure-workflow-runs.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-terminal-pr-state.mock.test.mts
+++ b/src/commands/check.runcheck-terminal-pr-state.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,

--- a/src/commands/check.runcheck-unknown-merge-state.mock.test.mts
+++ b/src/commands/check.runcheck-unknown-merge-state.mock.test.mts
@@ -1,9 +1,7 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
-  getMergeableState,
   makeBatchData,
   mockFetchPrBatch,
   mockGetMergeableState,

--- a/src/commands/check.test-support.mts
+++ b/src/commands/check.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 vi.mock("../github/batch.mts", () => ({ fetchPrBatch: vi.fn() }));
 vi.mock("../github/client.mts", () => ({

--- a/src/commands/clean.readdir-fallback.mock.test.mts
+++ b/src/commands/clean.readdir-fallback.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/src/commands/clean.runclean-all-repo.mock.test.mts
+++ b/src/commands/clean.runclean-all-repo.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { join } from "node:path";
 import { mkdir, rm } from "node:fs/promises";

--- a/src/commands/clean.runclean-branch-current.mock.test.mts
+++ b/src/commands/clean.runclean-branch-current.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { join } from "node:path";
 import {

--- a/src/commands/clean.runclean-pr.mock.test.mts
+++ b/src/commands/clean.runclean-pr.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { join } from "node:path";
 import {

--- a/src/commands/clean.test-support.mts
+++ b/src/commands/clean.test-support.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { vi, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
 import { mkdtemp, realpath, rm, mkdir, writeFile, stat } from "node:fs/promises";

--- a/src/commands/commit-suggestion.apply.runcommitsuggestion-output-shape.mock.test.mts
+++ b/src/commands/commit-suggestion.apply.runcommitsuggestion-output-shape.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   FILE_CONTENT,
   GLOBAL_OPTS,

--- a/src/commands/commit-suggestion.apply.test-support.mts
+++ b/src/commands/commit-suggestion.apply.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks

--- a/src/commands/commit-suggestion.runcommitsuggestion-file-read-failure.mock.test.mts
+++ b/src/commands/commit-suggestion.runcommitsuggestion-file-read-failure.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerHooks,
   GLOBAL_OPTS,
@@ -10,7 +9,6 @@ import {
   mockFetchBatch,
   mockGetCurrentBranch,
   mockReadFile,
-  readFile,
 } from "./commit-suggestion.test-support.mts";
 import { runCommitSuggestion } from "./commit-suggestion.mts";
 

--- a/src/commands/commit-suggestion.runcommitsuggestion-happy-path.mock.test.mts
+++ b/src/commands/commit-suggestion.runcommitsuggestion-happy-path.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   registerHooks,
   GLOBAL_OPTS,
@@ -8,7 +7,6 @@ import {
   mockExecFile,
   mockFetchBatch,
   mockGetCurrentBranch,
-  mockLoadConfig,
   setupHappyPath,
 } from "./commit-suggestion.test-support.mts";
 import { runCommitSuggestion } from "./commit-suggestion.mts";

--- a/src/commands/commit-suggestion.runcommitsuggestion-preflight.mock.test.mts
+++ b/src/commands/commit-suggestion.runcommitsuggestion-preflight.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   registerHooks,
   GLOBAL_OPTS,

--- a/src/commands/commit-suggestion.runcommitsuggestion-thread-classification.mock.test.mts
+++ b/src/commands/commit-suggestion.runcommitsuggestion-thread-classification.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   registerHooks,
   GLOBAL_OPTS,

--- a/src/commands/commit-suggestion.runcommitsuggestion-validation.mock.test.mts
+++ b/src/commands/commit-suggestion.runcommitsuggestion-validation.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   registerHooks,
   GLOBAL_OPTS,

--- a/src/commands/commit-suggestion.test-support.mts
+++ b/src/commands/commit-suggestion.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks

--- a/src/commands/iterate-stall.test-support.mts
+++ b/src/commands/iterate-stall.test-support.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { vi } from "vitest";
 import { NOW, makeOpts } from "./iterate-test-support.mts";
 import { readStallState, writeStallState, type StallState } from "../state/iterate-stall.mts";

--- a/src/commands/iterate.base-checks.excludes-skipped-and-filtered-checks.mock.test.mts
+++ b/src/commands/iterate.base-checks.excludes-skipped-and-filtered-checks.mock.test.mts
@@ -1,8 +1,6 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
-  buildRelevantChecks,
   makeOpts,
   makeReport,
   mockRunCheck,

--- a/src/commands/iterate.base-checks.runiterate-base-checks-carries-passing-failing-regression-mi.mock.test.mts
+++ b/src/commands/iterate.base-checks.runiterate-base-checks-carries-passing-failing-regression-mi.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.classify.approved-review-summary-minimize-filter.mock.test.mts
+++ b/src/commands/iterate.classify.approved-review-summary-minimize-filter.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,
@@ -21,9 +20,6 @@ registerIterateHooks();
 
 describe("runIterate — review summary auto-minimize", () => {
   const botSummary = makeReview("PRR_BOT", "copilot-pull-request-reviewer", "overview");
-  const genericBotSummary = makeReview("PRR_GEM", "gemini-code-assist", "overview");
-  const bracketBotSummary = makeReview("PRR_BRK", "github-actions[bot]", "overview");
-  const humanSummary = makeReview("PRR_HUMAN", "alice", "nice work");
 
   it("omits APPROVED reviews from minimize list by default (approvals: false)", async () => {
     mockRunCheck.mockResolvedValue(

--- a/src/commands/iterate.classify.edited-review-summaries.mock.test.mts
+++ b/src/commands/iterate.classify.edited-review-summaries.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,
@@ -17,11 +16,6 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 
 describe("runIterate — review summary auto-minimize", () => {
-  const botSummary = makeReview("PRR_BOT", "copilot-pull-request-reviewer", "overview");
-  const genericBotSummary = makeReview("PRR_GEM", "gemini-code-assist", "overview");
-  const bracketBotSummary = makeReview("PRR_BRK", "github-actions[bot]", "overview");
-  const humanSummary = makeReview("PRR_HUMAN", "alice", "nice work");
-
   it("editedSummaries are surfaced in fix_code but excluded from reviewSummaryIds (not re-minimized)", async () => {
     // A seen summary triggers fix_code (it needs minimizing); edited summary must NOT join the queue.
     const seenSummary = makeReview("PRR_SEEN", "copilot", "Old review.");

--- a/src/commands/iterate.classify.runiterate-review-summary-auto-minimize.mock.test.mts
+++ b/src/commands/iterate.classify.runiterate-review-summary-auto-minimize.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   defaultConfig,

--- a/src/commands/iterate.escalate.escalate-message-helpers.mock.test.mts
+++ b/src/commands/iterate.escalate.escalate-message-helpers.mock.test.mts
@@ -1,11 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  registerIterateHooks,
-  NOW,
-  defaultConfig,
-  mockLoadConfig,
-} from "./iterate-test-support.mts";
+import { describe, it, expect } from "vitest";
+import { registerIterateHooks, defaultConfig, mockLoadConfig } from "./iterate-test-support.mts";
 import {
   buildEscalateHumanMessage,
   buildEscalateSuggestion,
@@ -17,29 +11,6 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 // Escalate
 // ---------------------------------------------------------------------------
-
-const THREAD = {
-  id: "thread-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "reviewer",
-  authorType: "Unknown" as const,
-  body: "Fix this",
-  url: "",
-  createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
-};
 
 describe("escalate message helpers", () => {
   it("includes ambiguous comments and fallback suggestions", () => {

--- a/src/commands/iterate.escalate.fix-attempt-counter.mock.test.mts
+++ b/src/commands/iterate.escalate.fix-attempt-counter.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,
@@ -31,14 +30,6 @@ const THREAD = {
   body: "Fix this",
   url: "",
   createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
 };
 
 describe("runIterate — escalate (fix-thrash)", () => {

--- a/src/commands/iterate.escalate.iterate-helper-fallbacks.mock.test.mts
+++ b/src/commands/iterate.escalate.iterate-helper-fallbacks.mock.test.mts
@@ -1,6 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerIterateHooks, NOW, makeReport, mockExecFile } from "./iterate-test-support.mts";
+import { describe, it, expect } from "vitest";
+import { registerIterateHooks, makeReport, mockExecFile } from "./iterate-test-support.mts";
 import { buildRelevantChecks, buildWaitLog, getCurrentHeadSha } from "./iterate/helpers.mts";
 
 registerIterateHooks();
@@ -8,29 +7,6 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 // Escalate
 // ---------------------------------------------------------------------------
-
-const THREAD = {
-  id: "thread-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "reviewer",
-  authorType: "Unknown" as const,
-  body: "Fix this",
-  url: "",
-  createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
-};
 
 describe("iterate helper fallbacks", () => {
   it("returns null when current HEAD cannot be read", async () => {
@@ -91,6 +67,7 @@ describe("iterate helper fallbacks", () => {
         remainingSeconds: 0,
         summary: { passing: 1, skipped: 0, filtered: 0, inProgress: 0 },
         baseBranch: "main",
+        branchProtection: null,
         checks: [],
       }),
     ).toContain("branch is behind base");
@@ -102,7 +79,7 @@ describe("iterate helper fallbacks", () => {
       repo: "owner/repo",
       status: "IN_PROGRESS" as const,
       state: "OPEN" as const,
-      mergeStateStatus: "DRAFT",
+      mergeStateStatus: "DRAFT" as const,
       reviewDecision: null,
       blockingBotReviewInProgress: false,
       isDraft: false,
@@ -110,6 +87,7 @@ describe("iterate helper fallbacks", () => {
       remainingSeconds: 0,
       summary: { passing: 1, skipped: 0, filtered: 0, inProgress: 0 },
       baseBranch: "main",
+      branchProtection: null,
       checks: [],
     };
 

--- a/src/commands/iterate.escalate.runiterate-blocked-clean-hand-off-to-humans-via-ready-delay.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-blocked-clean-hand-off-to-humans-via-ready-delay.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.escalate.runiterate-escalate-fix-thrash.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-escalate-fix-thrash.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,
@@ -30,14 +29,6 @@ const THREAD = {
   body: "Fix this",
   url: "",
   createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
 };
 
 describe("runIterate — escalate (fix-thrash)", () => {

--- a/src/commands/iterate.escalate.runiterate-escalate-pr-level-changes-requested-suppressed-du.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-escalate-pr-level-changes-requested-suppressed-du.mock.test.mts
@@ -1,8 +1,6 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
-  NOW,
   makeOpts,
   makeReport,
   mockRunCheck,
@@ -15,29 +13,6 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 // Escalate
 // ---------------------------------------------------------------------------
-
-const THREAD = {
-  id: "thread-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "reviewer",
-  authorType: "Unknown" as const,
-  body: "Fix this",
-  url: "",
-  createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
-};
 
 describe("runIterate — CHANGES_REQUESTED review with merge CONFLICTS routes to fix_code", () => {
   it("routes to fix_code when changesRequestedReviews + merge CONFLICTS (rebase + dismiss)", async () => {

--- a/src/commands/iterate.escalate.runiterate-escalate-pr-level-changes-requested-with-actionab.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-escalate-pr-level-changes-requested-with-actionab.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,
@@ -15,29 +14,6 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 // Escalate
 // ---------------------------------------------------------------------------
-
-const THREAD = {
-  id: "thread-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "reviewer",
-  authorType: "Unknown" as const,
-  body: "Fix this",
-  url: "",
-  createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
-};
 
 describe("runIterate — escalate (pr-level-changes-requested with actionable comments)", () => {
   it("does NOT escalate when changesRequestedReviews + actionable comments exist (no inline threads)", async () => {

--- a/src/commands/iterate.escalate.runiterate-escalate-pr-level-changes-requested.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-escalate-pr-level-changes-requested.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,

--- a/src/commands/iterate.escalate.runiterate-escalate-thread-missing-location.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-escalate-thread-missing-location.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,
@@ -29,14 +28,6 @@ const THREAD = {
   body: "Fix this",
   url: "",
   createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
 };
 
 describe("runIterate — escalate (thread-missing-location)", () => {

--- a/src/commands/iterate.escalate.runiterate-no-pr.mock.test.mts
+++ b/src/commands/iterate.escalate.runiterate-no-pr.mock.test.mts
@@ -1,6 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerIterateHooks, NOW, mockGetCurrentPrNumber } from "./iterate-test-support.mts";
+import { describe, it, expect } from "vitest";
+import { registerIterateHooks, mockGetCurrentPrNumber } from "./iterate-test-support.mts";
 import { runIterate } from "./iterate/index.mts";
 
 registerIterateHooks();
@@ -8,29 +7,6 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 // Escalate
 // ---------------------------------------------------------------------------
-
-const THREAD = {
-  id: "thread-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "reviewer",
-  authorType: "Unknown" as const,
-  body: "Fix this",
-  url: "",
-  createdAtUnix: NOW - 3600,
-};
-
-const RESOLUTION_ONLY_THREAD = {
-  ...THREAD,
-  id: "thread-resolution-only",
-  isOutdated: true,
-  line: null,
-  body: "Already addressed on an old diff",
-};
 
 describe("runIterate — no PR", () => {
   it("throws when no PR number is passed and no current PR is found", async () => {

--- a/src/commands/iterate.fix-code-actionable.journal-instruction-dedup.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.journal-instruction-dedup.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,

--- a/src/commands/iterate.fix-code-actionable.runiterate-fix-code-actionable-threads.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.runiterate-fix-code-actionable-threads.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerIterateHooks,
   NOW,

--- a/src/commands/iterate.fix-code-actionable.unchanged-headsha-keeps-attempt-count.mock.test.mts
+++ b/src/commands/iterate.fix-code-actionable.unchanged-headsha-keeps-attempt-count.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,

--- a/src/commands/iterate.fix-code-ci-failure.cancel-failure-fallback.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.cancel-failure-fallback.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-ci-failure.runiterate-fix-code-actionable-ci-failure.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.runiterate-fix-code-actionable-ci-failure.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-ci-failure.shared-runid-cancel-instructions.mock.test.mts
+++ b/src/commands/iterate.fix-code-ci-failure.shared-runid-cancel-instructions.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-conflicts.runiterate-fix-code-merge-conflicts.mock.test.mts
+++ b/src/commands/iterate.fix-code-conflicts.runiterate-fix-code-merge-conflicts.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-in-progress.comment-only-fix-omits-run-cancel.mock.test.mts
+++ b/src/commands/iterate.fix-code-in-progress.comment-only-fix-omits-run-cancel.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-in-progress.fix-code-in-progress-run-cancellation.mock.test.mts
+++ b/src/commands/iterate.fix-code-in-progress.fix-code-in-progress-run-cancellation.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-in-progress.test-support.mts
+++ b/src/commands/iterate.fix-code-in-progress.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -62,6 +61,7 @@ function makeReport(overrides: Partial<ShepherdReport> = {}): ShepherdReport {
     repo: "owner/repo",
     status: "READY",
     baseBranch: "main",
+    branchProtection: null,
     mergeStatus: {
       status: "CLEAN",
       state: "OPEN" as const,

--- a/src/commands/iterate.fix-code-projection.external-status-instructions.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.external-status-instructions.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-projection.mixed-check-instruction-variants.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.mixed-check-instruction-variants.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.fix-code-projection.runiterate-fix-code-agent-projection.mock.test.mts
+++ b/src/commands/iterate.fix-code-projection.runiterate-fix-code-agent-projection.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.orchestrator.runiterate-mark-ready.mock.test.mts
+++ b/src/commands/iterate.orchestrator.runiterate-mark-ready.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.orchestrator.runiterate-triage-via-runcheck.mock.test.mts
+++ b/src/commands/iterate.orchestrator.runiterate-triage-via-runcheck.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.render-escalate-fields.runiterate-prescriptive-fields-resolvecommand-shape.mock.test.mts
+++ b/src/commands/iterate.render-escalate-fields.runiterate-prescriptive-fields-resolvecommand-shape.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,

--- a/src/commands/iterate.render-humanmessage.runiterate-prescriptive-fields-escalate-humanmessage.mock.test.mts
+++ b/src/commands/iterate.render-humanmessage.runiterate-prescriptive-fields-escalate-humanmessage.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,

--- a/src/commands/iterate.render-resolve-cmd.buildresolvecommand-argv-shape.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.buildresolvecommand-argv-shape.mock.test.mts
@@ -1,15 +1,11 @@
-// @ts-nocheck
 /* eslint-disable max-lines */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderResolveCommand } from "./iterate/render.mts";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   NOW,
-  defaultConfig,
   makeOpts,
   makeReport,
   makeReview,
-  mockLoadConfig,
   mockRunCheck,
   mockUpdateReadyDelay,
 } from "./iterate-test-support.mts";

--- a/src/commands/iterate.render-resolve-cmd.renderresolvecommand-format.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.renderresolvecommand-format.mock.test.mts
@@ -1,17 +1,6 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderResolveCommand } from "./iterate/render.mts";
-import {
-  registerIterateHooks,
-  NOW,
-  defaultConfig,
-  makeOpts,
-  makeReport,
-  mockLoadConfig,
-  mockRunCheck,
-  mockUpdateReadyDelay,
-} from "./iterate-test-support.mts";
-import { runIterate } from "./iterate/index.mts";
+import { registerIterateHooks } from "./iterate-test-support.mts";
 
 registerIterateHooks();
 

--- a/src/commands/iterate.render-resolve-cmd.renderresolvecommand-placeholders.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.renderresolvecommand-placeholders.mock.test.mts
@@ -1,17 +1,6 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderResolveCommand } from "./iterate/render.mts";
-import {
-  registerIterateHooks,
-  NOW,
-  defaultConfig,
-  makeOpts,
-  makeReport,
-  mockLoadConfig,
-  mockRunCheck,
-  mockUpdateReadyDelay,
-} from "./iterate-test-support.mts";
-import { runIterate } from "./iterate/index.mts";
+import { registerIterateHooks } from "./iterate-test-support.mts";
 
 registerIterateHooks();
 

--- a/src/commands/iterate.render-resolve-cmd.renderresolvecommand.mock.test.mts
+++ b/src/commands/iterate.render-resolve-cmd.renderresolvecommand.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderResolveCommand } from "./iterate/render.mts";
 import { registerIterateHooks } from "./iterate-test-support.mts";
 

--- a/src/commands/iterate.render.buildfixinstructions.mock.test.mts
+++ b/src/commands/iterate.render.buildfixinstructions.mock.test.mts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { describe, it, expect } from "vitest";
 import { registerIterateHooks } from "./iterate-test-support.mts";
 import { buildFixInstructions } from "./iterate/render.mts";
 

--- a/src/commands/iterate.render.runiterate-has-hooks-derived-blocked.mock.test.mts
+++ b/src/commands/iterate.render.runiterate-has-hooks-derived-blocked.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.render.runiterate-prescriptive-fields-log-strings.mock.test.mts
+++ b/src/commands/iterate.render.runiterate-prescriptive-fields-log-strings.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.render.startup-failure-instructions.mock.test.mts
+++ b/src/commands/iterate.render.startup-failure-instructions.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.runiterate-cancel-on-merged-closed-pr.mock.test.mts
+++ b/src/commands/iterate.runiterate-cancel-on-merged-closed-pr.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.runiterate-cancel.mock.test.mts
+++ b/src/commands/iterate.runiterate-cancel.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.runiterate-malformed-repo-format.mock.test.mts
+++ b/src/commands/iterate.runiterate-malformed-repo-format.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.runiterate-wait.mock.test.mts
+++ b/src/commands/iterate.runiterate-wait.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.stall.disabled-stall-timeout-refreshes-first-seen-at.mock.test.mts
+++ b/src/commands/iterate.stall.disabled-stall-timeout-refreshes-first-seen-at.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-clears-stall-state-on-cancel-ready-delay-elapsed-so.mock.test.mts
+++ b/src/commands/iterate.stall.it-clears-stall-state-on-cancel-ready-delay-elapsed-so.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockWriteStallState,
   STALL_TIMEOUT_S,

--- a/src/commands/iterate.stall.it-escalates-with-stall-timeout-when-threshold-exceede.mock.test.mts
+++ b/src/commands/iterate.stall.it-escalates-with-stall-timeout-when-threshold-exceede.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-includes-resolution-only-threads-in-stall-timeout-e.mock.test.mts
+++ b/src/commands/iterate.stall.it-includes-resolution-only-threads-in-stall-timeout-e.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-preserves-firstseenat-when-fingerprint-matches-and-.mock.test.mts
+++ b/src/commands/iterate.stall.it-preserves-firstseenat-when-fingerprint-matches-and-.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-resets-firstseenat-when-fingerprint-changes-differe.mock.test.mts
+++ b/src/commands/iterate.stall.it-resets-firstseenat-when-fingerprint-changes-differe.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-resets-firstseenat-when-head-sha-changes-async.mock.test.mts
+++ b/src/commands/iterate.stall.it-resets-firstseenat-when-head-sha-changes-async.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-resets-firstseenat-when-inprogress-check-names-chan.mock.test.mts
+++ b/src/commands/iterate.stall.it-resets-firstseenat-when-inprogress-check-names-chan.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-resets-firstseenat-when-stored-firstseenat-is-in-th.mock.test.mts
+++ b/src/commands/iterate.stall.it-resets-firstseenat-when-stored-firstseenat-is-in-th.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.stall.it-writes-stall-state-on-first-call-no-stored-state-as.mock.test.mts
+++ b/src/commands/iterate.stall.it-writes-stall-state-on-first-call-no-stored-state-as.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   mockReadStallState,
   mockWriteStallState,

--- a/src/commands/iterate.steps.runiterate-cancelled-behind.mock.test.mts
+++ b/src/commands/iterate.steps.runiterate-cancelled-behind.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/iterate.steps.runiterate-timeout-cancelled-failures-route-to-fix-code.mock.test.mts
+++ b/src/commands/iterate.steps.runiterate-timeout-cancelled-failures-route-to-fix-code.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerIterateHooks,
   makeOpts,

--- a/src/commands/log-file.test.mts
+++ b/src/commands/log-file.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from "vitest";
 
 const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));

--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -16,10 +16,12 @@ function writeTickProgress(
   sleepSeconds: number,
   verbose: boolean,
 ): void {
-  if (process.stderr.isTTY || verbose) {
+  if (verbose) {
     process.stderr.write(
       `[poll tick ${tick} / +${elapsedSeconds}s] WAIT — sleeping ${sleepSeconds}s\n`,
     );
+  } else {
+    process.stderr.write(".");
   }
 }
 
@@ -33,18 +35,23 @@ export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> 
   let tick = 0;
   let lastResult: IterateResult | undefined;
   const verbose = opts.verbose === true;
+  let dotsPrinted = false;
 
   while (true) {
     tick += 1;
     lastResult = await runIterate(iterateOpts);
-    if (lastResult.action !== "wait") return lastResult;
+    if (lastResult.action !== "wait") break;
 
     const elapsedMs = Date.now() - start;
     const remainingMs = timeoutMs - elapsedMs;
-    if (remainingMs <= 0) return lastResult;
+    if (remainingMs <= 0) break;
 
     const nextSleepMs = Math.min(intervalMs, remainingMs);
     writeTickProgress(tick, Math.round(elapsedMs / 1000), Math.round(nextSleepMs / 1000), verbose);
+    if (!verbose) dotsPrinted = true;
     await sleep(nextSleepMs);
   }
+
+  if (dotsPrinted) process.stderr.write("\n");
+  return lastResult!;
 }

--- a/src/commands/poll.runpoll-clamps-oversized-timer.mock.test.mts
+++ b/src/commands/poll.runpoll-clamps-oversized-timer.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from "vitest";
 import {
   mockRunIterate,

--- a/src/commands/poll.runpoll-loops-on-wait-then-stops.mock.test.mts
+++ b/src/commands/poll.runpoll-loops-on-wait-then-stops.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from "vitest";
 import {
   mockRunIterate,

--- a/src/commands/poll.runpoll-stops-on-cancel.mock.test.mts
+++ b/src/commands/poll.runpoll-stops-on-cancel.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { mockRunIterate, makeCancelResult, registerPollHooks } from "./poll.test-support.mts";
 import { runPoll } from "./poll.mts";

--- a/src/commands/poll.runpoll-stops-on-mark-ready.mock.test.mts
+++ b/src/commands/poll.runpoll-stops-on-mark-ready.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { mockRunIterate, makeMarkReadyResult, registerPollHooks } from "./poll.test-support.mts";
 import { runPoll } from "./poll.mts";

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from "vitest";
 import {
   mockRunIterate,

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -106,9 +106,7 @@ describe("runPoll — tick progress logging", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     await pollPromise;
 
-    const lastWrite = String(
-      stderrSpy.mock.calls[stderrSpy.mock.calls.length - 1]?.[0] ?? "",
-    );
+    const lastWrite = String(stderrSpy.mock.calls[stderrSpy.mock.calls.length - 1]?.[0] ?? "");
     expect(lastWrite).toBe("\n");
 
     stderrSpy.mockRestore();

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -11,7 +11,36 @@ import { runPoll } from "./poll.mts";
 registerPollHooks();
 
 describe("runPoll — tick progress logging", () => {
-  it("writes progress to stderr on TTY when looping", async () => {
+  it("writes a dot per WAIT tick to stderr (non-TTY, non-verbose)", async () => {
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    mockRunIterate
+      .mockResolvedValueOnce(makeWaitResult())
+      .mockResolvedValueOnce(makeWaitResult())
+      .mockResolvedValue(makeCancelResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pollPromise;
+
+    const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
+    expect(written).toContain("..");
+    expect(written).toContain("\n");
+    expect(written).not.toContain("[poll tick");
+
+    stderrSpy.mockRestore();
+    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+  });
+
+  it("writes dots even when stderr is a TTY (non-verbose)", async () => {
     const originalIsTTY = process.stderr.isTTY;
     Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -28,13 +57,15 @@ describe("runPoll — tick progress logging", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     await pollPromise;
 
-    expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(true);
+    const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
+    expect(written).toContain(".");
+    expect(written).not.toContain("[poll tick");
 
     stderrSpy.mockRestore();
     Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
   });
 
-  it("writes progress when verbose:true even on non-TTY", async () => {
+  it("writes detailed per-tick line when verbose:true", async () => {
     const originalIsTTY = process.stderr.isTTY;
     Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -53,6 +84,32 @@ describe("runPoll — tick progress logging", () => {
     await pollPromise;
 
     expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(true);
+
+    stderrSpy.mockRestore();
+    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+  });
+
+  it("writes trailing newline after dots when loop exits", async () => {
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await pollPromise;
+
+    const lastWrite = String(
+      stderrSpy.mock.calls[stderrSpy.mock.calls.length - 1]?.[0] ?? "",
+    );
+    expect(lastWrite).toBe("\n");
 
     stderrSpy.mockRestore();
     Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });

--- a/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
+++ b/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from "vitest";
 import { mockRunIterate, makeWaitResult, registerPollHooks } from "./poll.test-support.mts";
 import { runPoll } from "./poll.mts";

--- a/src/commands/ready-delay.test.mts
+++ b/src/commands/ready-delay.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";

--- a/src/commands/ready-mergeability.test.mts
+++ b/src/commands/ready-mergeability.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../github/client.mts", () => ({

--- a/src/commands/resolve.edited-outdated-and-minimized-items.mock.test.mts
+++ b/src/commands/resolve.edited-outdated-and-minimized-items.mock.test.mts
@@ -1,9 +1,7 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
-  autoResolveOutdated,
   loadConfig,
   makeBatchData,
   makeComment,

--- a/src/commands/resolve.fetch-without-review-summaries.mock.test.mts
+++ b/src/commands/resolve.fetch-without-review-summaries.mock.test.mts
@@ -1,9 +1,7 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
-  autoResolveOutdated,
   loadConfig,
   makeBatchData,
   makeThread,

--- a/src/commands/resolve.runresolvefetch-auto-resolves-outdated-threads.mock.test.mts
+++ b/src/commands/resolve.runresolvefetch-auto-resolves-outdated-threads.mock.test.mts
@@ -1,9 +1,7 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
-  autoResolveOutdated,
   makeBatchData,
   makeThread,
   mockAutoResolveOutdated,

--- a/src/commands/resolve.runresolvefetch-first-look-items.mock.test.mts
+++ b/src/commands/resolve.runresolvefetch-first-look-items.mock.test.mts
@@ -1,12 +1,10 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
   makeBatchData,
   makeComment,
   makeThread,
-  markSeen,
   mockAutoResolveOutdated,
   mockFetchPrBatch,
   mockLoadSeenMap,

--- a/src/commands/resolve.runresolvefetch-no-pr.mock.test.mts
+++ b/src/commands/resolve.runresolvefetch-no-pr.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, BASE_OPTS, mockGetCurrentPrNumber } from "./resolve.test-support.mts";
 import { runResolveFetch } from "./resolve.mts";
 

--- a/src/commands/resolve.runresolvemutate-forwards-options.mock.test.mts
+++ b/src/commands/resolve.runresolvemutate-forwards-options.mock.test.mts
@@ -1,9 +1,7 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
-  applyResolveOptions,
   makeBatchData,
   mockApplyResolveOptions,
   mockFetchPrBatch,

--- a/src/commands/resolve.runresolvemutate-no-pr.mock.test.mts
+++ b/src/commands/resolve.runresolvemutate-no-pr.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, BASE_OPTS, mockGetCurrentPrNumber } from "./resolve.test-support.mts";
 import { runResolveMutate } from "./resolve.mts";
 

--- a/src/commands/resolve.test-support.mts
+++ b/src/commands/resolve.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 vi.mock("../github/client.mts", () => ({
   getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
@@ -77,6 +76,7 @@ function makeBatchData(overrides: Partial<BatchPrData> = {}): BatchPrData {
     reviewSummaries: [],
     approvedReviews: [],
     checks: [],
+    branchProtection: null,
     ...overrides,
   };
 }

--- a/src/commands/shepherd-journal.instruction-heading-dedup.test.mts
+++ b/src/commands/shepherd-journal.instruction-heading-dedup.test.mts
@@ -1,7 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  registerHooks,
   SHEPHERD_JOURNAL_APPEND_HINT,
   SHEPHERD_JOURNAL_FIRST_LOOK_GUIDANCE,
   SHEPHERD_JOURNAL_REFERENCE_GUIDANCE_THREADS_AND_COMMENTS_IN_ITEMS,
@@ -55,7 +53,6 @@ describe("shepherd journal instruction helpers", () => {
       [],
       [],
       [],
-      undefined,
     );
 
     const text = instructions.join("\n");

--- a/src/commands/shepherd-journal.shepherd-journal-instruction-helpers.test.mts
+++ b/src/commands/shepherd-journal.shepherd-journal-instruction-helpers.test.mts
@@ -1,7 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  registerHooks,
   SHEPHERD_JOURNAL_APPEND_HINT,
   SHEPHERD_JOURNAL_FIRST_LOOK_GUIDANCE,
   SHEPHERD_JOURNAL_REFERENCE_GUIDANCE_THREADS_AND_COMMENTS_IN_ITEMS,
@@ -72,7 +70,6 @@ describe("shepherd journal instruction helpers", () => {
       [],
       [],
       [],
-      undefined,
     );
 
     const text = instructions.join("\n");

--- a/src/commands/shepherd-journal.test-support.mts
+++ b/src/commands/shepherd-journal.test-support.mts
@@ -1,6 +1,3 @@
-// @ts-nocheck
-import { describe, expect, it } from "vitest";
-
 import type { ResolveCommand, AgentThread } from "../types.mts";
 import type { FetchResult } from "./resolve.mts";
 import {

--- a/src/comments/minimize-policy.test.mts
+++ b/src/comments/minimize-policy.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, expect, it } from "vitest";
 
 import { shouldMinimizeAuthor } from "./minimize-policy.mts";

--- a/src/comments/outdated.test.mts
+++ b/src/comments/outdated.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { getOutdatedThreads } from "./outdated.mts";
 import type { ReviewThread } from "../types.mts";

--- a/src/comments/pending-ops.test.mts
+++ b/src/comments/pending-ops.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, expect, it } from "vitest";
 import { setPendingOps, type ResolveMutationOp } from "./pending-ops.mts";
 import type { ResolveResult } from "./resolve.mts";

--- a/src/comments/resolve.applyresolveoptions-mutations.mock.test.mts
+++ b/src/comments/resolve.applyresolveoptions-mutations.mock.test.mts
@@ -1,6 +1,5 @@
-// @ts-nocheck
 /* eslint-disable max-lines */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, REPO, makeBulkResponse, mockGraphql } from "./resolve.test-support.mts";
 import { applyResolveOptions } from "./resolve.mts";
 

--- a/src/comments/resolve.applyresolveoptions-requiresha.mock.test.mts
+++ b/src/comments/resolve.applyresolveoptions-requiresha.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { registerHooks, REPO, mockGetPrHeadSha } from "./resolve.test-support.mts";
 import { applyResolveOptions } from "./resolve.mts";
 

--- a/src/comments/resolve.applyresolveoptions-validation.mock.test.mts
+++ b/src/comments/resolve.applyresolveoptions-validation.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, REPO, mockGraphql } from "./resolve.test-support.mts";
 import { applyResolveOptions } from "./resolve.mts";
 

--- a/src/comments/resolve.autoresolveoutdated.mock.test.mts
+++ b/src/comments/resolve.autoresolveoutdated.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, mockGraphql } from "./resolve.test-support.mts";
 import { autoResolveOutdated } from "./resolve.mts";
 

--- a/src/comments/resolve.batch-alias-rate-limit-headers.mock.test.mts
+++ b/src/comments/resolve.batch-alias-rate-limit-headers.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, REPO, mockGraphql } from "./resolve.test-support.mts";
 import { applyResolveOptions } from "./resolve.mts";
 

--- a/src/comments/resolve.test-support.mts
+++ b/src/comments/resolve.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mock github/client.mts before any imports.

--- a/src/comments/sha-poll.test.mts
+++ b/src/comments/sha-poll.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../github/client.mts", () => ({

--- a/src/config/load.test.mts
+++ b/src/config/load.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/src/github/batch-parsers-author-type.mock.test.mts
+++ b/src/github/batch-parsers-author-type.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("./client.mts", () => ({

--- a/src/github/batch-parsers.fetchprbatch-check-type-mapping.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-check-type-mapping.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.fetchprbatch-extractrunid.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-extractrunid.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.fetchprbatch-null-author-fallbacks.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-null-author-fallbacks.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.fetchprbatch-parsecreatedat.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-parsecreatedat.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.fetchprbatch-pr-not-found.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-pr-not-found.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.fetchprbatch-reviewthread-isminimized-mapping.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-reviewthread-isminimized-mapping.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.fetchprbatch-team-reviewer-fallback.mock.test.mts
+++ b/src/github/batch-parsers.fetchprbatch-team-reviewer-fallback.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch-parsers.summary.mock.test.mts
+++ b/src/github/batch-parsers.summary.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("./client.mts", () => ({

--- a/src/github/batch-parsers.test-support.mts
+++ b/src/github/batch-parsers.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 vi.mock("./client.mts", () => ({
   graphql: vi.fn(),

--- a/src/github/batch.fetchprbatch-approvedreviews.mock.test.mts
+++ b/src/github/batch.fetchprbatch-approvedreviews.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-changesrequestedreviews-pagination.mock.test.mts
+++ b/src/github/batch.fetchprbatch-changesrequestedreviews-pagination.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-checks-pagination.mock.test.mts
+++ b/src/github/batch.fetchprbatch-checks-pagination.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-comment-pagination.mock.test.mts
+++ b/src/github/batch.fetchprbatch-comment-pagination.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-pr-not-found-in-pagination-callbacks.mock.test.mts
+++ b/src/github/batch.fetchprbatch-pr-not-found-in-pagination-callbacks.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-reviewsummaries-pagination.mock.test.mts
+++ b/src/github/batch.fetchprbatch-reviewsummaries-pagination.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-reviewsummaries.mock.test.mts
+++ b/src/github/batch.fetchprbatch-reviewsummaries.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.fetchprbatch-thread-pagination.mock.test.mts
+++ b/src/github/batch.fetchprbatch-thread-pagination.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   REPO,

--- a/src/github/batch.test-support.mts
+++ b/src/github/batch.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 vi.mock("./client.mts", () => ({
   graphql: vi.fn(),

--- a/src/github/client.getcurrentprnumber.mock.test.mts
+++ b/src/github/client.getcurrentprnumber.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,15 +26,7 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-  getPrNumberForBranch,
-} from "./client.mts";
+import { getCurrentPrNumber, getPrNumberForBranch } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
@@ -51,26 +42,6 @@ function gqlOk(data: unknown): Response {
     }),
     json: () => Promise.resolve({ data }),
     text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
   } as unknown as Response;
 }
 

--- a/src/github/client.getmergeablestate.mock.test.mts
+++ b/src/github/client.getmergeablestate.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,41 +26,12 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-} from "./client.mts";
+import { getMergeableState } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
 
 function restOk(data: unknown): Response {
   return {

--- a/src/github/client.getprheadsha.mock.test.mts
+++ b/src/github/client.getprheadsha.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,14 +26,7 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-} from "./client.mts";
+import { getPrHeadSha } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
@@ -50,26 +42,6 @@ function gqlOk(data: unknown): Response {
     }),
     json: () => Promise.resolve({ data }),
     text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
   } as unknown as Response;
 }
 

--- a/src/github/client.getrepoinfo-remote-url-parsing.mock.test.mts
+++ b/src/github/client.getrepoinfo-remote-url-parsing.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,51 +26,12 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-} from "./client.mts";
+import { getRepoInfo } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
-  } as unknown as Response;
-}
 
 beforeEach(() => {
   mockFetch.mockReset();

--- a/src/github/client.graphql-arg-building.mock.test.mts
+++ b/src/github/client.graphql-arg-building.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,14 +26,7 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-} from "./client.mts";
+import { graphql } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
@@ -50,26 +42,6 @@ function gqlOk(data: unknown): Response {
     }),
     json: () => Promise.resolve({ data }),
     text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
   } as unknown as Response;
 }
 

--- a/src/github/client.graphql-error-handling.mock.test.mts
+++ b/src/github/client.graphql-error-handling.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,31 +26,12 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-} from "./client.mts";
+import { graphql } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
 
 function gqlErrors(errors: Array<{ message: string }>): Response {
   return {
@@ -60,16 +40,6 @@ function gqlErrors(errors: Array<{ message: string }>): Response {
     headers: new Headers({ "content-type": "application/json" }),
     json: () => Promise.resolve({ data: null, errors }),
     text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
   } as unknown as Response;
 }
 

--- a/src/github/client.graphqlwithratelimit-header-parsing.mock.test.mts
+++ b/src/github/client.graphqlwithratelimit-header-parsing.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -27,14 +26,7 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import {
-  graphql,
-  graphqlWithRateLimit,
-  getCurrentPrNumber,
-  getMergeableState,
-  getPrHeadSha,
-  getRepoInfo,
-} from "./client.mts";
+import { graphqlWithRateLimit } from "./client.mts";
 import { _resetTokenCache } from "./http.mts";
 
 // ---------------------------------------------------------------------------
@@ -50,26 +42,6 @@ function gqlOk(data: unknown): Response {
     }),
     json: () => Promise.resolve({ data }),
     text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
   } as unknown as Response;
 }
 

--- a/src/github/graphql-http.mts
+++ b/src/github/graphql-http.mts
@@ -15,6 +15,7 @@ const BASE_URL = "https://api.github.com";
 
 export interface GitHubGraphQlError {
   message: string;
+  path?: unknown;
 }
 
 export interface GraphQlResult<T = unknown> {

--- a/src/github/http.graphql-error-handling.mock.test.mts
+++ b/src/github/http.graphql-error-handling.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { registerHooks, gqlOk, mockFetch } from "./http.test-support.mts";
 import { graphql } from "./http.mts";
 

--- a/src/github/http.graphqlwithratelimit-header-parsing.mock.test.mts
+++ b/src/github/http.graphqlwithratelimit-header-parsing.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { registerHooks, gqlOk, mockFetch } from "./http.test-support.mts";
 import { GitHubRequestError, graphqlWithRateLimit } from "./http.mts";
 

--- a/src/github/http.rest.mock.test.mts
+++ b/src/github/http.rest.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { registerHooks, jsonOk, mockFetch } from "./http.test-support.mts";
 import { rest } from "./http.mts";
 

--- a/src/github/http.resttext-redirect-handling.mock.test.mts
+++ b/src/github/http.resttext-redirect-handling.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { registerHooks, mockFetch } from "./http.test-support.mts";
 import { restText } from "./http.mts";
 

--- a/src/github/http.test-support.mts
+++ b/src/github/http.test-support.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Stub fetch and child_process globally before any imports.

--- a/src/github/http.token-resolution.mock.test.mts
+++ b/src/github/http.token-resolution.mock.test.mts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { registerHooks, gqlOk, mockExecFile, mockFetch } from "./http.test-support.mts";
 import { graphql } from "./http.mts";
 

--- a/src/github/pagination.test.mts
+++ b/src/github/pagination.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { paginateForward, paginateBackward, type Connection } from "./pagination.mts";
 

--- a/src/github/queries.test.mts
+++ b/src/github/queries.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { BATCH_PR_QUERY, GET_PR_HEAD_SHA_QUERY } from "./queries.mts";
 

--- a/src/index.mock.test.mts
+++ b/src/index.mock.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { mockMain } = vi.hoisted(() => ({ mockMain: vi.fn() }));

--- a/src/log/log-file.test.mts
+++ b/src/log/log-file.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
 import { rm, readFile } from "node:fs/promises";

--- a/src/log/session.buildsessionheader.test.mts
+++ b/src/log/session.buildsessionheader.test.mts
@@ -1,11 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi } from "vitest";
-import {
-  buildSessionHeader,
-  formatRequestEntry,
-  formatResponseEntry,
-  formatOutputEntry,
-} from "./session.mts";
+import { describe, it, expect } from "vitest";
+import { buildSessionHeader } from "./session.mts";
 
 describe("buildSessionHeader", () => {
   it("includes the ISO timestamp and command args", () => {

--- a/src/log/session.formatoutputentry.test.mts
+++ b/src/log/session.formatoutputentry.test.mts
@@ -1,11 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi } from "vitest";
-import {
-  buildSessionHeader,
-  formatRequestEntry,
-  formatResponseEntry,
-  formatOutputEntry,
-} from "./session.mts";
+import { describe, it, expect } from "vitest";
+import { formatOutputEntry } from "./session.mts";
 
 describe("formatOutputEntry", () => {
   it("wraps text output in a fenced block", () => {

--- a/src/log/session.formatrequestentry.test.mts
+++ b/src/log/session.formatrequestentry.test.mts
@@ -1,11 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi } from "vitest";
-import {
-  buildSessionHeader,
-  formatRequestEntry,
-  formatResponseEntry,
-  formatOutputEntry,
-} from "./session.mts";
+import { describe, it, expect } from "vitest";
+import { formatRequestEntry } from "./session.mts";
 
 describe("formatRequestEntry", () => {
   it("formats a GraphQL request with operation name and variables", () => {

--- a/src/log/session.formatresponseentry.test.mts
+++ b/src/log/session.formatresponseentry.test.mts
@@ -1,11 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi } from "vitest";
-import {
-  buildSessionHeader,
-  formatRequestEntry,
-  formatResponseEntry,
-  formatOutputEntry,
-} from "./session.mts";
+import { describe, it, expect } from "vitest";
+import { formatResponseEntry } from "./session.mts";
 
 describe("formatResponseEntry", () => {
   it("formats a successful GraphQL response", () => {

--- a/src/log/session.truncation.test.mts
+++ b/src/log/session.truncation.test.mts
@@ -1,11 +1,4 @@
-// @ts-nocheck
 import { describe, it, expect, vi } from "vitest";
-import {
-  buildSessionHeader,
-  formatRequestEntry,
-  formatResponseEntry,
-  formatOutputEntry,
-} from "./session.mts";
 
 describe("truncation", () => {
   it("truncates when MAX_BODY env is set before module load", async () => {

--- a/src/log/setup.test.mts
+++ b/src/log/setup.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetRepoInfo, mockInitLog, mockAppendEntry, mockBuildSessionHeader, mockFormatOutput } =

--- a/src/merge-status/derive.test.mts
+++ b/src/merge-status/derive.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { deriveMergeStatus } from "./derive.mts";
 import type { BatchPrData } from "../types.mts";

--- a/src/reporters/agent.toagentcheck.test.mts
+++ b/src/reporters/agent.toagentcheck.test.mts
@@ -1,32 +1,6 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import { toAgentThread, toAgentComment, toAgentCheck, toAgentChecks } from "./agent.mts";
-import type { ReviewThread, PrComment, TriagedCheck } from "../types.mts";
-
-const thread: ReviewThread = {
-  id: "t-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "alice",
-  authorType: "User",
-  body: "Please fix this method.",
-  url: "",
-  createdAtUnix: 1700000000,
-};
-
-const comment: PrComment = {
-  id: "c-1",
-  isMinimized: false,
-  author: "bob",
-  authorType: "Bot",
-  body: "Consider renaming.",
-  url: "",
-  createdAtUnix: 1700000001,
-};
+import { toAgentCheck } from "./agent.mts";
+import type { TriagedCheck } from "../types.mts";
 
 function makeCheck(runId: string | null, name = "typecheck"): TriagedCheck {
   return {

--- a/src/reporters/agent.toagentchecks.test.mts
+++ b/src/reporters/agent.toagentchecks.test.mts
@@ -1,32 +1,6 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import { toAgentThread, toAgentComment, toAgentCheck, toAgentChecks } from "./agent.mts";
-import type { ReviewThread, PrComment, TriagedCheck } from "../types.mts";
-
-const thread: ReviewThread = {
-  id: "t-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "alice",
-  authorType: "User",
-  body: "Please fix this method.",
-  url: "",
-  createdAtUnix: 1700000000,
-};
-
-const comment: PrComment = {
-  id: "c-1",
-  isMinimized: false,
-  author: "bob",
-  authorType: "Bot",
-  body: "Consider renaming.",
-  url: "",
-  createdAtUnix: 1700000001,
-};
+import { toAgentChecks } from "./agent.mts";
+import type { TriagedCheck } from "../types.mts";
 
 function makeCheck(runId: string | null, name = "typecheck"): TriagedCheck {
   return {

--- a/src/reporters/agent.toagentcomment.test.mts
+++ b/src/reporters/agent.toagentcomment.test.mts
@@ -1,22 +1,6 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import { toAgentThread, toAgentComment, toAgentCheck, toAgentChecks } from "./agent.mts";
-import type { ReviewThread, PrComment, TriagedCheck } from "../types.mts";
-
-const thread: ReviewThread = {
-  id: "t-1",
-  isResolved: false,
-  isOutdated: false,
-  isMinimized: false,
-  path: "src/foo.mts",
-  line: 10,
-  startLine: null,
-  author: "alice",
-  authorType: "User",
-  body: "Please fix this method.",
-  url: "",
-  createdAtUnix: 1700000000,
-};
+import { toAgentComment } from "./agent.mts";
+import type { PrComment } from "../types.mts";
 
 const comment: PrComment = {
   id: "c-1",
@@ -27,18 +11,6 @@ const comment: PrComment = {
   url: "",
   createdAtUnix: 1700000001,
 };
-
-function makeCheck(runId: string | null, name = "typecheck"): TriagedCheck {
-  return {
-    name,
-    status: "COMPLETED",
-    conclusion: "FAILURE",
-    detailsUrl: `https://github.com/owner/repo/actions/runs/${runId}`,
-    event: "pull_request",
-    runId,
-    category: "failing",
-  };
-}
 
 describe("toAgentComment", () => {
   it("keeps id/author/body and drops isMinimized/createdAtUnix", () => {

--- a/src/reporters/agent.toagentthread.test.mts
+++ b/src/reporters/agent.toagentthread.test.mts
@@ -1,7 +1,6 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
-import { toAgentThread, toAgentComment, toAgentCheck, toAgentChecks } from "./agent.mts";
-import type { ReviewThread, PrComment, TriagedCheck } from "../types.mts";
+import { toAgentThread } from "./agent.mts";
+import type { ReviewThread } from "../types.mts";
 
 const thread: ReviewThread = {
   id: "t-1",
@@ -17,28 +16,6 @@ const thread: ReviewThread = {
   url: "",
   createdAtUnix: 1700000000,
 };
-
-const comment: PrComment = {
-  id: "c-1",
-  isMinimized: false,
-  author: "bob",
-  authorType: "Bot",
-  body: "Consider renaming.",
-  url: "",
-  createdAtUnix: 1700000001,
-};
-
-function makeCheck(runId: string | null, name = "typecheck"): TriagedCheck {
-  return {
-    name,
-    status: "COMPLETED",
-    conclusion: "FAILURE",
-    detailsUrl: `https://github.com/owner/repo/actions/runs/${runId}`,
-    event: "pull_request",
-    runId,
-    category: "failing",
-  };
-}
 
 describe("toAgentThread", () => {
   it("keeps id/path/line/author/body and drops isResolved/isOutdated/createdAtUnix", () => {

--- a/src/state/base.test.mts
+++ b/src/state/base.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, afterEach } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/src/state/fix-attempts.test.mts
+++ b/src/state/fix-attempts.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
 import { rm, writeFile, mkdir } from "node:fs/promises";

--- a/src/state/iterate-stall.test.mts
+++ b/src/state/iterate-stall.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
 import { rm, writeFile, mkdir } from "node:fs/promises";

--- a/src/state/seen-comments.classifyitem.test.mts
+++ b/src/state/seen-comments.classifyitem.test.mts
@@ -1,22 +1,9 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { rm } from "node:fs/promises";
+import { classifyItem, hashBody } from "./seen-comments.mts";
 
 let testStateDir: string;
-
-const testKey = { owner: "test-owner", repo: "test-repo", pr: 123 };
-const testId = "PRRT_kwDOTest123";
 
 beforeEach(() => {
   testStateDir = `${process.env["TMPDIR"] ?? "/tmp"}/shepherd-seen-test-${randomBytes(4).toString("hex")}`;

--- a/src/state/seen-comments.hasseen-default-state-dir.test.mts
+++ b/src/state/seen-comments.hasseen-default-state-dir.test.mts
@@ -1,17 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { rm } from "node:fs/promises";
+import { hasSeen } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.hasseen-markseen-unsafe-key-segments.test.mts
+++ b/src/state/seen-comments.hasseen-markseen-unsafe-key-segments.test.mts
@@ -1,17 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { rm } from "node:fs/promises";
+import { hasSeen, markSeen } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.hasseen-miss.test.mts
+++ b/src/state/seen-comments.hasseen-miss.test.mts
@@ -1,17 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { rm } from "node:fs/promises";
+import { hasSeen } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.loadseenmap.test.mts
+++ b/src/state/seen-comments.loadseenmap.test.mts
@@ -1,17 +1,8 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes, createHash } from "node:crypto";
 import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { markSeen, loadSeenMap, hashBody } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.loadseenset.test.mts
+++ b/src/state/seen-comments.loadseenset.test.mts
@@ -1,17 +1,8 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
+import { rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { markSeen, loadSeenSet } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.markseen-bodyhash-upsert.test.mts
+++ b/src/state/seen-comments.markseen-bodyhash-upsert.test.mts
@@ -1,17 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { rm } from "node:fs/promises";
+import { markSeen, readSeenMarker, hashBody } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.markseen-fire-and-forget.test.mts
+++ b/src/state/seen-comments.markseen-fire-and-forget.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes, createHash } from "node:crypto";
 import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
@@ -7,15 +6,7 @@ import { join } from "node:path";
 function idToFilename(id: string): string {
   return createHash("sha256").update(id, "utf8").digest("hex") + ".json";
 }
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { markSeen } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.markseen-hasseen-round-trip.test.mts
+++ b/src/state/seen-comments.markseen-hasseen-round-trip.test.mts
@@ -1,17 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { rm } from "node:fs/promises";
+import { hasSeen, markSeen } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/state/seen-comments.readseenmarker.test.mts
+++ b/src/state/seen-comments.readseenmarker.test.mts
@@ -1,21 +1,12 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomBytes, createHash } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
+import { rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
 function idToFilename(id: string): string {
   return createHash("sha256").update(id, "utf8").digest("hex") + ".json";
 }
-import {
-  hasSeen,
-  markSeen,
-  readSeenMarker,
-  loadSeenSet,
-  loadSeenMap,
-  classifyItem,
-  hashBody,
-} from "./seen-comments.mts";
+import { markSeen, readSeenMarker } from "./seen-comments.mts";
 
 let testStateDir: string;
 

--- a/src/suggestions/parse.test.mts
+++ b/src/suggestions/parse.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { parseSuggestion, isCommittableSuggestion } from "./parse.mts";
 

--- a/src/suggestions/patch.buildunifieddiff.emits-no-newline-marker-for-context-lines-before-the-hunk-when-last-line.test.mts
+++ b/src/suggestions/patch.buildunifieddiff.emits-no-newline-marker-for-context-lines-before-the-hunk-when-last-line.test.mts
@@ -1,6 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerHooks, buildUnifiedDiff } from "./patch.test-support.mts";
+import { describe, it, expect } from "vitest";
+import { buildUnifiedDiff } from "./patch.test-support.mts";
 
 describe("buildUnifiedDiff", () => {
   it("emits no-newline marker for context lines before the hunk when last line is in before-context", () => {

--- a/src/suggestions/patch.buildunifieddiff.test.mts
+++ b/src/suggestions/patch.buildunifieddiff.test.mts
@@ -1,6 +1,5 @@
-// @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerHooks, buildUnifiedDiff } from "./patch.test-support.mts";
+import { describe, it, expect } from "vitest";
+import { buildUnifiedDiff } from "./patch.test-support.mts";
 
 describe("buildUnifiedDiff", () => {
   it("replaces a single line in the middle of a file", () => {

--- a/src/suggestions/patch.test-support.mts
+++ b/src/suggestions/patch.test-support.mts
@@ -1,6 +1,3 @@
-// @ts-nocheck
-import { describe, it, expect } from "vitest";
-
 import { buildUnifiedDiff } from "./patch.mts";
 
 export { buildUnifiedDiff };

--- a/src/util/markdown.test.mts
+++ b/src/util/markdown.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { joinSections } from "./markdown.mts";
 

--- a/src/util/path-segment.test.mts
+++ b/src/util/path-segment.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect } from "vitest";
 import { SAFE_SEGMENT } from "./path-segment.mts";
 

--- a/src/util/worktree.test.mts
+++ b/src/util/worktree.test.mts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHash } from "node:crypto";
 

--- a/test-cases/harness.mts
+++ b/test-cases/harness.mts
@@ -327,7 +327,7 @@ async function runMain(args: string[]): Promise<{ out: string; exitCode: number 
 }
 
 export async function captureRun(fixture: Fixture): Promise<RunResult> {
-  const args = ["42", ...(fixture.args ?? [])];
+  const args = ["iterate", "42", ...(fixture.args ?? [])];
   const { out: textOut, exitCode } = await runMain(args);
   const { out: jsonOut } = await runMain([...args, "--format=json"]);
   return { textOut, jsonOut, exitCode };
@@ -338,7 +338,7 @@ export async function captureRun(fixture: Fixture): Promise<RunResult> {
  * firstSeenAt far in the past so applyStallGuard escalates.
  */
 export async function captureTwoTickStallRun(fixture: Fixture): Promise<RunResult> {
-  const args = ["42", ...(fixture.args ?? [])];
+  const args = ["iterate", "42", ...(fixture.args ?? [])];
 
   // Clear write history so we only inspect calls from this run's tick 1.
   mockWriteStallState.mockClear();

--- a/test-cases/index.test.mts
+++ b/test-cases/index.test.mts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+
 import { describe, it, expect } from "vitest";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
## Summary

- `pr-shepherd <PR>` now defaults to poll instead of iterate — the default invocation loops until a non-WAIT result without callers needing to spell out `poll`
- `--interval` and `--timeout` are accepted on the default path so callers can write `pr-shepherd <N> --interval 45s --timeout 4m`
- Poll tick progress: single `.` per WAIT tick written unconditionally to stderr (replaces the TTY-gated verbose line); trailing `\n` after the loop exits; `--verbose` restores the detailed per-tick line
- Skill updated to use `pr-shepherd <N> --interval 45s --timeout 4m` with no explanation of the flags
- `iterate` subcommand preserved as a single-tick alias

## Test plan

- [x] All 1062 tests pass (`npm test`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] `pr-shepherd --help` describes `[PR]` as poll-by-default
- [x] `pr-shepherd 42 --help` shows poll help (not iterate)
- [x] `pr-shepherd iterate 42` runs one tick and exits
- [x] `pr-shepherd 42 --interval 45s --timeout 4m` is accepted without error
- [x] Poll stderr emits dots then `\n`, not verbose lines, without `--verbose`

## Shepherd Journal

- **[PRRT_kwDOSGizTs6DGYLg](https://github.com/jonathanong/pr-shepherd/pull/234#discussion_r3265133414)** — Rejected Codacy suggestion to pass `$ARGUMENTS` as extra flags. The instruction "Do not pass `$ARGUMENTS` through as extra flags" is intentional: `$ARGUMENTS` contains the PR number or URL (the skill resolves it), not CLI flags. Passing it through would break the invocation.

- **[PRRT_kwDOSGizTs6DGYLs](https://github.com/jonathanong/pr-shepherd/pull/234#discussion_r3265133433)** — Rejected Codacy suggestion to unify repeated `pr-shepherd <N> --interval 45s --timeout 4m` calls. The repetition is intentional — each bullet in the persistence loop shows the exact command for that state, so the agent doesn't have to reason about which command applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)