### PR TITLE
Add mark-files-as-viewed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42               # single tick
 ```
 
+### Mark files as viewed
+
+Hide already-reviewed files in GitHub's PR diff:
+
+```sh
+pr-shepherd mark-files-as-viewed 42 --tests
+pr-shepherd mark-files-as-viewed 42 src/a.ts --match '^docs/'
+```
+
+The shipped `mark-files-as-viewed` skill maps a standalone `tests` argument to `--tests`, so `/pr-shepherd:mark-files-as-viewed 42 tests` marks changed test files as viewed.
+
 ## Iterate decision loop
 
 On each tick: fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (`fix_code`, `mark_ready`, `cancel`, `escalate`, or `wait`). See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
@@ -168,7 +179,7 @@ This repo ships two `marketplace.json` files that serve different Claude install
 
 ### Codex
 
-Codex uses the repo-shipped Codex plugin rather than the Claude plugin or `/pr-shepherd:*` slash commands. The plugin provides one `pr-shepherd` skill for iterating a PR to completion.
+Codex uses the repo-shipped Codex plugin rather than the Claude plugin or `/pr-shepherd:*` slash commands. The plugin provides skills for iterating a PR to completion and marking PR files as viewed.
 
 Install the Codex plugin marketplace from GitHub:
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -7,6 +7,7 @@ pr-shepherd -v|--version
 pr-shepherd [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd resolve [PR] [--fetch | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
 pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
+pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]
 pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # single tick
 pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
 pr-shepherd log-file
@@ -168,6 +169,20 @@ git push
 ```
 
 If a patch fails to apply (drift since the suggestion was written), apply the fix manually using the line range shown in the output.
+
+### pr-shepherd mark-files-as-viewed [PR] [files...]
+
+Marks changed files as viewed in GitHub's PR diff using GraphQL. Exact path arguments must match files in the PR changed-file list. Selectors expand against the same GitHub PR diff, not local uncommitted changes.
+
+```sh
+pr-shepherd mark-files-as-viewed 42 src/a.ts src/b.test.ts
+pr-shepherd mark-files-as-viewed 42 --tests
+pr-shepherd mark-files-as-viewed 42 --match '^docs/' --match '\\.md$'
+```
+
+`--tests` selects common test file paths such as `tests/`, `__tests__/`, `spec/`, `*.test.ts`, `*.spec.tsx`, `_test.rs`, and `tests.rs`. `--match <regex>` is a repeatable, case-insensitive JavaScript regex over changed-file paths.
+
+Mutation batches are sent in groups of 10. If GitHub returns a primary or secondary rate-limit response, Shepherd stops and reports both completed files and pending files. JSON output exposes the same data as text output: matched paths, marked paths, already-viewed paths, missing exact paths, unmatched selectors, errors, rate-limit details, and pending unmarked paths.
 
 ### pr-shepherd [PR]
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,7 @@ The module supports a focused automation loop for PR monitoring and deterministi
 - Supports `pr-shepherd resolve [PR]` fetch mode (via `--fetch` or when no mutation flags are passed).
 - Supports `pr-shepherd resolve [PR]` mutate mode with `--resolve-thread-ids`, `--minimize-comment-ids`, `--dismiss-review-ids`.
 - Supports `pr-shepherd commit-suggestion [PR] --thread-id <id> --message "<one-sentence headline>"` (or `--description`) for suggestion-thread patch generation.
+- Supports `pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]` for marking PR changed files as viewed in GitHub.
 - Supports `pr-shepherd log-file` to print the per-worktree debug log path.
 - Supports `--version`/`-v`.
 - Supports `--format text|json`, and `--verbose` output mode (iterate only).

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,10 @@
 
 [← README](../README.md)
 
-One skill is shipped for both Claude Code and Codex: `pr-shepherd`. It is a thin poll dispatcher — it runs `pr-shepherd poll <PR>` and follows the `## Instructions` embedded in the output. All policy, state transitions, and per-action guidance live in the CLI output, not in the skill.
+Two skills are shipped for both Claude Code and Codex:
+
+- `pr-shepherd` is a thin poll dispatcher — it runs `pr-shepherd poll <PR>` and follows the `## Instructions` embedded in the output. All policy, state transitions, and per-action guidance live in the CLI output, not in the skill.
+- `mark-files-as-viewed` marks PR changed files as viewed in GitHub by invoking `pr-shepherd mark-files-as-viewed`.
 
 ## Claude Code
 
@@ -19,6 +22,7 @@ Use the skill inside a `/goal`:
 /goal /pr-shepherd:pr-shepherd        # infer PR from current branch
 /goal /pr-shepherd:pr-shepherd 42
 /goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
+/pr-shepherd:mark-files-as-viewed 42 tests
 ```
 
 The goal loop handles recurrence. The skill invokes `pr-shepherd poll <N>` and prints the output. For non-terminal actions, follow the CLI's `## Instructions`, then invoke `pr-shepherd poll <N>` again. `[CANCEL]` and `[ESCALATE]` stop the goal.
@@ -53,6 +57,7 @@ Use the skill inside a `/goal`:
 ```
 /goal $pr-shepherd        # infer PR from current branch
 /goal $pr-shepherd 42
+$mark-files-as-viewed 42 tests
 ```
 
 Codex runs the same skill: invoke `pr-shepherd poll <N>`, follow the output, and continue until `[CANCEL]` or `[ESCALATE]`.
@@ -66,3 +71,14 @@ pr-shepherd resolve <N> --fetch
 ```
 
 Follow the `## Instructions` in the output. The `fix_code` action emits the exact `resolve` command to run after pushing fixes — so a full `pr-shepherd` iterate tick also covers resolve.
+
+## Mark files as viewed
+
+To hide already-reviewed files in GitHub's PR diff:
+
+```bash
+pr-shepherd mark-files-as-viewed <N> --tests
+pr-shepherd mark-files-as-viewed <N> src/a.ts --match '^docs/'
+```
+
+The `mark-files-as-viewed` skill treats a standalone `tests` argument as `--tests`; exact file paths and explicit `--match <regex>` selectors are passed through.

--- a/plugins/pr-shepherd/skills/mark-files-as-viewed/SKILL.md
+++ b/plugins/pr-shepherd/skills/mark-files-as-viewed/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: mark-files-as-viewed
+description: 'Mark PR changed files as viewed in GitHub with pr-shepherd. Use for requests like "mark tests as viewed" or "mark these files as viewed".'
+user-invocable: true
+argument-hint: "[PR number or URL] [files|tests|--tests|--match REGEX]"
+allowed-tools: ["Bash", "Read", "Grep", "Glob"]
+---
+
+# mark-files-as-viewed
+
+Thin dispatcher for marking GitHub PR changed files as viewed.
+
+## Arguments: $ARGUMENTS
+
+## Steps
+
+1. **Resolve arguments:**
+   - If `$ARGUMENTS` contains a PR number, use it.
+   - If `$ARGUMENTS` contains a GitHub PR URL, extract the number.
+   - Otherwise, infer: `gh pr view --json number --jq .number`
+   - Treat a standalone `tests` argument as `--tests`.
+   - Preserve explicit file paths, `--tests`, and `--match <regex>` arguments.
+   - If no PR found, report an error and stop.
+
+2. **Run `pr-shepherd`:**
+
+   ```bash
+   pr-shepherd mark-files-as-viewed <N> <selectors>
+   ```
+
+   Print the full output.

--- a/src/cli-parser.main-help.mock.test.mts
+++ b/src/cli-parser.main-help.mock.test.mts
@@ -18,6 +18,7 @@ describe("main — top-level help", () => {
     expect(out).toContain("pr-shepherd poll");
     expect(out).toContain("pr-shepherd resolve");
     expect(out).toContain("pr-shepherd commit-suggestion");
+    expect(out).toContain("pr-shepherd mark-files-as-viewed");
     expect(out).toContain("pr-shepherd clean <pr|branch|current|repo|all>");
     expect(out).toContain("pr-shepherd log-file");
     expect(out).toContain("pr [number]");

--- a/src/cli-parser.mark-files-as-viewed.mock.test.mts
+++ b/src/cli-parser.mark-files-as-viewed.mock.test.mts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  registerHooks,
+  getStdout,
+  mockRunMarkFilesAsViewed,
+  stderrSpy,
+} from "./cli-parser.test-support.mts";
+import { main } from "./cli-parser.mts";
+
+registerHooks();
+
+const BASE_RESULT = {
+  repo: "owner/repo",
+  prNumber: 42,
+  pullRequestId: "PR_1",
+  requestedPaths: [],
+  testSelector: false,
+  matchPatterns: [],
+  matchedPaths: [],
+  markedPaths: [],
+  alreadyViewedPaths: [],
+  missingPaths: [],
+  unmatchedSelectors: [],
+  errors: [],
+};
+
+describe("main — mark-files-as-viewed", () => {
+  it("passes exact paths and selectors to runMarkFilesAsViewed", async () => {
+    mockRunMarkFilesAsViewed.mockResolvedValue({
+      ...BASE_RESULT,
+      requestedPaths: ["src/a.ts"],
+      testSelector: true,
+      matchPatterns: ["docs"],
+      matchedPaths: ["src/a.ts"],
+      markedPaths: ["src/a.ts"],
+    });
+
+    await main([
+      "node",
+      "shepherd",
+      "mark-files-as-viewed",
+      "42",
+      "src/a.ts",
+      "--tests",
+      "--match",
+      "docs",
+    ]);
+
+    expect(mockRunMarkFilesAsViewed).toHaveBeenCalledWith({
+      format: "text",
+      verbose: false,
+      prNumber: 42,
+      files: ["src/a.ts"],
+      tests: true,
+      matchPatterns: ["docs"],
+    });
+    expect(getStdout()).toContain("Marked viewed (1)");
+  });
+
+  it("emits JSON when requested", async () => {
+    mockRunMarkFilesAsViewed.mockResolvedValue({
+      ...BASE_RESULT,
+      matchedPaths: ["src/a.test.ts"],
+      markedPaths: ["src/a.test.ts"],
+    });
+
+    await main(["node", "shepherd", "mark-files-as-viewed", "42", "--tests", "--format=json"]);
+
+    expect(JSON.parse(getStdout())).toMatchObject({ prNumber: 42, markedPaths: ["src/a.test.ts"] });
+  });
+
+  it("rejects missing selectors", async () => {
+    await main(["node", "shepherd", "mark-files-as-viewed", "42"]);
+
+    expect(mockRunMarkFilesAsViewed).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "pr-shepherd: mark-files-as-viewed: provide at least one file, --tests, or --match <regex>\n",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -10,6 +10,8 @@
  *                            [--dismiss-review-ids Q] [--message MSG] [--require-sha SHA]
  *   pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [--description DESC]
  *                                      [--format text|json]
+ *   pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]
+ *                                           [--format text|json]
  *   pr-shepherd iterate [PR] [--format text|json] [--ready-delay Nm]
  *                              [--stall-timeout <duration>] [--no-auto-mark-ready]
  *                              [--no-auto-cancel-actionable]
@@ -27,7 +29,12 @@ import { parseCommonArgs, getFlag, hasFlag, parseList } from "./cli/args.mts";
 import { isDefaultPollInvocation, validateDefaultPollArgs } from "./cli/default-poll.mts";
 import { USAGE, maybePrintHelp } from "./cli/help.mts";
 import { formatFetchResult, formatMutateResult } from "./cli/formatters.mts";
-import { handleClean, handleCommitSuggestion, handleIterate } from "./cli/handlers.mts";
+import {
+  handleClean,
+  handleCommitSuggestion,
+  handleIterate,
+  handleMarkFilesAsViewed,
+} from "./cli/handlers.mts";
 import { handlePoll } from "./cli/poll-handler.mts";
 import { setupLog } from "./log/setup.mts";
 
@@ -85,6 +92,9 @@ export async function main(argv: string[]): Promise<void> {
       break;
     case "commit-suggestion":
       await handleCommitSuggestion(args.slice(1));
+      break;
+    case "mark-files-as-viewed":
+      await handleMarkFilesAsViewed(args.slice(1));
       break;
     case "iterate":
       await handleIterate(args.slice(1));

--- a/src/cli-parser.subcommand-help.mock.test.mts
+++ b/src/cli-parser.subcommand-help.mock.test.mts
@@ -10,6 +10,7 @@ vi.mock("./commands/resolve.mts", () => ({
   runResolveMutate: vi.fn(),
 }));
 vi.mock("./commands/commit-suggestion.mts", () => ({ runCommitSuggestion: vi.fn() }));
+vi.mock("./commands/mark-files-as-viewed.mts", () => ({ runMarkFilesAsViewed: vi.fn() }));
 vi.mock("./commands/clean.mts", () => ({ runClean: vi.fn() }));
 vi.mock("./commands/log-file.mts", () => ({ runLogFile: vi.fn() }));
 vi.mock("./github/client.mts", () => ({
@@ -48,6 +49,7 @@ afterEach(() => {
 const SUBCOMMANDS = [
   "resolve",
   "commit-suggestion",
+  "mark-files-as-viewed",
   "iterate",
   "poll",
   "clean",
@@ -57,6 +59,7 @@ const SUBCOMMANDS = [
 const HELP_EXPECTATIONS: Record<(typeof SUBCOMMANDS)[number], string[]> = {
   resolve: ["Modes:", "--resolve-thread-ids", "--require-sha", "Exit code:"],
   "commit-suggestion": ["Preconditions:", "--thread-id", "--description", "Exit codes:"],
+  "mark-files-as-viewed": ["Selectors:", "--tests", "--match", "Exit code:"],
   iterate: ["Actions:", "FIX_CODE", "--stall-timeout", "Exit codes:"],
   poll: ["Poll flags:", "--interval", "--timeout", "Forwarded iterate flags:"],
   clean: ["Variants:", "pr [number]", "branch [name]", "--dry-run"],

--- a/src/cli-parser.test-support.mts
+++ b/src/cli-parser.test-support.mts
@@ -12,6 +12,9 @@ vi.mock("./commands/log-file.mts", () => ({
 vi.mock("./commands/commit-suggestion.mts", () => ({
   runCommitSuggestion: vi.fn(),
 }));
+vi.mock("./commands/mark-files-as-viewed.mts", () => ({
+  runMarkFilesAsViewed: vi.fn(),
+}));
 vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
   return { ...actual, runIterate: vi.fn() };
@@ -19,10 +22,12 @@ vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
 import { main } from "./cli-parser.mts";
 import { runLogFile } from "./commands/log-file.mts";
 import { runResolveFetch, runResolveMutate } from "./commands/resolve.mts";
+import { runMarkFilesAsViewed } from "./commands/mark-files-as-viewed.mts";
 
 const mockRunResolveFetch = vi.mocked(runResolveFetch);
 const mockRunResolveMutate = vi.mocked(runResolveMutate);
 const mockRunLogFile = vi.mocked(runLogFile);
+const mockRunMarkFilesAsViewed = vi.mocked(runMarkFilesAsViewed);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let stdoutSpy: any;
@@ -50,6 +55,7 @@ export {
   getStdout,
   main,
   mockRunLogFile,
+  mockRunMarkFilesAsViewed,
   mockRunResolveFetch,
   mockRunResolveMutate,
   readFileSync,

--- a/src/cli/args.mts
+++ b/src/cli/args.mts
@@ -20,6 +20,7 @@ const FLAGS_WITH_VALUES = new Set([
   "--dismiss-review-ids",
   "--interval",
   "--timeout",
+  "--match",
 ]);
 
 // Boolean flags that do NOT consume the next argument. Any --flag not in this

--- a/src/cli/args.parsecommonargs-pr-number-detection.test.mts
+++ b/src/cli/args.parsecommonargs-pr-number-detection.test.mts
@@ -21,6 +21,12 @@ describe("parseCommonArgs — PR number detection", () => {
     expect(prNumber).toBe(42);
   });
 
+  it("does not make subcommand-only --tests a global boolean flag", () => {
+    const { prNumber, extra } = parseCommonArgs(["--tests", "123", "--fetch"]);
+    expect(prNumber).toBeUndefined();
+    expect(extra).toEqual(["--tests", "123", "--fetch"]);
+  });
+
   it("does not skip past argv when a known value flag is missing its value", () => {
     const { prNumber, extra } = parseCommonArgs(["--message"]);
     expect(prNumber).toBeUndefined();

--- a/src/cli/formatters.mts
+++ b/src/cli/formatters.mts
@@ -1,6 +1,7 @@
 export { formatIterateResult } from "./iterate-formatter.mts";
 export { projectIterateLean, projectIterateVerbose } from "./iterate-lean.mts";
 export { formatCleanResult } from "./clean-formatter.mts";
+export { formatMarkFilesAsViewedResult } from "./mark-files-as-viewed-formatter.mts";
 
 import { safeFence } from "./fence.mts";
 import {
@@ -126,12 +127,7 @@ export function formatCommitSuggestionResult(result: CommitSuggestionResult): st
     lines.push(fence);
   }
 
-  lines.push("");
-  lines.push("## Suggested commit message");
-  lines.push("");
-  lines.push(result.commitMessage);
-  lines.push("");
-  lines.push(result.commitBody);
+  lines.push("", "## Suggested commit message", "", result.commitMessage, "", result.commitBody);
 
   if (result.postActionInstructions.length > 0) {
     lines.push("");

--- a/src/cli/handlers.mts
+++ b/src/cli/handlers.mts
@@ -1,12 +1,18 @@
 import { runCommitSuggestion } from "../commands/commit-suggestion.mts";
+import { runMarkFilesAsViewed } from "../commands/mark-files-as-viewed.mts";
 import { runIterate } from "../commands/iterate/index.mts";
 import { runClean, type CleanVariant } from "../commands/clean.mts";
 import { loadConfig } from "../config/load.mts";
 import { parseCommonArgs, getFlag } from "./args.mts";
 import { USAGE } from "./help.mts";
-import { formatCommitSuggestionResult, formatCleanResult } from "./formatters.mts";
+import {
+  formatCommitSuggestionResult,
+  formatCleanResult,
+  formatMarkFilesAsViewedResult,
+} from "./formatters.mts";
 import { parseIterateFlags } from "./iterate-flags.mts";
 import { emitIterateResult } from "./iterate-emitter.mts";
+import { parseMarkFilesAsViewedArgs } from "./mark-files-as-viewed-flags.mts";
 
 const CLEAN_VARIANTS = new Set<string>(["pr", "branch", "current", "repo", "all"]);
 
@@ -132,4 +138,28 @@ export async function handleIterate(args: string[]): Promise<void> {
     verbose: globalOpts.verbose ?? false,
     readyDelaySuffix: flags.readyDelaySuffix ?? undefined,
   });
+}
+
+export async function handleMarkFilesAsViewed(args: string[]): Promise<void> {
+  const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);
+  const parsed = parseMarkFilesAsViewedArgs(extra);
+  if (!parsed.ok) {
+    process.stderr.write(`pr-shepherd: mark-files-as-viewed: ${parsed.error}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await runMarkFilesAsViewed({
+    ...globalOpts,
+    prNumber,
+    files: parsed.files,
+    tests: parsed.tests,
+    matchPatterns: parsed.matchPatterns,
+  });
+
+  process.stdout.write(
+    globalOpts.format === "json"
+      ? `${JSON.stringify(result, null, 2)}\n`
+      : `${formatMarkFilesAsViewedResult(result)}\n`,
+  );
 }

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -51,6 +51,27 @@ Exit codes:
   0  suggestion patch and instructions produced
   1  validation, lookup, precondition, or suggestion parsing failure`,
 
+  "mark-files-as-viewed": `pr-shepherd mark-files-as-viewed
+
+Mark changed files as viewed in the GitHub pull request diff.
+
+Usage:
+  pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]
+                                      [--format text|json]
+
+Selectors:
+  files...          Exact changed-file paths from the PR diff.
+  --tests           Select changed test files.
+  --match <regex>   Select changed files whose paths match a case-insensitive JavaScript regex.
+                    May be repeated.
+
+Flags:
+  --format text|json  Output format. Default: text.
+  --help, -h          Print this help and exit before GitHub I/O.
+
+PR may be a number or GitHub pull request URL. When omitted, the current branch PR is inferred.
+Exit code: 0 on success; 1 on validation or lookup failure.`,
+
   iterate: `pr-shepherd iterate
 
 Run one iterate tick for a pull request. The no-subcommand form polls; use this subcommand for a single tick.

--- a/src/cli/help-top-page.mts
+++ b/src/cli/help-top-page.mts
@@ -10,6 +10,7 @@ Usage:
   pr-shepherd poll [PR] [poll-flags] [iterate-flags]
   pr-shepherd resolve [PR] [resolve-flags]
   pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [flags]
+  pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]
   pr-shepherd clean <pr|branch|current|repo|all> [value] [flags]
   pr-shepherd log-file [--format text|json]
 
@@ -19,6 +20,7 @@ Commands:
   poll                 Re-run iterate while the action is WAIT, then print the final tick.
   resolve              Fetch actionable review items, or resolve/minimize/dismiss IDs.
   commit-suggestion    Convert one GitHub suggestion thread into a patch and commit instructions.
+  mark-files-as-viewed Mark PR changed files as viewed in GitHub.
   clean                Remove pr-shepherd state files.
   log-file             Print the per-worktree debug log path.
 

--- a/src/cli/mark-files-as-viewed-flags.mts
+++ b/src/cli/mark-files-as-viewed-flags.mts
@@ -1,0 +1,39 @@
+import { hasFlag } from "./args.mts";
+
+export type ParseMarkFilesAsViewedResult =
+  | { ok: true; files: string[]; tests: boolean; matchPatterns: string[] }
+  | { ok: false; error: string };
+
+export function parseMarkFilesAsViewedArgs(args: string[]): ParseMarkFilesAsViewedResult {
+  const files: string[] = [];
+  const matchPatterns: string[] = [];
+  const tests = hasFlag(args, "--tests");
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--tests") continue;
+    if (arg === "--match") {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        return { ok: false, error: "--match requires a regex value" };
+      }
+      matchPatterns.push(value);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--match=")) {
+      const value = arg.slice("--match=".length);
+      if (value === "") return { ok: false, error: "--match requires a regex value" };
+      matchPatterns.push(value);
+      continue;
+    }
+    if (arg.startsWith("--")) return { ok: false, error: `unknown flag: "${arg}"` };
+    files.push(arg);
+  }
+
+  if (files.length === 0 && !tests && matchPatterns.length === 0) {
+    return { ok: false, error: "provide at least one file, --tests, or --match <regex>" };
+  }
+
+  return { ok: true, files, tests, matchPatterns };
+}

--- a/src/cli/mark-files-as-viewed-flags.test.mts
+++ b/src/cli/mark-files-as-viewed-flags.test.mts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseMarkFilesAsViewedArgs } from "./mark-files-as-viewed-flags.mts";
+
+describe("parseMarkFilesAsViewedArgs", () => {
+  it("parses paths, tests, and repeated match patterns", () => {
+    expect(
+      parseMarkFilesAsViewedArgs(["src/a.ts", "--tests", "--match", "^docs/", "--match=\\.md$"]),
+    ).toEqual({
+      ok: true,
+      files: ["src/a.ts"],
+      tests: true,
+      matchPatterns: ["^docs/", "\\.md$"],
+    });
+  });
+
+  it("rejects missing --match values", () => {
+    expect(parseMarkFilesAsViewedArgs(["--match"])).toEqual({
+      ok: false,
+      error: "--match requires a regex value",
+    });
+    expect(parseMarkFilesAsViewedArgs(["--match", "--tests"])).toEqual({
+      ok: false,
+      error: "--match requires a regex value",
+    });
+  });
+
+  it("rejects empty inline match and unknown flags", () => {
+    expect(parseMarkFilesAsViewedArgs(["--match="])).toEqual({
+      ok: false,
+      error: "--match requires a regex value",
+    });
+    expect(parseMarkFilesAsViewedArgs(["--glob", "src"])).toEqual({
+      ok: false,
+      error: 'unknown flag: "--glob"',
+    });
+  });
+
+  it("requires at least one selector", () => {
+    expect(parseMarkFilesAsViewedArgs([])).toEqual({
+      ok: false,
+      error: "provide at least one file, --tests, or --match <regex>",
+    });
+  });
+});

--- a/src/cli/mark-files-as-viewed-formatter.mts
+++ b/src/cli/mark-files-as-viewed-formatter.mts
@@ -1,0 +1,64 @@
+import type { MarkFilesAsViewedResult } from "../commands/mark-files-as-viewed.mts";
+
+export function formatMarkFilesAsViewedResult(result: MarkFilesAsViewedResult): string {
+  const lines: string[] = [];
+  lines.push(
+    `# PR #${result.prNumber} — Mark files as viewed (${result.markedPaths.length} marked)`,
+  );
+  lines.push("");
+  lines.push(`repo: ${result.repo}`);
+
+  appendPathSection(lines, "Matched files", result.matchedPaths);
+  appendPathSection(lines, "Marked viewed", result.markedPaths);
+  appendPathSection(lines, "Already viewed", result.alreadyViewedPaths);
+  appendPathSection(lines, "Missing from PR diff", result.missingPaths);
+  appendTextSection(lines, "Unmatched selectors", result.unmatchedSelectors);
+
+  if (result.rateLimit) {
+    const details = [
+      result.rateLimit.retryAfterSeconds !== undefined
+        ? `retry after ${result.rateLimit.retryAfterSeconds}s`
+        : null,
+      result.rateLimit.remaining !== undefined && result.rateLimit.limit !== undefined
+        ? `remaining ${result.rateLimit.remaining}/${result.rateLimit.limit}`
+        : null,
+      result.rateLimit.resetAt !== undefined
+        ? `reset at ${new Date(result.rateLimit.resetAt * 1000).toISOString()}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    lines.push("");
+    lines.push(
+      `Stopped: GitHub rate limit hit — ${result.rateLimit.message}${details ? ` (${details})` : ""}`,
+    );
+  }
+
+  appendPathSection(lines, "Not marked due to rate limit", result.unmarkedPaths ?? []);
+
+  const errors = result.rateLimit
+    ? result.errors.filter((e) => !e.startsWith("rate limit:"))
+    : result.errors;
+  appendTextSection(lines, "Errors", errors);
+
+  if (result.matchedPaths.length === 0) {
+    lines.push("");
+    lines.push("No files matched.");
+  }
+
+  return lines.join("\n");
+}
+
+function appendPathSection(lines: string[], label: string, paths: string[]): void {
+  if (paths.length === 0) return;
+  lines.push("");
+  lines.push(`## ${label} (${paths.length})`);
+  lines.push(paths.map((path) => `- \`${path}\``).join("\n"));
+}
+
+function appendTextSection(lines: string[], label: string, values: string[]): void {
+  if (values.length === 0) return;
+  lines.push("");
+  lines.push(`## ${label} (${values.length})`);
+  lines.push(values.map((value) => `- ${value}`).join("\n"));
+}

--- a/src/cli/mark-files-as-viewed-formatter.test.mts
+++ b/src/cli/mark-files-as-viewed-formatter.test.mts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { formatMarkFilesAsViewedResult } from "./mark-files-as-viewed-formatter.mts";
+import type { MarkFilesAsViewedResult } from "../commands/mark-files-as-viewed.mts";
+
+describe("formatMarkFilesAsViewedResult", () => {
+  it("renders all populated sections and filters rate-limit errors", () => {
+    const out = formatMarkFilesAsViewedResult({
+      ...baseResult(),
+      matchedPaths: ["src/a.ts", "tests/a.test.ts"],
+      markedPaths: ["src/a.ts"],
+      alreadyViewedPaths: ["tests/a.test.ts"],
+      missingPaths: ["src/missing.ts"],
+      unmatchedSelectors: ["--match docs"],
+      errors: ["rate limit: API rate limit exceeded", "src/b.ts: mark returned null"],
+      rateLimit: {
+        message: "API rate limit exceeded",
+        retryAfterSeconds: 60,
+        remaining: 0,
+        limit: 5000,
+        resetAt: 1700000000,
+      },
+      unmarkedPaths: ["src/b.ts"],
+    });
+
+    expect(out).toContain("# PR #42 — Mark files as viewed (1 marked)");
+    expect(out).toContain("## Matched files (2)");
+    expect(out).toContain("## Marked viewed (1)");
+    expect(out).toContain("## Already viewed (1)");
+    expect(out).toContain("## Missing from PR diff (1)");
+    expect(out).toContain("## Unmatched selectors (1)");
+    expect(out).toContain("Stopped: GitHub rate limit hit");
+    expect(out).toContain("retry after 60s");
+    expect(out).toContain("remaining 0/5000");
+    expect(out).toContain("reset at 2023-11-14T22:13:20.000Z");
+    expect(out).toContain("## Not marked due to rate limit (1)");
+    expect(out).toContain("## Errors (1)");
+    expect(out).toContain("src/b.ts: mark returned null");
+    expect(out).not.toContain("rate limit: API rate limit exceeded");
+  });
+
+  it("renders a no-match message and non-rate-limit errors", () => {
+    const out = formatMarkFilesAsViewedResult({
+      ...baseResult(),
+      errors: ["src/a.ts: server unavailable"],
+    });
+
+    expect(out).toContain("No files matched.");
+    expect(out).toContain("## Errors (1)");
+    expect(out).toContain("src/a.ts: server unavailable");
+  });
+});
+
+function baseResult(): MarkFilesAsViewedResult {
+  return {
+    repo: "owner/repo",
+    prNumber: 42,
+    pullRequestId: "PR_1",
+    requestedPaths: [],
+    testSelector: false,
+    matchPatterns: [],
+    matchedPaths: [],
+    markedPaths: [],
+    alreadyViewedPaths: [],
+    missingPaths: [],
+    unmatchedSelectors: [],
+    errors: [],
+  };
+}

--- a/src/commands/mark-files-as-viewed.mock.test.mts
+++ b/src/commands/mark-files-as-viewed.mock.test.mts
@@ -1,0 +1,302 @@
+/* eslint-disable max-lines */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetRepoInfo, mockGetCurrentPrNumber, mockGraphql, mockGraphqlWithRateLimit } =
+  vi.hoisted(() => ({
+    mockGetRepoInfo: vi.fn(),
+    mockGetCurrentPrNumber: vi.fn(),
+    mockGraphql: vi.fn(),
+    mockGraphqlWithRateLimit: vi.fn(),
+  }));
+
+vi.mock("../github/client.mts", () => ({
+  getRepoInfo: mockGetRepoInfo,
+  getCurrentPrNumber: mockGetCurrentPrNumber,
+  graphql: mockGraphql,
+  graphqlWithRateLimit: mockGraphqlWithRateLimit,
+}));
+
+import { runMarkFilesAsViewed } from "./mark-files-as-viewed.mts";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetRepoInfo.mockResolvedValue({ owner: "owner", name: "repo" });
+  mockGetCurrentPrNumber.mockResolvedValue(42);
+  mockGraphql.mockResolvedValue(filesResponse(["src/a.ts"]));
+  mockGraphqlWithRateLimit.mockImplementation(async (doc: string) => markResponse(doc));
+});
+
+describe("runMarkFilesAsViewed", () => {
+  it("marks exact changed paths and reports missing paths", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["src/a.ts", "src/b.ts"]));
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["src/a.ts", "src/missing.ts"],
+    });
+
+    expect(result.markedPaths).toEqual(["src/a.ts"]);
+    expect(result.missingPaths).toEqual(["src/missing.ts"]);
+    expect(mockGraphqlWithRateLimit).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlWithRateLimit.mock.calls[0]?.[0]).toContain("markFileAsViewed");
+  });
+
+  it("selects tests and skips already viewed files", async () => {
+    mockGraphql.mockResolvedValueOnce(
+      filesResponse([
+        { path: "src/a.test.ts", viewerViewedState: "UNVIEWED" },
+        { path: "tests/b.rs", viewerViewedState: "VIEWED" },
+        { path: "tests.rs", viewerViewedState: "UNVIEWED" },
+        { path: "test.rs", viewerViewedState: "UNVIEWED" },
+        { path: "src/main.ts", viewerViewedState: "UNVIEWED" },
+      ]),
+    );
+
+    const result = await runMarkFilesAsViewed({ format: "text", files: [], tests: true });
+
+    expect(result.matchedPaths).toEqual(["src/a.test.ts", "tests/b.rs", "tests.rs", "test.rs"]);
+    expect(result.markedPaths).toEqual(["src/a.test.ts", "tests.rs", "test.rs"]);
+    expect(result.alreadyViewedPaths).toEqual(["tests/b.rs"]);
+  });
+
+  it("does not report selectors unmatched when they match already-selected files", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["tests/a.test.ts"]));
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["tests/a.test.ts"],
+      tests: true,
+      matchPatterns: ["a\\.test"],
+    });
+
+    expect(result.matchedPaths).toEqual(["tests/a.test.ts"]);
+    expect(result.unmatchedSelectors).toEqual([]);
+    expect(result.markedPaths).toEqual(["tests/a.test.ts"]);
+  });
+
+  it("reports unmatched selectors when tests and match patterns select nothing new", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["src/main.ts"]));
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: [],
+      tests: true,
+      matchPatterns: ["docs"],
+    });
+
+    expect(result.matchedPaths).toEqual([]);
+    expect(result.unmatchedSelectors).toEqual(["--tests", "--match docs"]);
+    expect(mockGraphqlWithRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("supports repeated --match patterns", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["docs/a.md", "src/foo.ts", "src/bar.ts"]));
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: [],
+      matchPatterns: ["^docs/", "bar"],
+    });
+
+    expect(result.matchedPaths).toEqual(["docs/a.md", "src/bar.ts"]);
+    expect(result.markedPaths).toEqual(["docs/a.md", "src/bar.ts"]);
+  });
+
+  it("paginates changed files", async () => {
+    mockGraphql
+      .mockResolvedValueOnce(
+        filesResponse(["src/a.ts"], { hasNextPage: true, endCursor: "cursor-1" }),
+      )
+      .mockResolvedValueOnce(filesResponse(["src/b.ts"]));
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["src/a.ts", "src/b.ts"],
+    });
+
+    expect(result.markedPaths).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(mockGraphql).toHaveBeenCalledTimes(2);
+    expect(mockGraphql.mock.calls[1]?.[1]).toMatchObject({ filesCursor: "cursor-1" });
+  });
+
+  it("batches mutations in chunks of 10", async () => {
+    const paths = Array.from({ length: 12 }, (_, i) => `src/${i}.ts`);
+    mockGraphql.mockResolvedValueOnce(filesResponse(paths));
+
+    const result = await runMarkFilesAsViewed({ format: "text", files: paths });
+
+    expect(result.markedPaths).toEqual(paths);
+    expect(mockGraphqlWithRateLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports rate-limited pending paths", async () => {
+    const paths = Array.from({ length: 12 }, (_, i) => `src/${i}.ts`);
+    mockGraphql.mockResolvedValueOnce(filesResponse(paths));
+    mockGraphqlWithRateLimit.mockResolvedValueOnce({
+      ...markResponse("  m0:\n  m1:\n  m2:\n  m3:\n  m4:\n  m5:\n  m6:\n  m7:\n  m8:\n  m9:"),
+      rateLimit: { remaining: 0, limit: 5000, resetAt: 1700000000 },
+    });
+
+    const result = await runMarkFilesAsViewed({ format: "text", files: paths });
+
+    expect(result.markedPaths).toEqual(paths.slice(0, 10));
+    expect(result.unmarkedPaths).toEqual(paths.slice(10));
+    expect(result.rateLimit?.message).toContain("remaining is 0");
+    expect(mockGraphqlWithRateLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports thrown non-rate-limit mutation errors per path", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["src/a.ts", "src/b.ts"]));
+    mockGraphqlWithRateLimit.mockRejectedValueOnce(new Error("server unavailable"));
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["src/a.ts", "src/b.ts"],
+    });
+
+    expect(result.markedPaths).toEqual([]);
+    expect(result.errors).toEqual(["src/a.ts: server unavailable", "src/b.ts: server unavailable"]);
+  });
+
+  it("stops on thrown rate limits and reports all pending paths", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["src/a.ts", "src/b.ts"]));
+    mockGraphqlWithRateLimit.mockRejectedValueOnce(
+      Object.assign(new Error("API rate limit exceeded"), {
+        status: 403,
+        retryAfterSeconds: 60,
+      }),
+    );
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["src/a.ts", "src/b.ts"],
+    });
+
+    expect(result.rateLimit).toMatchObject({
+      message: "API rate limit exceeded",
+      retryAfterSeconds: 60,
+    });
+    expect(result.unmarkedPaths).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(result.errors).toEqual(["rate limit: API rate limit exceeded"]);
+  });
+
+  it("records alias failures from GraphQL errors", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["src/a.ts", "src/b.ts"]));
+    mockGraphqlWithRateLimit.mockResolvedValueOnce({
+      data: {
+        m0: { pullRequest: { id: "PR_1" } },
+        m1: null,
+      },
+      errors: [
+        { message: "path is not in this pull request", path: ["m1", "markFileAsViewed"] },
+        { message: "unmapped warning" },
+      ],
+    });
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["src/a.ts", "src/b.ts"],
+    });
+
+    expect(result.markedPaths).toEqual(["src/a.ts"]);
+    expect(result.errors).toEqual(["src/b.ts: path is not in this pull request"]);
+  });
+
+  it("suppresses current-chunk null errors when GraphQL reports a rate-limit error", async () => {
+    mockGraphql.mockResolvedValueOnce(filesResponse(["src/a.ts", "src/b.ts"]));
+    mockGraphqlWithRateLimit.mockResolvedValueOnce({
+      data: {
+        m0: { pullRequest: { id: "PR_1" } },
+        m1: null,
+      },
+      errors: [{ message: "You have exceeded a secondary rate limit" }],
+      rateLimit: { remaining: 10, limit: 5000, resetAt: 1700000000 },
+    });
+
+    const result = await runMarkFilesAsViewed({
+      format: "text",
+      files: ["src/a.ts", "src/b.ts"],
+    });
+
+    expect(result.markedPaths).toEqual(["src/a.ts"]);
+    expect(result.errors).toEqual(["rate limit: You have exceeded a secondary rate limit"]);
+    expect(result.unmarkedPaths).toEqual(["src/b.ts"]);
+  });
+
+  it("errors when no PR number can be resolved", async () => {
+    mockGetCurrentPrNumber.mockResolvedValueOnce(null);
+
+    await expect(runMarkFilesAsViewed({ format: "text", files: ["src/a.ts"] })).rejects.toThrow(
+      "No PR number provided",
+    );
+  });
+
+  it("errors when the PR is not found", async () => {
+    mockGraphql.mockResolvedValueOnce({ data: { repository: { pullRequest: null } } });
+
+    await expect(runMarkFilesAsViewed({ format: "text", files: ["src/a.ts"] })).rejects.toThrow(
+      "PR #42 not found",
+    );
+  });
+
+  it("errors when the PR disappears while paginating files", async () => {
+    mockGraphql
+      .mockResolvedValueOnce(
+        filesResponse(["src/a.ts"], { hasNextPage: true, endCursor: "cursor-1" }),
+      )
+      .mockResolvedValueOnce({ data: { repository: { pullRequest: null } } });
+
+    await expect(runMarkFilesAsViewed({ format: "text", files: ["src/a.ts"] })).rejects.toThrow(
+      "PR #42 not found",
+    );
+  });
+
+  it("rejects invalid match regexes", async () => {
+    await expect(
+      runMarkFilesAsViewed({ format: "text", files: [], matchPatterns: ["["] }),
+    ).rejects.toThrow(/Invalid --match regex/);
+  });
+});
+
+function filesResponse(
+  files: Array<string | { path: string; viewerViewedState?: string | null }>,
+  pageInfo: { hasNextPage?: boolean; endCursor?: string | null } = {},
+) {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          id: "PR_1",
+          number: 42,
+          files: {
+            pageInfo: { hasNextPage: false, endCursor: null, ...pageInfo },
+            nodes: files.map((file) =>
+              typeof file === "string"
+                ? { path: file, viewerViewedState: "UNVIEWED" }
+                : { viewerViewedState: "UNVIEWED", ...file },
+            ),
+          },
+        },
+      },
+    },
+  };
+}
+
+function markResponse(doc: string) {
+  const data: Record<string, unknown> = {};
+  for (const line of doc.split("\n")) {
+    const alias = line.trim().split(":", 1)[0] ?? "";
+    if (!isMarkAlias(alias)) continue;
+    data[alias] = { pullRequest: { id: "PR_1" } };
+  }
+  return { data };
+}
+
+function isMarkAlias(value: string): boolean {
+  if (!value.startsWith("m")) return false;
+  if (value.length === 1) return false;
+  for (const char of value.slice(1)) {
+    if (char < "0" || char > "9") return false;
+  }
+  return true;
+}

--- a/src/commands/mark-files-as-viewed.mts
+++ b/src/commands/mark-files-as-viewed.mts
@@ -1,0 +1,326 @@
+/* eslint-disable max-lines */
+import {
+  graphql,
+  graphqlWithRateLimit,
+  getCurrentPrNumber,
+  getRepoInfo,
+} from "../github/client.mts";
+import { paginateForward, type Connection } from "../github/pagination.mts";
+import type { RepoInfo } from "../github/client.mts";
+import {
+  isRateLimitMessage,
+  rateLimitFromError,
+  rateLimitFromGraphQlResult,
+  type ResolveRateLimitStop,
+} from "../comments/rate-limit.mts";
+import type { GlobalOptions } from "../types.mts";
+
+export interface MarkFilesAsViewedOptions extends GlobalOptions {
+  prNumber?: number;
+  files: string[];
+  tests?: boolean;
+  matchPatterns?: string[];
+}
+
+export interface ChangedFile {
+  path: string;
+  viewerViewedState?: string | null;
+}
+
+export interface MarkFilesAsViewedResult {
+  repo: string;
+  prNumber: number;
+  pullRequestId: string;
+  requestedPaths: string[];
+  testSelector: boolean;
+  matchPatterns: string[];
+  matchedPaths: string[];
+  markedPaths: string[];
+  alreadyViewedPaths: string[];
+  missingPaths: string[];
+  unmatchedSelectors: string[];
+  errors: string[];
+  rateLimit?: ResolveRateLimitStop;
+  unmarkedPaths?: string[];
+}
+
+interface PullRequestFilesResponse {
+  repository: {
+    pullRequest: {
+      id: string;
+      number: number;
+      files: Connection<ChangedFile>;
+    } | null;
+  } | null;
+}
+
+interface GraphQlErrorLike {
+  message: string;
+  path?: unknown;
+}
+
+const FILES_QUERY = `query PullRequestFiles($owner: String!, $repo: String!, $pr: Int!, $filesCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      id
+      number
+      files(first: 100, after: $filesCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          path
+          viewerViewedState
+        }
+      }
+    }
+  }
+}`;
+
+const TEST_FILE_RE =
+  /(^|\/)(tests?|__tests__|spec)(\/|$)|\.(test|spec)\.[cm]?[jt]sx?$|_tests?\.rs$|(^|\/)tests?\.rs$/i;
+
+const BULK_CHUNK_SIZE = 10;
+
+export async function runMarkFilesAsViewed(
+  opts: MarkFilesAsViewedOptions,
+): Promise<MarkFilesAsViewedResult> {
+  const repo = await getRepoInfo();
+  const prNumber = opts.prNumber ?? (await getCurrentPrNumber());
+  if (!prNumber) throw new Error("No PR number provided and no current branch PR found");
+
+  const matchPatterns = opts.matchPatterns ?? [];
+  const matchRegexes = matchPatterns.map((pattern) => compilePattern(pattern));
+  const fetched = await fetchPullRequestFiles(prNumber, repo);
+  const selected = selectChangedFiles(fetched.files, {
+    files: opts.files,
+    tests: opts.tests === true,
+    matchPatterns,
+    matchRegexes,
+  });
+
+  const result: MarkFilesAsViewedResult = {
+    repo: `${repo.owner}/${repo.name}`,
+    prNumber,
+    pullRequestId: fetched.pullRequestId,
+    requestedPaths: opts.files,
+    testSelector: opts.tests === true,
+    matchPatterns,
+    matchedPaths: selected.matchedPaths,
+    markedPaths: [],
+    alreadyViewedPaths: selected.alreadyViewedPaths,
+    missingPaths: selected.missingPaths,
+    unmatchedSelectors: selected.unmatchedSelectors,
+    errors: [],
+  };
+
+  await bulkMarkFilesAsViewed(fetched.pullRequestId, selected.pathsToMark, result);
+  return result;
+}
+
+async function fetchPullRequestFiles(
+  pr: number,
+  repo: RepoInfo,
+): Promise<{ pullRequestId: string; files: ChangedFile[] }> {
+  const first = await graphql<PullRequestFilesResponse>(FILES_QUERY, {
+    owner: repo.owner,
+    repo: repo.name,
+    pr,
+  });
+  const raw = first.data.repository?.pullRequest;
+  if (!raw) throw new Error(`PR #${pr} not found`);
+
+  let files = raw.files.nodes;
+  if (raw.files.pageInfo.hasNextPage && raw.files.pageInfo.endCursor) {
+    const extra = await paginateForward<ChangedFile>(async (cursor) => {
+      const res = await graphql<PullRequestFilesResponse>(FILES_QUERY, {
+        owner: repo.owner,
+        repo: repo.name,
+        pr,
+        ...(cursor ? { filesCursor: cursor } : {}),
+      });
+      const pr2 = res.data.repository?.pullRequest;
+      if (!pr2) throw new Error(`PR #${pr} not found`);
+      return pr2.files;
+    }, raw.files.pageInfo.endCursor);
+    files = [...files, ...extra];
+  }
+
+  return { pullRequestId: raw.id, files };
+}
+
+function compilePattern(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern, "i");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Invalid --match regex ${JSON.stringify(pattern)}: ${msg}`);
+  }
+}
+
+function selectChangedFiles(
+  changedFiles: ChangedFile[],
+  opts: {
+    files: string[];
+    tests: boolean;
+    matchPatterns: string[];
+    matchRegexes: RegExp[];
+  },
+): {
+  matchedPaths: string[];
+  alreadyViewedPaths: string[];
+  missingPaths: string[];
+  unmatchedSelectors: string[];
+  pathsToMark: string[];
+} {
+  const byPath = new Map(changedFiles.map((f) => [f.path, f]));
+  const matched = new Set<string>();
+  const missingPaths: string[] = [];
+  const unmatchedSelectors: string[] = [];
+
+  for (const path of opts.files) {
+    if (byPath.has(path)) matched.add(path);
+    else missingPaths.push(path);
+  }
+
+  if (opts.tests) {
+    let matchedAny = false;
+    for (const file of changedFiles) {
+      if (TEST_FILE_RE.test(file.path)) {
+        matched.add(file.path);
+        matchedAny = true;
+      }
+    }
+    if (!matchedAny) unmatchedSelectors.push("--tests");
+  }
+
+  for (let i = 0; i < opts.matchRegexes.length; i += 1) {
+    let matchedAny = false;
+    const regex = opts.matchRegexes[i]!;
+    for (const file of changedFiles) {
+      if (regex.test(file.path)) {
+        matched.add(file.path);
+        matchedAny = true;
+      }
+    }
+    if (!matchedAny) unmatchedSelectors.push(`--match ${opts.matchPatterns[i]!}`);
+  }
+
+  const matchedPaths = [...matched];
+  const alreadyViewedPaths = matchedPaths.filter(
+    (path) => byPath.get(path)?.viewerViewedState === "VIEWED",
+  );
+  const alreadyViewedSet = new Set(alreadyViewedPaths);
+  const pathsToMark = matchedPaths.filter((path) => !alreadyViewedSet.has(path));
+
+  return { matchedPaths, alreadyViewedPaths, missingPaths, unmatchedSelectors, pathsToMark };
+}
+
+function buildBulkMutation(paths: string[]): string {
+  const ops = paths.map(
+    (path, i) =>
+      `  m${i}: markFileAsViewed(input: { pullRequestId: $pullRequestId, path: ${JSON.stringify(path)} }) { pullRequest { id } }`,
+  );
+  return `mutation BulkMarkFilesAsViewed($pullRequestId: ID!) {\n${ops.join("\n")}\n}`;
+}
+
+async function bulkMarkFilesAsViewed(
+  pullRequestId: string,
+  paths: string[],
+  result: MarkFilesAsViewedResult,
+): Promise<void> {
+  for (let i = 0; i < paths.length; i += BULK_CHUNK_SIZE) {
+    const chunk = paths.slice(i, i + BULK_CHUNK_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const stopped = await bulkMarkFilesAsViewedChunk(
+      pullRequestId,
+      chunk,
+      result,
+      i + BULK_CHUNK_SIZE < paths.length,
+    );
+    if (stopped) {
+      const markedSet = new Set(result.markedPaths);
+      result.unmarkedPaths = paths.slice(i).filter((path) => !markedSet.has(path));
+      return;
+    }
+  }
+}
+
+async function bulkMarkFilesAsViewedChunk(
+  pullRequestId: string,
+  paths: string[],
+  result: MarkFilesAsViewedResult,
+  hasPendingAfter: boolean,
+): Promise<boolean> {
+  if (paths.length === 0) return false;
+
+  let data: Record<string, unknown> = {};
+  let graphQlErrors: GraphQlErrorLike[] = [];
+  let suppressCurrentChunkErrors = false;
+  let rateLimitStop: ResolveRateLimitStop | undefined;
+  try {
+    const resp = await graphqlWithRateLimit<Record<string, unknown>>(buildBulkMutation(paths), {
+      pullRequestId,
+    });
+    data = resp.data;
+    graphQlErrors = (resp.errors ?? []) as GraphQlErrorLike[];
+    const messages = graphQlErrors.map((e) => e.message);
+    suppressCurrentChunkErrors = messages.some(isRateLimitMessage);
+    rateLimitStop = rateLimitFromGraphQlResult(messages, {
+      rateLimit: resp.rateLimit,
+      retryAfterSeconds: resp.retryAfterSeconds,
+      stopOnZeroRemaining: hasPendingAfter,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const stop = rateLimitFromError(err, msg);
+    if (stop) {
+      result.errors.push(`rate limit: ${stop.message}`);
+      result.rateLimit = stop;
+      return true;
+    }
+    for (const path of paths) result.errors.push(`${path}: ${msg}`);
+    return false;
+  }
+
+  const errorMessagesByAlias = mapAliasErrors(graphQlErrors);
+  for (let i = 0; i < paths.length; i += 1) {
+    const alias = `m${i}`;
+    const m = data[alias] as { pullRequest?: { id?: string } } | null | undefined;
+    if (m?.pullRequest?.id === pullRequestId) {
+      result.markedPaths.push(paths[i]!);
+    } else if (!suppressCurrentChunkErrors) {
+      result.errors.push(
+        `${paths[i]!}: ${errorMessagesByAlias.get(alias) ?? "mark returned null"}`,
+      );
+    }
+  }
+
+  if (rateLimitStop) {
+    result.errors.push(`rate limit: ${rateLimitStop.message}`);
+    result.rateLimit = rateLimitStop;
+    return true;
+  }
+
+  return false;
+}
+
+function mapAliasErrors(errors: GraphQlErrorLike[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const error of errors) {
+    if (!Array.isArray(error.path)) continue;
+    const alias = error.path.find((part) => typeof part === "string" && isMarkAlias(part));
+    if (typeof alias === "string") out.set(alias, error.message);
+  }
+  return out;
+}
+
+function isMarkAlias(value: string): boolean {
+  if (!value.startsWith("m")) return false;
+  if (value.length === 1) return false;
+  for (const char of value.slice(1)) {
+    if (char < "0" || char > "9") return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add GraphQL-backed `pr-shepherd mark-files-as-viewed` with exact paths, `--tests`, and repeatable `--match` selectors
- batch `markFileAsViewed` mutations and report skipped, missing, already-viewed, and rate-limited paths
- add the `mark-files-as-viewed` skill plus CLI/docs/test coverage

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test