### PR TITLE
test: extract shared test boilerplate to fix SonarCloud duplication

### DIFF
--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -11,12 +11,16 @@ registerPollHooks();
 
 function withStderrTTY(isTTY: boolean, fn: () => Promise<void>): () => Promise<void> {
   return async () => {
-    const originalIsTTY = process.stderr.isTTY;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
     Object.defineProperty(process.stderr, "isTTY", { value: isTTY, configurable: true });
     try {
       await fn();
     } finally {
-      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+      if (originalDescriptor) {
+        Object.defineProperty(process.stderr, "isTTY", originalDescriptor);
+      } else {
+        delete (process.stderr as { isTTY?: boolean }).isTTY;
+      }
     }
   };
 }

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -9,106 +9,115 @@ import { runPoll } from "./poll.mts";
 
 registerPollHooks();
 
+function withStderrTTY(isTTY: boolean, fn: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: isTTY, configurable: true });
+    try {
+      await fn();
+    } finally {
+      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+    }
+  };
+}
+
 describe("runPoll — tick progress logging", () => {
-  it("writes a dot per WAIT tick to stderr (non-TTY, non-verbose)", async () => {
-    const originalIsTTY = process.stderr.isTTY;
-    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  it(
+    "writes a dot per WAIT tick to stderr (non-TTY, non-verbose)",
+    withStderrTTY(false, async () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-    mockRunIterate
-      .mockResolvedValueOnce(makeWaitResult())
-      .mockResolvedValueOnce(makeWaitResult())
-      .mockResolvedValue(makeCancelResult());
+      mockRunIterate
+        .mockResolvedValueOnce(makeWaitResult())
+        .mockResolvedValueOnce(makeWaitResult())
+        .mockResolvedValue(makeCancelResult());
 
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      intervalSeconds: 30,
-      timeoutSeconds: 300,
-    });
+      const pollPromise = runPoll({
+        prNumber: 42,
+        format: "text",
+        intervalSeconds: 30,
+        timeoutSeconds: 300,
+      });
 
-    await vi.advanceTimersByTimeAsync(60_000);
-    await pollPromise;
+      await vi.advanceTimersByTimeAsync(60_000);
+      await pollPromise;
 
-    const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
-    expect(written).toContain("..");
-    expect(written).toContain("\n");
-    expect(written).not.toContain("[poll tick");
+      const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
+      expect(written).toContain("..");
+      expect(written).toContain("\n");
+      expect(written).not.toContain("[poll tick");
 
-    stderrSpy.mockRestore();
-    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
-  });
+      stderrSpy.mockRestore();
+    }),
+  );
 
-  it("writes dots even when stderr is a TTY (non-verbose)", async () => {
-    const originalIsTTY = process.stderr.isTTY;
-    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  it(
+    "writes dots even when stderr is a TTY (non-verbose)",
+    withStderrTTY(true, async () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
 
-    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+      const pollPromise = runPoll({
+        prNumber: 42,
+        format: "text",
+        intervalSeconds: 30,
+        timeoutSeconds: 300,
+      });
 
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      intervalSeconds: 30,
-      timeoutSeconds: 300,
-    });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await pollPromise;
 
-    await vi.advanceTimersByTimeAsync(30_000);
-    await pollPromise;
+      const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
+      expect(written).toContain(".");
+      expect(written).not.toContain("[poll tick");
 
-    const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
-    expect(written).toContain(".");
-    expect(written).not.toContain("[poll tick");
+      stderrSpy.mockRestore();
+    }),
+  );
 
-    stderrSpy.mockRestore();
-    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
-  });
+  it(
+    "writes detailed per-tick line when verbose:true",
+    withStderrTTY(false, async () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
 
-  it("writes detailed per-tick line when verbose:true", async () => {
-    const originalIsTTY = process.stderr.isTTY;
-    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const pollPromise = runPoll({
+        prNumber: 42,
+        format: "text",
+        verbose: true,
+        intervalSeconds: 30,
+        timeoutSeconds: 300,
+      });
 
-    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
+      await vi.advanceTimersByTimeAsync(30_000);
+      await pollPromise;
 
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      verbose: true,
-      intervalSeconds: 30,
-      timeoutSeconds: 300,
-    });
+      expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(
+        true,
+      );
+      stderrSpy.mockRestore();
+    }),
+  );
 
-    await vi.advanceTimersByTimeAsync(30_000);
-    await pollPromise;
+  it(
+    "writes trailing newline after dots when loop exits",
+    withStderrTTY(false, async () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
 
-    expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(true);
+      const pollPromise = runPoll({
+        prNumber: 42,
+        format: "text",
+        intervalSeconds: 30,
+        timeoutSeconds: 300,
+      });
 
-    stderrSpy.mockRestore();
-    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
-  });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await pollPromise;
 
-  it("writes trailing newline after dots when loop exits", async () => {
-    const originalIsTTY = process.stderr.isTTY;
-    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-
-    mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
-
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      intervalSeconds: 30,
-      timeoutSeconds: 300,
-    });
-
-    await vi.advanceTimersByTimeAsync(30_000);
-    await pollPromise;
-
-    const lastWrite = String(stderrSpy.mock.calls[stderrSpy.mock.calls.length - 1]?.[0] ?? "");
-    expect(lastWrite).toBe("\n");
-
-    stderrSpy.mockRestore();
-    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
-  });
+      const lastWrite = String(stderrSpy.mock.calls[stderrSpy.mock.calls.length - 1]?.[0] ?? "");
+      expect(lastWrite).toBe("\n");
+      stderrSpy.mockRestore();
+    }),
+  );
 });

--- a/src/commands/poll.runpoll-tick-progress.mock.test.mts
+++ b/src/commands/poll.runpoll-tick-progress.mock.test.mts
@@ -9,13 +9,17 @@ import { runPoll } from "./poll.mts";
 
 registerPollHooks();
 
-function withStderrTTY(isTTY: boolean, fn: () => Promise<void>): () => Promise<void> {
+type SpyCalls = { mock: { calls: unknown[][] } };
+
+function withStderrTTY(isTTY: boolean, fn: (spy: SpyCalls) => Promise<void>): () => Promise<void> {
   return async () => {
     const originalDescriptor = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
     Object.defineProperty(process.stderr, "isTTY", { value: isTTY, configurable: true });
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     try {
-      await fn();
+      await fn(spy as unknown as SpyCalls);
     } finally {
+      spy.mockRestore();
       if (originalDescriptor) {
         Object.defineProperty(process.stderr, "isTTY", originalDescriptor);
       } else {
@@ -28,9 +32,7 @@ function withStderrTTY(isTTY: boolean, fn: () => Promise<void>): () => Promise<v
 describe("runPoll — tick progress logging", () => {
   it(
     "writes a dot per WAIT tick to stderr (non-TTY, non-verbose)",
-    withStderrTTY(false, async () => {
-      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-
+    withStderrTTY(false, async (stderrSpy) => {
       mockRunIterate
         .mockResolvedValueOnce(makeWaitResult())
         .mockResolvedValueOnce(makeWaitResult())
@@ -50,15 +52,12 @@ describe("runPoll — tick progress logging", () => {
       expect(written).toContain("..");
       expect(written).toContain("\n");
       expect(written).not.toContain("[poll tick");
-
-      stderrSpy.mockRestore();
     }),
   );
 
   it(
     "writes dots even when stderr is a TTY (non-verbose)",
-    withStderrTTY(true, async () => {
-      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    withStderrTTY(true, async (stderrSpy) => {
       mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
 
       const pollPromise = runPoll({
@@ -74,15 +73,12 @@ describe("runPoll — tick progress logging", () => {
       const written = stderrSpy.mock.calls.map((args) => String(args[0])).join("");
       expect(written).toContain(".");
       expect(written).not.toContain("[poll tick");
-
-      stderrSpy.mockRestore();
     }),
   );
 
   it(
     "writes detailed per-tick line when verbose:true",
-    withStderrTTY(false, async () => {
-      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    withStderrTTY(false, async (stderrSpy) => {
       mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
 
       const pollPromise = runPoll({
@@ -99,14 +95,12 @@ describe("runPoll — tick progress logging", () => {
       expect(stderrSpy.mock.calls.some((args) => String(args[0]).includes("[poll tick"))).toBe(
         true,
       );
-      stderrSpy.mockRestore();
     }),
   );
 
   it(
     "writes trailing newline after dots when loop exits",
-    withStderrTTY(false, async () => {
-      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    withStderrTTY(false, async (stderrSpy) => {
       mockRunIterate.mockResolvedValueOnce(makeWaitResult()).mockResolvedValue(makeCancelResult());
 
       const pollPromise = runPoll({
@@ -121,7 +115,6 @@ describe("runPoll — tick progress logging", () => {
 
       const lastWrite = String(stderrSpy.mock.calls[stderrSpy.mock.calls.length - 1]?.[0] ?? "");
       expect(lastWrite).toBe("\n");
-      stderrSpy.mockRestore();
     }),
   );
 });

--- a/src/github/client.getcurrentprnumber.mock.test.mts
+++ b/src/github/client.getcurrentprnumber.mock.test.mts
@@ -1,60 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockFetch, mockExecFile, gqlOk, registerClientHooks } from "./client.test-support.mts";
 import { getCurrentPrNumber, getPrNumberForBranch } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("getCurrentPrNumber", () => {
   it("returns null when branch is HEAD (detached)", async () => {

--- a/src/github/client.getmergeablestate.mock.test.mts
+++ b/src/github/client.getmergeablestate.mock.test.mts
@@ -1,58 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockFetch, restOk, registerClientHooks } from "./client.test-support.mts";
 import { getMergeableState } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function restOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
-  } as unknown as Response;
-}
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("getMergeableState", () => {
   it("maps REST true/clean to MERGEABLE/CLEAN", async () => {

--- a/src/github/client.getprheadsha.mock.test.mts
+++ b/src/github/client.getprheadsha.mock.test.mts
@@ -1,60 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockFetch, gqlOk, registerClientHooks } from "./client.test-support.mts";
 import { getPrHeadSha } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("getPrHeadSha", () => {
   it("returns headRefOid from GraphQL response", async () => {

--- a/src/github/client.getrepoinfo-remote-url-parsing.mock.test.mts
+++ b/src/github/client.getrepoinfo-remote-url-parsing.mock.test.mts
@@ -1,48 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockExecFile, registerClientHooks } from "./client.test-support.mts";
 import { getRepoInfo } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("getRepoInfo — remote URL parsing", () => {
   it("parses git@github.com:owner/repo.git", async () => {

--- a/src/github/client.graphql-arg-building.mock.test.mts
+++ b/src/github/client.graphql-arg-building.mock.test.mts
@@ -1,60 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockFetch, gqlOk, registerClientHooks } from "./client.test-support.mts";
 import { graphql } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("graphql — arg building", () => {
   it("sends query as JSON body to /graphql", async () => {

--- a/src/github/client.graphql-error-handling.mock.test.mts
+++ b/src/github/client.graphql-error-handling.mock.test.mts
@@ -1,58 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockFetch, gqlErrors, registerClientHooks } from "./client.test-support.mts";
 import { graphql } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function gqlErrors(errors: Array<{ message: string }>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: () => Promise.resolve({ data: null, errors }),
-    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
-  } as unknown as Response;
-}
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("graphql — error handling", () => {
   it("throws when response contains errors[]", async () => {

--- a/src/github/client.graphqlwithratelimit-header-parsing.mock.test.mts
+++ b/src/github/client.graphqlwithratelimit-header-parsing.mock.test.mts
@@ -1,60 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Stub fetch globally so http.mts uses our mock.
-// child_process is still used by client.mts for `git` calls, so mock those too.
-// ---------------------------------------------------------------------------
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
-
-vi.mock("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    optsOrCb:
-      | Record<string, unknown>
-      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
-    mockExecFile(cmd, args)
-      .then((result: { stdout: string; stderr: string }) => cb(null, result))
-      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
-  },
-}));
-
+import { describe, it, expect } from "vitest";
+import { mockFetch, gqlOk, registerClientHooks } from "./client.test-support.mts";
 import { graphqlWithRateLimit } from "./client.mts";
-import { _resetTokenCache } from "./http.mts";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function gqlOk(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({
-      "content-type": "application/json",
-    }),
-    json: () => Promise.resolve({ data }),
-    text: () => Promise.resolve(JSON.stringify({ data })),
-  } as unknown as Response;
-}
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockExecFile.mockReset();
-  _resetTokenCache();
-  process.env["GH_TOKEN"] = "test-token";
-});
-
-// ---------------------------------------------------------------------------
-// graphql — argument building
-// ---------------------------------------------------------------------------
+registerClientHooks();
 
 describe("graphqlWithRateLimit — header parsing", () => {
   it("parses x-ratelimit-* response headers", async () => {

--- a/src/github/client.test-support.mts
+++ b/src/github/client.test-support.mts
@@ -1,4 +1,4 @@
-import { vi, beforeEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 import { _resetTokenCache } from "./http.mts";
 
 export const mockFetch = vi.fn();
@@ -58,6 +58,12 @@ export function registerClientHooks(): void {
     mockFetch.mockReset();
     mockExecFile.mockReset();
     _resetTokenCache();
+    delete process.env["GITHUB_TOKEN"];
+    delete process.env["GITHUB_PERSONAL_ACCESS_TOKEN"];
     process.env["GH_TOKEN"] = "test-token";
+  });
+  afterEach(() => {
+    delete process.env["GH_TOKEN"];
+    _resetTokenCache();
   });
 }

--- a/src/github/client.test-support.mts
+++ b/src/github/client.test-support.mts
@@ -1,0 +1,63 @@
+import { vi, beforeEach } from "vitest";
+import { _resetTokenCache } from "./http.mts";
+
+export const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { _mockExecFile } = vi.hoisted(() => ({ _mockExecFile: vi.fn() }));
+export const mockExecFile = _mockExecFile;
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    optsOrCb:
+      | Record<string, unknown>
+      | ((err: Error | null, result: { stdout: string; stderr: string }) => void),
+    maybeCb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    const cb = typeof optsOrCb === "function" ? optsOrCb : maybeCb!;
+    _mockExecFile(cmd, args)
+      .then((result: { stdout: string; stderr: string }) => cb(null, result))
+      .catch((err: Error) => cb(err, { stdout: "", stderr: "" }));
+  },
+}));
+
+export function gqlOk(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve({ data }),
+    text: () => Promise.resolve(JSON.stringify({ data })),
+  } as unknown as Response;
+}
+
+export function restOk(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as unknown as Response;
+}
+
+export function gqlErrors(errors: Array<{ message: string }>): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve({ data: null, errors }),
+    text: () => Promise.resolve(JSON.stringify({ data: null, errors })),
+  } as unknown as Response;
+}
+
+export function registerClientHooks(): void {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockExecFile.mockReset();
+    _resetTokenCache();
+    process.env["GH_TOKEN"] = "test-token";
+  });
+}

--- a/src/state/seen-comments.markseen-fire-and-forget.test.mts
+++ b/src/state/seen-comments.markseen-fire-and-forget.test.mts
@@ -1,27 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { randomBytes, createHash } from "node:crypto";
-import { rm, writeFile, mkdir, readdir } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
-
-function idToFilename(id: string): string {
-  return createHash("sha256").update(id, "utf8").digest("hex") + ".json";
-}
+import {
+  idToFilename,
+  testKey,
+  testId,
+  testStateDir,
+  registerHooks,
+} from "./seen-comments.test-support.mts";
 import { markSeen } from "./seen-comments.mts";
 
-let testStateDir: string;
-
-const testKey = { owner: "test-owner", repo: "test-repo", pr: 123 };
-const testId = "PRRT_kwDOTest123";
-
-beforeEach(() => {
-  testStateDir = `${process.env["TMPDIR"] ?? "/tmp"}/shepherd-seen-test-${randomBytes(4).toString("hex")}`;
-  process.env["PR_SHEPHERD_STATE_DIR"] = testStateDir;
-});
-
-afterEach(async () => {
-  delete process.env["PR_SHEPHERD_STATE_DIR"];
-  await rm(testStateDir, { recursive: true, force: true });
-});
+registerHooks();
 
 describe("markSeen — fire and forget", () => {
   it("does not throw when the state dir is not writable", async () => {

--- a/src/state/seen-comments.readseenmarker.test.mts
+++ b/src/state/seen-comments.readseenmarker.test.mts
@@ -1,27 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { randomBytes, createHash } from "node:crypto";
-import { rm, writeFile, mkdir } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-
-function idToFilename(id: string): string {
-  return createHash("sha256").update(id, "utf8").digest("hex") + ".json";
-}
+import {
+  idToFilename,
+  testKey,
+  testId,
+  testStateDir,
+  registerHooks,
+} from "./seen-comments.test-support.mts";
 import { markSeen, readSeenMarker } from "./seen-comments.mts";
 
-let testStateDir: string;
-
-const testKey = { owner: "test-owner", repo: "test-repo", pr: 123 };
-const testId = "PRRT_kwDOTest123";
-
-beforeEach(() => {
-  testStateDir = `${process.env["TMPDIR"] ?? "/tmp"}/shepherd-seen-test-${randomBytes(4).toString("hex")}`;
-  process.env["PR_SHEPHERD_STATE_DIR"] = testStateDir;
-});
-
-afterEach(async () => {
-  delete process.env["PR_SHEPHERD_STATE_DIR"];
-  await rm(testStateDir, { recursive: true, force: true });
-});
+registerHooks();
 
 describe("readSeenMarker", () => {
   it("returns null when no file exists", async () => {

--- a/src/state/seen-comments.test-support.mts
+++ b/src/state/seen-comments.test-support.mts
@@ -1,0 +1,24 @@
+import { beforeEach, afterEach } from "vitest";
+import { randomBytes, createHash } from "node:crypto";
+import { rm } from "node:fs/promises";
+
+export function idToFilename(id: string): string {
+  return createHash("sha256").update(id, "utf8").digest("hex") + ".json";
+}
+
+export const testKey = { owner: "test-owner", repo: "test-repo", pr: 123 };
+export const testId = "PRRT_kwDOTest123";
+
+export let testStateDir: string;
+
+export function registerHooks(): void {
+  beforeEach(() => {
+    testStateDir = `${process.env["TMPDIR"] ?? "/tmp"}/shepherd-seen-test-${randomBytes(4).toString("hex")}`;
+    process.env["PR_SHEPHERD_STATE_DIR"] = testStateDir;
+  });
+
+  afterEach(async () => {
+    delete process.env["PR_SHEPHERD_STATE_DIR"];
+    await rm(testStateDir, { recursive: true, force: true });
+  });
+}


### PR DESCRIPTION
## Summary

- Create `src/github/client.test-support.mts` consolidating the identical `vi.mock("node:child_process", ...)` block, response helpers (`gqlOk`, `restOk`, `gqlErrors`), and `beforeEach` setup shared across all 7 github client test files
- Create `src/state/seen-comments.test-support.mts` sharing `idToFilename`, `testKey`, `testId`, and `beforeEach`/`afterEach` hooks between the two seen-comments test files
- Refactor `poll.runpoll-tick-progress.mock.test.mts` with a `withStderrTTY` helper to eliminate the repeated `Object.defineProperty(process.stderr, "isTTY", ...)` boilerplate in each test case

These changes reduce test-code duplication, targeting the SonarCloud quality gate (Duplication on New Code ≤ 3%).

## Test plan

- [x] `npm run build` — no TypeScript errors
- [x] `npx vitest run` — 1062/1062 tests pass
- [x] `npm run format:check` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- [PRRT_kwDOSGizTs6DHMH3](https://github.com/jonathanong/pr-shepherd/pull/236#discussion_r3265429138) (Gemini: restore original GH_TOKEN in afterEach) — Rejected. Our `afterEach` already deletes `GH_TOKEN`, matching the `http.test-support.mts` pattern. Restoring the original value is marginally safer but unnecessary: Vitest runs each test file in an isolated worker where env mutations don't persist across files.
- [PRRT_kwDOSGizTs6DHMH8](https://github.com/jonathanong/pr-shepherd/pull/236#discussion_r3265429145) (Gemini: export getter instead of `let testStateDir`) — Rejected. The mutable export is a live ESM binding but Vitest isolates test files in separate workers, so there is no actual cross-file state sharing. A getter adds noise without any correctness benefit.