### PR TITLE
docs: align pr-shepherd references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,24 @@
 # pr-shepherd
 
 Autonomous PR CI monitor and review-comment resolver for agentic coding tools, including Claude Code and Codex.
-The goal is to have an agent take a plan to a human-reviewable PR autonomously.
 
-Example Workflow:
+The goal is to help an agent carry a planned change to a human-reviewable PR: passing CI, no unresolved Shepherd-visible work, and a useful PR description/journal.
 
-1. `/model opusplan`
-2. Create a plan
-3. Accept the plan
-4. Switch to Auto Mode
-5. Prompt: `make a PR, then run /pr-shepherd:pr-shepherd`
-6. Agent makes a draft PR
-7. PR has passing CI -> draft is marked Ready for Review
-8. Review bots begin providing reviews
-9. Agent automatically classifies and fixes review comments based on the Plan
-10. Human reviews PR with a well-documented PR title and description, passing CI, and no open threads/comments/reviews
+## How It Works
 
-## How it works
+`pr-shepherd` moves deterministic PR orchestration into a CLI. The CLI fetches GitHub state, emits raw-enough context, and prints a numbered `## Instructions` section for the calling agent to follow. The agent still decides whether a comment or CI failure requires a code change.
 
-`pr-shepherd` optimizes token management, rate limits, and agentic orchestration by moving **ALL** deterministic logic and prompts to code via a CLI tool, enshrining what would be a large skill or command prompt (of which the agent would inevitably make mistakes) into the code and returning a clear, actionable prompt.
+The shipped skills call `pr-shepherd poll <PR>`. Direct CLI users can run `pr-shepherd <PR>`, which is the same poll dispatcher. Use `pr-shepherd iterate <PR>` for one single tick.
 
-The CLI emits unified recheck instructions. Generated commands call `pr-shepherd` directly.
+Each tick returns exactly one action:
 
-At a high level, the skill invokes `pr-shepherd <PR>` (which polls by default), providing actionable feedback directly to the agent:
+- `WAIT` — no immediate action; poll can recheck until timeout.
+- `MARK_READY` — the CLI already converted an eligible draft PR to ready for review.
+- `FIX_CODE` — review items, failing CI, conflicts, or minimization work need agent action.
+- `CANCEL` — terminal success for merged/closed PRs or elapsed ready-delay.
+- `ESCALATE` — manual direction is needed.
+
+Example shape:
 
 ```text
 > pr-shepherd 123
@@ -36,216 +32,171 @@ At a high level, the skill invokes `pr-shepherd <PR>` (which polls by default), 
 
 ### `threadId=PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate/index.mts:42` (@alice)
 
-#### `commentId=PRRC_kwDOSGizTs58XB1M` (@alice)
-
 > The variable name is misleading.
->
-> Consider renaming `x` to `remainingSeconds` so readers don't have to
-> trace back to the declaration to understand its meaning.
 
 ## Failing checks
 
-- `24697658766` — `CI › lint / typecheck / test (22.x)`
+- `24697658766` — `CI › lint / typecheck / test (22.x)` [conclusion: FAILURE]
   > oxfmt
 
 ## Post-fix push
 
 - base: `main`
-- resolve: `pr-shepherd resolve 123 --reply-thread-ids PRRT_kwDOSGizTs58XB1L --minimize-comment-ids IC_kwDOSGizTs7_ajT8,IC_kwDOSGizTs7_ajT9 --message "$DISMISS_MESSAGE" --require-sha "$HEAD_SHA"`
+- resolve: `pr-shepherd resolve 123 --reply-thread-ids PRRT_kwDOSGizTs58XB1L --message "$DISMISS_MESSAGE" --require-sha "$HEAD_SHA"`
 
 ## Instructions
 
-_(schematic — actual steps depend on PR state)_
-
-1. Apply code fixes for each file referenced under `## Review threads`.
-2. For each failing check: examine the log tail to decide — rerun if transient, fix code if real.
-3. Commit changed files.
-4. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`.
-5. Run the `resolve:` command above, substituting `"$HEAD_SHA"`.
-6. Add or update a `## Shepherd Journal` section in the PR description for any large decisions made, appending under the existing heading if it already exists.
-7. CI needs time to run on the new push. Run `pr-shepherd 123` again to continue until Shepherd returns `[CANCEL]` or `[ESCALATE]`.
+1. Decide for each item under `## Review threads` and `## Failing checks` whether a code change is warranted. If code changes are needed, apply edits, commit, rebase/push according to the repository's conventions, then run the `resolve:` command.
+2. For each failing check under `## Failing checks`: fetch logs when needed and decide whether to rerun or fix.
+3. Run the `resolve:` command shown above with a specific `$DISMISS_MESSAGE` and the relevant `$HEAD_SHA`.
+4. Stop this iteration.
 ```
 
-On every iteration, a command is returned to instruct the agent exactly what to do. No guessing, no thinking, as few agentic turns as possible:
+See [docs/actions.md](docs/actions.md) for the complete output contract.
 
-```text
-pr-shepherd resolve 123 --reply-thread-ids PRRT_kwDOSGizTs58XB1L --minimize-comment-ids IC_kwDOSGizTs7_ajT8,IC_kwDOSGizTs7_ajT9 --message "$DISMISS_MESSAGE" --require-sha "$HEAD_SHA"
-```
+## Workflow Assumptions
 
-## Workflow
+This system is opinionated and works best with PRs that use required status checks and conversation resolution.
 
-This system makes opinionated decisions, which may or may not work for your team's workflow.
-
-- The following PR branch protection rules are expected:
-  - There are required status checks
-  - All inline comments are resolved
-- Non-human comments and review summaries may be hidden by default. Human-authored comments, threads, and reviews are never minimized or auto-resolved; reviews are marker-gated and re-surface only when edited.
-  - The primary reason is to optimize tokens by avoiding re-fetching comments and re-adding them to the agent's context.
-  - This also ties hand-in-hand with requiring all inline comments to be resolved.
-  - We also want to avoid storing state as comments can be unresolved/minimized/hidden.
-- `pr-shepherd` keeps the PR title and description up to date, including a journal of decisions with links to comments/threads/reviews (that would be hidden at this point).
-  - This may break your workflow if your PR titles and descriptions are restricted to a specific format.
-- `pr-shepherd` replies to human-authored inline threads with the supplied resolve message, but does not mark those human threads resolved. Bot/non-human inline threads are resolved by the generated resolve command.
-- Branches are currently kept up-to-date with `git push --force-with-lease`. Please make a PR for making `merge <default branch>` an option.
-- Branches are currently only rebased when 1) pushing a commit on a branch that is out of date or 2) there are merge conflicts. It does not continuously rebase the branch (use a merge queue for that).
-- To optimize AI code reviewer tokens, create your pull requests initially as drafts and instruct your AI code reviewers to only code review PRs that are ready for review. `pr-shepherd` will automatically mark PRs as ready for review when all CI passes (can be disabled). If you have no intention of marking your PR as ready for review, then don't run `pr-shepherd`.
-
-Some other workflow improvements:
-
-- `pr-shepherd` knows whether a GitHub Copilot code review is in progress
-- `pr-shepherd` waits 10 minutes (configurable) until after all comments are hidden and CI passes before exiting. The primary reason is to wait for any lingering automated code reviews that do not provide status updates via the GitHub GraphQL API.
-- The agent is instructed to cancel failed CI runs and, when a failure looks transient (e.g. network timeout, runner setup crash), re-run them via `gh run rerun <id> --failed`. The primary reason is to minimize CI costs.
-- `pr-shepherd` supports "commit suggestions" by converting them into a diff, applying them, and then committing them with attribution. This avoids a file read & write. One commit is always made per suggestion to avoid any merge conflicts — in these cases, the agent will resolve the comment manually.
-
-Recommendations:
-
-- Run `pr-shepherd` on all your PRs before you go to sleep so that you wake up to reviewable PRs. Keep an active goal cycling `pr-shepherd <PR>` until Shepherd emits `[CANCEL]` for ready-delay completion or merged/closed, or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures or CI that never starts).
-- Instruct your agents to write comments in a single review (comment, changes requested, or approved). This allows the review's comments/threads to be minimized or resolved together, keeping your pull request history clean. If you write inline comments outside of a review, each comment would still show up in the pull request history and take up space.
-- Avoid sticky comments as they will continue to be hidden. Instead, just make a new comment, especially on reviews. If you really want sticky comments, instruct your agent to unhide/unminimize them when updating them.
-- Avoid having automation edit comments, reviews, or threads in place because updated items get minimized. Instead, always make a new review, comment, thread, etc.
-
-## Design Principles
-
-- **Reduced agent context and turns** — logic lives in the CLI, not the prompt. The relevant context is provided automatically to the agent, reducing tool calls.
-- **Reduced GitHub rate-limit exposure** — GraphQL requests are batched when possible
-- **Minimal state** — `pr-shepherd` stores minimal state in `$PR_SHEPHERD_STATE_DIR` (default `$TMPDIR/pr-shepherd-state/`), not in the repository
-- **Classifications and decisions still happen at the agent level** — `pr-shepherd`'s goal is to provide sufficient context to make informed decisions and provide clear actionable steps without writing unreliable code-level heuristics
-- **Configurable** — `pr-shepherd` is configurable via `.pr-shepherdrc.yml`, which is only possible with a light prompt that simply invokes the CLI which returns the prompt.
+- Human-authored threads are replied to, not resolved or minimized by Shepherd.
+- Bot/non-human threads, PR comments, and review summaries can be resolved or minimized when eligible.
+- Every review thread/comment/review summary is surfaced at least once, even if already outdated, resolved, or minimized; edited items re-surface through seen markers.
+- Draft PRs can be marked ready automatically when clean; disable with `actions.autoMarkReady: false` or `--no-auto-mark-ready`.
+- The CLI never performs git mutations. It emits instructions; the caller commits, rebases, pushes, and handles repository hooks.
+- `commit-suggestion` turns one GitHub suggestion thread into a patch and commit instructions, but still does not edit the working tree or git history.
 
 ## Usage
 
-### Iterate a PR to completion
+### Iterate A PR
 
-Poll dispatcher — checks CI and review comments, fixes issues, and marks the PR ready for review when clean. Each non-terminal tick emits an `## Instructions` section; the skill follows it, then invokes `pr-shepherd <PR>` again until `[CANCEL]` or `[ESCALATE]`.
+Claude Code:
 
-Claude Code (via `pr-shepherd` skill):
-
-```
-/pr-shepherd:pr-shepherd                  # infer PR from current branch
-/pr-shepherd:pr-shepherd 42
-/pr-shepherd:pr-shepherd 42 --ready-delay 15m
+```text
+/goal /pr-shepherd:pr-shepherd        # infer PR from current branch
+/goal /pr-shepherd:pr-shepherd 42
+/goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
 ```
 
-Codex or direct CLI:
+Codex:
+
+```text
+/goal $pr-shepherd        # infer PR from current branch
+/goal $pr-shepherd 42
+```
+
+Direct CLI:
 
 ```sh
-pr-shepherd 42
+pr-shepherd 42                         # poll until non-WAIT or timeout
 pr-shepherd 42 --interval 45s --timeout 4m
 pr-shepherd 42 --ready-delay 15m
-pr-shepherd iterate 42               # single tick
+pr-shepherd iterate 42                 # single tick
+pr-shepherd poll 42                    # explicit poll command
 ```
 
-### Mark files as viewed
+### Resolve Review Items
 
-Hide already-reviewed files in GitHub's PR diff:
+```sh
+pr-shepherd resolve 42 --fetch
+pr-shepherd resolve 42 --reply-thread-ids PRRT_abc --message "Renamed the variable for clarity." --require-sha "$(git rev-parse HEAD)"
+```
+
+### Apply One Suggestion Thread
+
+```sh
+pr-shepherd commit-suggestion 42 --thread-id PRRT_abc --message "rename value for clarity"
+```
+
+The output contains a diff and numbered instructions for applying, staging, committing, resolving, and pushing.
+
+### Mark Files As Viewed
 
 ```sh
 pr-shepherd mark-files-as-viewed 42 --tests
 pr-shepherd mark-files-as-viewed 42 src/a.ts --match '^docs/'
 ```
 
-The shipped `mark-files-as-viewed` skill maps a standalone `tests` argument to `--tests`, so `/pr-shepherd:mark-files-as-viewed 42 tests` marks changed test files as viewed.
+The shipped `mark-files-as-viewed` skill maps a standalone `tests` argument to `--tests`.
 
-## Iterate decision loop
+### Clean Local State
 
-On each tick: fetch PR state in one GraphQL batch → classify CI, comments, and merge status → take one action (`fix_code`, `mark_ready`, `cancel`, `escalate`, or `wait`). See [docs/iterate-flow.md](docs/iterate-flow.md) for the decision table and [docs/flow.md](docs/flow.md) for the end-to-end flow diagram.
-
-## Cleaning state
-
-`pr-shepherd` accumulates state under `$PR_SHEPHERD_STATE_DIR` (seen markers, fix-attempt counters, stall fingerprints, etc.). To reset it:
+`pr-shepherd` stores seen markers, fix-attempt counters, stall fingerprints, ready-delay markers, and logs under `$PR_SHEPHERD_STATE_DIR` (default `$TMPDIR/pr-shepherd-state`).
 
 ```sh
-pr-shepherd clean current    # remove state for the current branch's PR
-pr-shepherd clean repo       # remove all state for this repo
-pr-shepherd clean all        # remove all pr-shepherd state
+pr-shepherd clean current
+pr-shepherd clean repo
+pr-shepherd clean all --dry-run
+pr-shepherd log-file
 ```
-
-Add `--dry-run` to preview what would be removed. See [docs/cli-usage.md](docs/cli-usage.md) for the full `clean` reference.
 
 ## Install
 
-> **Note:** Skill and plugin install methods add the skill definitions only — they do not install the `pr-shepherd` CLI. Ensure `pr-shepherd` is available on `PATH` wherever the skill runs.
+Skill and plugin install methods add the skill definitions only. Install the `pr-shepherd` CLI separately wherever the skill runs.
 
 ### Claude Code
-
-Install as a Claude Code plugin:
 
 ```bash
 claude /plugin marketplace add jonathanong/pr-shepherd
 claude /plugin install pr-shepherd
 ```
 
-This repo ships two `marketplace.json` files that serve different Claude install flows: the root `marketplace.json` resolves the published plugin (used by the `claude /plugin marketplace add` command above); `.claude-plugin/marketplace.json` is the owner-level registry manifest that resolves the plugin from the local plugin directory (used when Claude Code installs from a local or git-based source). Both files are needed to support these two install paths.
-
 ### Codex
-
-Codex uses the repo-shipped Codex plugin rather than the Claude plugin or `/pr-shepherd:*` slash commands. The plugin provides skills for iterating a PR to completion and marking PR files as viewed.
-
-Install the Codex plugin marketplace from GitHub:
 
 ```bash
 codex plugin marketplace add jonathanong/pr-shepherd
 ```
 
-Or pin a branch/tag/ref:
+Or pin a ref:
 
 ```bash
 codex plugin marketplace add jonathanong/pr-shepherd --ref main
 ```
 
-For local development, point Codex at a checkout:
+For local development:
 
 ```bash
 git clone https://github.com/jonathanong/pr-shepherd ~/.codex/plugin-sources/pr-shepherd
 codex plugin marketplace add ~/.codex/plugin-sources/pr-shepherd
 ```
 
-After adding the marketplace, open the Codex plugin directory, choose the `jonathanong` marketplace, and install/enable `pr-shepherd`. The marketplace root must contain `.agents/plugins/marketplace.json` and `plugins/pr-shepherd/`.
-
-Install the CLI where Codex will run it so `pr-shepherd` is available on `PATH`. The plugin only installs the skill; it does not install the CLI into target repositories.
-
-Iterate a PR from Codex:
-
-```bash
-pr-shepherd iterate 42
-```
-
-Or ask Codex to use the `pr-shepherd` skill, for example: `run pr-shepherd until this PR is ready`. Follow the output's `## Instructions`. Continue until Shepherd emits `[CANCEL]` or `[ESCALATE]` (including `stall-timeout` for repeated unchanged CI failures or CI that never starts). `pr-shepherd iterate 42` remains supported for existing workflows.
+After adding the marketplace, install/enable the `pr-shepherd` plugin from Codex. The marketplace root must contain `.agents/plugins/marketplace.json` and `plugins/pr-shepherd/`.
 
 ## Configuration
 
-Create a `.pr-shepherdrc.yml` in your project root (or any parent directory) to override defaults. The loader walks up from `cwd` to `$HOME` (if `$HOME` is on that path) or the filesystem root; the first match wins.
+Create `.pr-shepherdrc.yml` in your project root or an ancestor directory.
 
 ```yaml
 iterate:
-  fixAttemptsPerThread: 5 # raise before escalating to manual review
+  fixAttemptsPerThread: 5
+  stallTimeoutMinutes: 60
+  minimizeApprovals: false
   minimizeComments: all # all | bots | users | none
 checks:
   ciTriggerEvents:
     - pull_request
     - pull_request_target
-    - merge_group # add for merge-queue repos
+    - merge_group
 actions:
-  autoMarkReady: false # disable to stay draft until you manually promote
+  autoMarkReady: false
 ```
 
-Environment variables: `GH_TOKEN` / `GITHUB_TOKEN` (auth; falls back to `gh auth token`, then `GITHUB_PERSONAL_ACCESS_TOKEN`), `PR_SHEPHERD_STATE_DIR` (override loop-state and log base dir), `PR_SHEPHERD_LOG_DISABLED=1` (disable the per-worktree debug log).
+Environment variables:
 
-See [docs/configuration.md](docs/configuration.md) for full semantics and deprecated-key migration.
+- `GH_TOKEN` / `GITHUB_TOKEN` / `GITHUB_PERSONAL_ACCESS_TOKEN` for auth; `gh auth token` is used as a fallback.
+- `PR_SHEPHERD_STATE_DIR` to override state and log location.
+- `PR_SHEPHERD_LOG_DISABLED=1` to disable per-worktree debug logging.
+
+See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ## Requirements
 
-- Node.js ≥ 22.0.0
-- A GitHub token: set `GH_TOKEN` or `GITHUB_TOKEN`, **or** install and authenticate the `gh` CLI (`gh auth login`) — pr-shepherd uses `gh auth token` as a fallback before trying `GITHUB_PERSONAL_ACCESS_TOKEN`. The `repo` scope is required for private repositories.
+- Node.js >= 22.0.0
+- A GitHub token or authenticated `gh` CLI; private repositories require `repo` scope.
 - `git`
 
 ## Docs
 
-Full reference: [docs/README.md](docs/README.md) — CLI usage, skills, configuration, architecture, actions, debugging, and more.
-
-## Architecture
-
-See [docs/architecture.md](docs/architecture.md) for the module map and dependency rules.
+Full reference: [docs/README.md](docs/README.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The goal is to help an agent carry a planned change to a human-reviewable PR: pa
 
 `pr-shepherd` moves deterministic PR orchestration into a CLI. The CLI fetches GitHub state, emits raw-enough context, and prints a numbered `## Instructions` section for the calling agent to follow. The agent still decides whether a comment or CI failure requires a code change.
 
-The shipped skills call `pr-shepherd poll <PR>`. Direct CLI users can run `pr-shepherd <PR>`, which is the same poll dispatcher. Use `pr-shepherd iterate <PR>` for one single tick.
+The shipped skills invoke the default poll dispatcher (`pr-shepherd <PR>`, equivalent to `pr-shepherd poll <PR>`). Use `pr-shepherd iterate <PR>` for one single tick.
 
 Each tick returns exactly one action:
 
@@ -74,7 +74,6 @@ Claude Code:
 ```text
 /goal /pr-shepherd:pr-shepherd        # infer PR from current branch
 /goal /pr-shepherd:pr-shepherd 42
-/goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
 ```
 
 Codex:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Quick entry point. For a command overview see [`../README.md`](../README.md).
 | Document                             | What it covers                                                  |
 | ------------------------------------ | --------------------------------------------------------------- |
 | [cli-usage.md](cli-usage.md)         | CLI command reference and flags                                 |
-| [skills.md](skills.md)               | Claude Code and Codex skill usage (`/pr-shepherd:*`)            |
+| [skills.md](skills.md)               | Claude Code and Codex skill usage                               |
 | [configuration.md](configuration.md) | `.pr-shepherdrc.yml` reference                                  |
 | [flow.md](flow.md)                   | End-to-end mermaid flow diagram                                 |
 | [architecture.md](architecture.md)   | Module map, dependency rules, where to put new code             |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -4,9 +4,9 @@
 
 Each `pr-shepherd iterate` invocation returns exactly one action. The default `pr-shepherd <PR>` command runs the poll dispatcher and prints the final iterate action. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
 
-The default output format is Markdown — what `pr-shepherd poll <PR>` returns to the iterate skill and what direct CLI users see. `--format=json` emits the same action data as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
+The default output format is Markdown — what the skill receives from the default poll dispatcher and what direct CLI users see. `--format=json` emits the same action data as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
-The shipped skill invokes `pr-shepherd poll`, which loops with `--interval`/`--timeout` while the PR remains in `[WAIT]` and returns whenever an actionable or terminal state appears. Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
+The shipped skill invokes the default command with `--interval`/`--timeout`, which is equivalent to `pr-shepherd poll` while the PR remains in `[WAIT]` and returns whenever an actionable or terminal state appears. Do not run `while true` or unbounded polling loops outside of the poll dispatcher.
 
 Command examples call `pr-shepherd` directly everywhere a follow-up command is emitted.
 
@@ -88,7 +88,7 @@ When the current command includes a ready-delay override, the rerun command pres
 
 The body line (`WAIT: …`) varies with the merge state — `branch is behind base`, `blocked by pending reviews or required status checks`, `PR is a draft`, or `some checks are unstable`.
 
-**What the skill does:** Follow `## Instructions`, then run `pr-shepherd poll <N>` again unless the action is terminal.
+**What the skill does:** Follow `## Instructions`, then run the default poll dispatcher again unless the action is terminal.
 
 ---
 
@@ -117,7 +117,7 @@ MARKED READY: PR #42 converted from draft to ready for review
 1. The CLI already marked the PR ready for review. Recheck: rerun `pr-shepherd 42` to recheck once after a fresh 30s–4m delay.
 ```
 
-**What the skill does:** Follow `## Instructions`, then run `pr-shepherd poll <N>` again unless the action is terminal.
+**What the skill does:** Follow `## Instructions`, then run the default poll dispatcher again unless the action is terminal.
 
 ---
 
@@ -396,7 +396,7 @@ The `resolve:` command at the bottom of `## Post-fix push` includes both IDs:
 
 Both IDs stay in `--reply-thread-ids` — `commit-suggestion` does not resolve threads automatically. If a patch failed to apply and was handled manually instead, the ID still belongs in `--reply-thread-ids`.
 
-**What the skill does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed. See `## Instructions` in the output for the exact steps. After handling the action, run `pr-shepherd poll <N>` again unless the action is terminal.
+**What the skill does:** Follow `## Instructions` in order. The instructions are self-contained and action-specific — no dispatch table needed. See `## Instructions` in the output for the exact steps. After handling the action, run the default poll dispatcher again unless the action is terminal.
 
 ---
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -2,9 +2,9 @@
 
 [← README](../README.md)
 
-Each default `pr-shepherd` invocation returns exactly one iterate action. The legacy `pr-shepherd iterate` spelling is still supported. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
+Each `pr-shepherd iterate` invocation returns exactly one action. The default `pr-shepherd <PR>` command runs the poll dispatcher and prints the final iterate action. See [docs/iterate-flow.md](iterate-flow.md) for the decision order.
 
-The default output format is Markdown — what you see when running `pr-shepherd <PR>` directly, and what `pr-shepherd poll <PR>` returns to the iterate skill. `--format=json` emits the same information as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
+The default output format is Markdown — what `pr-shepherd poll <PR>` returns to the iterate skill and what direct CLI users see. `--format=json` emits the same action data as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
 The shipped skill invokes `pr-shepherd poll`, which loops with `--interval`/`--timeout` while the PR remains in `[WAIT]` and returns whenever an actionable or terminal state appears. Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ shepherd/
 ├── index.mts              # bin entrypoint — thin shim that imports cli-parser
 ├── cli-parser.mts         # argv dispatch; subcommand routing
 ├── types.mts              # barrel re-exporting types/github.mts, types/iterate.mts, types/report.mts
-├── config.json            # default config values (TTL, concurrency, intervals, etc.)
+├── config.json            # default config values
 │
 ├── cli/                   # formatting and argument helpers
 │   ├── args.mts           # low-level argv parsing helpers (getFlag, hasFlag, parseCommonArgs, …)
@@ -27,9 +27,11 @@ shepherd/
 │   └── fix-formatter.mts  # Markdown formatter for fix_code variant
 │
 ├── commands/              # one file (or dir) per subcommand
+│   ├── check-annotations.mts  # fetches inline annotations for failing CheckRuns
 │   ├── check.mts          # read-only snapshot (GraphQL fetch → classify → report); internal helper
 │   ├── check-status.mts   # derives ShepherdStatus from a report
-│   ├── commit-suggestion.mts  # applies a reviewer ```suggestion block as a commit
+│   ├── clean.mts          # removes local state files
+│   ├── commit-suggestion.mts  # emits patch and commit instructions for one suggestion
 │   ├── iterate/           # iterate subcommand (default invocation)
 │   │   ├── index.mts      # main runIterate orchestrator
 │   │   ├── classify.mts   # classifyReviewSummaries
@@ -38,6 +40,9 @@ shepherd/
 │   │   ├── helpers.mts    # shared small utilities
 │   │   ├── render.mts     # renderResolveCommand
 │   │   └── stall.mts      # stall-timeout guard
+│   ├── log-file.mts       # prints the per-worktree debug log path
+│   ├── mark-files-as-viewed.mts  # marks changed PR files viewed in GitHub
+│   ├── poll.mts           # repeats iterate while action is WAIT
 │   ├── ready-delay.mts    # ready-delay state machine (ready-since.txt marker)
 │   ├── resolve.mts        # fetch + mutate modes (resolve threads, minimize comments, dismiss reviews)
 │   └── resolve-instructions.mts  # builds fetch-instructions Markdown
@@ -55,9 +60,11 @@ shepherd/
 │   ├── pagination.mts     # generic GraphQL paginator (cursor-based, forward + backward)
 │   └── gql/               # *.gql files — one per query/mutation
 │       ├── batch-pr.gql   # main batch query
-│       ├── resolve-thread.gql
-│       ├── minimize-comment.gql
-│       └── dismiss-review.gql
+│       ├── check-run-annotations.gql
+│       ├── get-pr-head-sha.gql
+│       ├── mark-pr-ready.gql
+│       ├── pr-number-by-branch.gql
+│       └── review-thread-comments.gql
 │
 ├── state/
 │   ├── fix-attempts.mts   # per-thread fix-attempt counter (JSON file in state dir)
@@ -96,16 +103,18 @@ shepherd/
 Dependencies flow in one direction only:
 
 ```
-commands → github → cache
-commands → checks
-commands → comments
+commands → github
+commands → checks → github
+commands → comments → github
 commands → merge-status
 commands → reporters
+comments → state
 ```
 
-- `commands` may import from `github`, `cache`, `checks`, `comments`, `merge-status`, and `reporters`.
-- `github` may import from `cache` but not from `commands`.
-- `checks`, `comments`, `merge-status`, and `reporters` are leaf nodes — they do not import from `commands` or `github`.
+- `commands` may import from `github`, `checks`, `comments`, `merge-status`, and `reporters`.
+- `checks` and `comments` may import from `github` for their domain-specific GitHub reads/mutations.
+- `github` must not import from `commands`, `checks`, or `comments`.
+- `merge-status` and `reporters` are leaf-ish domain modules — they do not import from `commands` or `github`.
 - `types/` is shared by all — the files there have no imports from `commands` or `github`. Keep them lean.
 
 Never import upward (e.g., `github` importing from `commands`) — that creates circular dependencies and breaks the single-responsibility model.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,12 +106,13 @@ Dependencies flow in one direction only:
 commands → github
 commands → checks → github
 commands → comments → github
+commands → state
 commands → merge-status
 commands → reporters
 comments → state
 ```
 
-- `commands` may import from `github`, `checks`, `comments`, `merge-status`, and `reporters`.
+- `commands` may import from `github`, `checks`, `comments`, `state`, `merge-status`, and `reporters`.
 - `checks` and `comments` may import from `github` for their domain-specific GitHub reads/mutations.
 - `github` must not import from `commands`, `checks`, or `comments`.
 - `merge-status` and `reporters` are leaf-ish domain modules — they do not import from `commands` or `github`.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -2,178 +2,117 @@
 
 [← README](../README.md)
 
-```
-pr-shepherd -v|--version
-pr-shepherd [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
-pr-shepherd resolve [PR] [--fetch | --reply-thread-ids … | --resolve-thread-ids … | --minimize-comment-ids … | --dismiss-review-ids … | --message "…" | --require-sha <sha>]
-pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
-pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]
-pr-shepherd iterate [PR] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]  # single tick
-pr-shepherd poll [PR] [--interval 30s] [--timeout 5m] [--verbose] [--ready-delay Nm] [--stall-timeout <duration>] [--no-auto-mark-ready] [--no-auto-cancel-actionable]
-pr-shepherd log-file
-pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]
-```
-
-## Common flags
-
-All subcommands accept:
-
-| Flag                  | Default | Description                                                                                       |
-| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `--format text\|json` | `text`  | Output format                                                                                     |
-| `--verbose`           | false   | (`iterate` only) emit full `IterateResult` JSON / show all base/summary fields in Markdown output |
-
-### pr-shepherd resolve [PR]
-
-Two modes: **fetch** (default) returns actionable items and first-look items; **mutate** replies/resolves/minimizes/dismisses specific IDs after you push fixes. Human-authored threads are replied to, not resolved.
-
-**Fetch mode:**
-
-```sh
-pr-shepherd resolve           # fetch review items
-pr-shepherd resolve 42 --fetch
-```
-
-```markdown
-# PR #42 — Resolve fetch (2 actionable, 1 first-look)
-
-## Actionable Review Threads (2) [commit-suggestions: enabled]
-
-- `threadId=RT_kwDOabc` `src/api.ts:47` (@reviewer): Please add error handling here
-- `threadId=RT_kwDOdef` `src/utils.ts:12` (@alice) [suggestion]: Replace manual loop with Array.from
-
-## First-look items (1) — acknowledge status before acting
-
-- `threadId=RT_kwDOghi` `src/old.ts:9` (@bob) [status: outdated]: This variable name is confusing
-
-## Summary
-
-2 actionable, 1 first-look
-
-## Instructions
-
-1. Classify every item listed above …
-2. Items in `## First-look items` are shown so you can acknowledge their current status before acting. If a first-look human thread also appears under `## Review threads to resolve`, include its ID in `--reply-thread-ids`; otherwise do not pass first-look-only IDs to mutation flags.
-3. For each thread marked `[suggestion]`: run `pr-shepherd commit-suggestion 42 --thread-id <id> --message "<message>" --format=json` (one thread at a time). On `applied: false`, fall through to step 4 for that thread.
-4. For remaining threads (no suggestion, or commit-suggestion failed): read and edit the referenced files.
-5. Commit changed files and push: `git add <files> && git commit -m "<message>"`, then rebase and push.
-6. Run `pr-shepherd resolve 42 [--reply-thread-ids <ids>] …` with the appropriate flags.
-```
-
-First-look items (threads / comments that are outdated, resolved, or minimized on GitHub) are surfaced on first fetch only; a per-item seen-marker file suppresses them on subsequent fetches. They carry a `[status: …]` tag: `outdated`, `resolved`, or `minimized`. Unresolved human outdated/minimized threads also appear under `## Review threads to resolve` and should be included in `--reply-thread-ids`.
-
-The `[suggestion]` marker appears on threads whose body contains a ` ```suggestion ` fenced block and `actions.commitSuggestions` is enabled. See the [`commit-suggestion` section](#pr-shepherd-commit-suggestion-pr---thread-id-id---message) below for how to apply them.
-
-**Mutate mode** (after pushing fixes):
-
-```sh
-pr-shepherd resolve 42 \
-  --reply-thread-ids RT_kwDOabc,RT_kwDOdef \
-  --minimize-comment-ids IC_kwDOxyz \
-  --dismiss-review-ids PRR_kwDO123 \
-  --message "Switched query to parameterized form in src/db.ts" \
-  --require-sha $(git rev-parse HEAD)
-```
-
-```
-Replied to threads (2): RT_kwDOabc, RT_kwDOdef
-Minimized comments (1): IC_kwDOxyz
-Dismissed reviews (1): PRR_kwDO123
-```
-
-Mutation batches are sent in groups of 10. If GitHub returns a primary or secondary
-rate-limit response, Shepherd stops immediately and reports both completed IDs and
-the IDs still pending:
+Run any command with `--help` or `-h` for the built-in usage text. Help exits before GitHub, git, config, cleanup, or log I/O.
 
 ```text
-Minimized comments (35): IC_1, IC_2, …
-Stopped: GitHub rate limit hit — API rate limit exceeded (retry after 60s, remaining 0/5000, reset at 2023-11-14T22:13:20.000Z)
-Not minimized due to rate limit (5): IC_36, IC_37, IC_38, IC_39, IC_40
+pr-shepherd --version | -v
+pr-shepherd --help | -h
+pr-shepherd [PR] [poll-flags] [iterate-flags]
+pr-shepherd iterate [PR] [iterate-flags]
+pr-shepherd poll [PR] [poll-flags] [iterate-flags]
+pr-shepherd resolve [PR] [resolve-flags]
+pr-shepherd commit-suggestion [PR] --thread-id ID --message MSG [--description DESC]
+pr-shepherd mark-files-as-viewed [PR] [files...] [--tests] [--match REGEX]
+pr-shepherd clean <pr|branch|current|repo|all> [value] [--dry-run] [--format text|json]
+pr-shepherd log-file [--format text|json]
 ```
 
-Retry a later run with the pending IDs only. JSON output exposes the same data in
-`rateLimit`, `unrepliedThreads`, `unresolvedThreads`, `unminimizedComments`, `undismissedReviews`, and
-`skippedDismissals`.
+`PR` may be a number or GitHub pull request URL. When omitted, Shepherd infers the current branch's open PR.
 
-**Flags:**
+## Poll And Iterate
 
-| Flag                     | Description                                                    |
-| ------------------------ | -------------------------------------------------------------- |
-| `--fetch`                | Fetch mode (default when no mutation flags are given)          |
-| `--reply-thread-ids`     | Comma-separated human thread IDs to reply to                   |
-| `--resolve-thread-ids`   | Comma-separated non-human/manual thread IDs to mark resolved   |
-| `--minimize-comment-ids` | Comma-separated non-human comment or review-summary IDs        |
-| `--dismiss-review-ids`   | Comma-separated non-human `CHANGES_REQUESTED` review IDs       |
-| `--message`              | Reply/dismiss message (required for replies or dismissals)     |
-| `--require-sha`          | Poll GitHub until the PR head matches this SHA before mutating |
+`pr-shepherd [PR]` is the default poll dispatcher and is equivalent to `pr-shepherd poll [PR]`. It runs iterate ticks while the action is `WAIT`, then prints the final tick when the action becomes `MARK_READY`, `FIX_CODE`, `CANCEL`, or `ESCALATE`, or when `--timeout` returns the last `WAIT`.
 
-`--require-sha` polls `GET /repos/{owner}/{repo}/pulls/{pr}` for `headRefOid` until it matches, then issues the mutations — ensures reviewers see the fix before replies or other mutations land. Exit code: always `0`. `--message` must describe the specific fix; it is shown to the reviewer on GitHub.
+`pr-shepherd iterate [PR]` runs one tick and prints one action. See [actions.md](actions.md) for the full output contract.
 
-### pr-shepherd commit-suggestion [PR] --thread-id <id> --message "…"
+```sh
+pr-shepherd 42
+pr-shepherd 42 --interval 45s --timeout 4m
+pr-shepherd 42 --ready-delay 15m
+pr-shepherd iterate 42
+pr-shepherd poll 42 --format=json
+```
 
-Generates a suggestion for a single reviewer ` ```suggestion ` fenced block. Builds a unified diff from the suggestion, produces the suggested commit message and body (with a `Co-authored-by: <reviewer>` trailer), and emits numbered instructions for the caller to apply the patch, stage, commit, resolve the thread on GitHub, and push. The CLI does not mutate the working tree or git history — the calling agent executes the instructions.
+### Iterate Flags
+
+| Flag                          | Default                       | Description                                                      |
+| ----------------------------- | ----------------------------- | ---------------------------------------------------------------- |
+| `--ready-delay <duration>`    | `watch.readyDelayMinutes`     | Settle window before a clean handoff cancels. Example: `15m`.    |
+| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` | Escalate repeated unchanged state or unstarted CI; `0` disables. |
+| `--no-auto-mark-ready`        | false                         | Do not convert draft PRs to ready for review.                    |
+| `--no-auto-cancel-actionable` | false                         | Do not cancel in-progress runs before actionable fixes.          |
+| `--format text\|json`         | `text`                        | Output Markdown text or JSON.                                    |
+| `--verbose`                   | false                         | Include verbose iterate fields; poll also prints detailed ticks. |
+
+### Poll Flags
+
+| Flag                    | Default | Description                                                        |
+| ----------------------- | ------- | ------------------------------------------------------------------ |
+| `--interval <duration>` | `30s`   | Sleep between `WAIT` ticks.                                        |
+| `--timeout <duration>`  | `5m`    | Maximum wall-clock wait before returning the latest `WAIT` result. |
+
+Durations accept seconds, minutes, hours, or bare seconds: `30s`, `2m`, `1h`, `45`.
+
+Exit codes for iterate and poll: `0` `WAIT`/`MARK_READY`, `1` `FIX_CODE` or command error, `2` `CANCEL`, `3` `ESCALATE`.
+
+## Resolve
+
+`resolve` has two modes:
+
+- **Fetch** (`--fetch`, or no mutation IDs): print actionable review items, first-look items, review summaries when enabled, and a numbered `## Instructions` section.
+- **Mutate** (any mutation ID flag): reply to human threads, resolve non-human/manual thread IDs, minimize comments/review summaries, and dismiss non-human `CHANGES_REQUESTED` reviews.
+
+```sh
+pr-shepherd resolve 42 --fetch
+pr-shepherd resolve 42 \
+  --reply-thread-ids PRRT_human \
+  --resolve-thread-ids PRRT_bot \
+  --minimize-comment-ids IC_bot,PRR_summary \
+  --dismiss-review-ids PRR_changes_requested \
+  --message "Switched query construction to parameterized SQL." \
+  --require-sha "$(git rev-parse HEAD)"
+```
+
+| Flag                     | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| `--fetch`                | Force fetch mode.                                                    |
+| `--reply-thread-ids`     | Comma-separated human review thread IDs to reply to.                 |
+| `--resolve-thread-ids`   | Comma-separated non-human/manual review thread IDs to mark resolved. |
+| `--minimize-comment-ids` | Comma-separated issue comment or review IDs to minimize.             |
+| `--dismiss-review-ids`   | Comma-separated `CHANGES_REQUESTED` review IDs to dismiss.           |
+| `--message`              | Required with replies or dismissals; must describe the specific fix. |
+| `--require-sha`          | Poll GraphQL `headRefOid` until GitHub reports this PR head SHA.     |
+| `--format text\|json`    | Output format.                                                       |
+
+Mutation batches are sent in chunks of 10. On a primary or secondary GitHub rate-limit response, Shepherd stops and reports completed IDs plus pending IDs to retry later.
+
+Fetch-mode first-look items are surfaced once even if outdated, resolved, or minimized. Edited item bodies re-surface through the seen-marker gate. Review-summary IDs (`PRR_…`) go to `--minimize-comment-ids`, never `--dismiss-review-ids`.
+
+## Commit Suggestion
+
+`commit-suggestion` turns one review thread containing exactly one GitHub ` ```suggestion ` block into a patch, commit metadata, and numbered instructions. It does not edit files or mutate git history.
 
 ```sh
 pr-shepherd commit-suggestion 42 \
   --thread-id PRRT_abc \
-  --message "trim trailing whitespace per reviewer" \
-  --description "Optional longer body text."
+  --message "rename value for clarity" \
+  --description "Optional longer body."
 ```
 
-Requires that the current branch matches the PR head ref and that the local HEAD SHA matches the PR head SHA. Precondition or lookup failures (wrong branch, thread not found, already resolved, outdated, no suggestion block, nested fencing) are hard errors that exit `1` with a specific reason string.
+Preconditions:
 
-Gated by `actions.commitSuggestions` (default `true`) — `/pr-shepherd:resolve` calls this automatically for threads that `resolve --fetch` annotates with `[suggestion]`.
+- Current branch matches the PR head branch.
+- Local `HEAD` matches the PR head SHA.
+- Target file is clean.
+- Thread is active, locatable, unresolved, not outdated, and not minimized.
 
-**Example output:**
+The output includes a unified diff, a suggested commit subject/body with reviewer attribution, files to stage, and post-action instructions. Invoke once per suggestion thread.
 
-````
-Suggestion from @alice for PR #42 — thread PRRT_abc:
-  src/foo.ts (line 42)
+Exit codes: `0` suggestion produced, `1` validation/lookup/precondition/parsing failure.
 
-```diff
---- a/src/foo.ts
-+++ b/src/foo.ts
-@@ -42 +42 @@
--const x = computeRemaining();
-+const remainingSeconds = computeRemaining();
-```
+## Mark Files As Viewed
 
-## Suggested commit message
-
-rename x to remainingSeconds
-
-Co-authored-by: alice <alice@users.noreply.github.com>
-
-## Instructions
-
-1. Apply the patch to `src/foo.ts`: run `git apply` with the diff shown above, or edit the file directly using the line range (line 42).
-2. Stage the file: `git add -- src/foo.ts`
-3. Commit: `git commit -m "rename x to remainingSeconds" -m "Co-authored-by: alice <alice@users.noreply.github.com>"`
-4. Reply to the thread on GitHub: `pr-shepherd resolve 42 --reply-thread-ids PRRT_abc --message "Applied the suggestion."`
-5. Push when ready: `git push` (or `git push --force-with-lease` after rebasing).
-````
-
-Exit codes: `0` suggestion produced · `1` any precondition or lookup error.
-
-**Applying multiple suggestions.** Invoke once per thread — the command handles one suggestion at a time. For a PR with multiple suggestion threads, apply each in sequence and commit each separately (or amend as appropriate), then push all commits together:
-
-```sh
-# Get suggestion for first thread, apply it, then commit
-pr-shepherd commit-suggestion 42 --thread-id PRRT_aaa --message "rename x to remainingSeconds"
-# … follow the printed ## Instructions …
-
-# Get suggestion for second thread, apply it, then commit
-pr-shepherd commit-suggestion 42 --thread-id PRRT_bbb --message "simplify loop body"
-# … follow the printed ## Instructions …
-
-git push
-```
-
-If a patch fails to apply (drift since the suggestion was written), apply the fix manually using the line range shown in the output.
-
-### pr-shepherd mark-files-as-viewed [PR] [files...]
-
-Marks changed files as viewed in GitHub's PR diff using GraphQL. Exact path arguments must match files in the PR changed-file list. Selectors expand against the same GitHub PR diff, not local uncommitted changes.
+Marks changed files as viewed in the GitHub PR diff using GraphQL.
 
 ```sh
 pr-shepherd mark-files-as-viewed 42 src/a.ts src/b.test.ts
@@ -181,181 +120,47 @@ pr-shepherd mark-files-as-viewed 42 --tests
 pr-shepherd mark-files-as-viewed 42 --match '^docs/' --match '\\.md$'
 ```
 
-`--tests` selects common test file paths such as `tests/`, `__tests__/`, `spec/`, `*.test.ts`, `*.spec.tsx`, `_test.rs`, and `tests.rs`. `--match <regex>` is a repeatable, case-insensitive JavaScript regex over changed-file paths.
+Selectors expand against GitHub's changed-file list:
 
-Mutation batches are sent in groups of 10. If GitHub returns a primary or secondary rate-limit response, Shepherd stops and reports both completed files and pending files. JSON output exposes the same data as text output: matched paths, marked paths, already-viewed paths, missing exact paths, unmatched selectors, errors, rate-limit details, and pending unmarked paths.
+- Exact path arguments must match changed-file paths.
+- `--tests` selects common test paths and suffixes.
+- `--match <regex>` is repeatable and case-insensitive.
 
-### pr-shepherd [PR]
+Mutation batches are sent in groups of 10 and stop on GitHub rate limits with completed and pending file lists.
 
-Poll: loops iterate ticks until the action is non-WAIT or `--timeout` elapses. This is the default command — `pr-shepherd 42` is equivalent to `pr-shepherd poll 42`. `pr-shepherd iterate [PR]` runs a single tick. See [iterate-flow.md](iterate-flow.md) for the decision tree and [actions.md](actions.md) for every action's full output shape.
+## Log File
 
-```sh
-pr-shepherd 42
-pr-shepherd 42 --interval 45s --timeout 4m    # custom cadence
-pr-shepherd 42 --ready-delay 15m             # override ready-delay for this run
-pr-shepherd iterate 42                       # single tick only
-```
-
-**Flags:**
-
-| Flag                          | Default                                 | Description                                                                                          |
-| ----------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `--verbose`                   | false                                   | Full JSON output (all fields); restores full summary line in Markdown. See [actions.md](actions.md). |
-| `--ready-delay Nm`            | `watch.readyDelayMinutes` in config     | Settle window before the loop cancels after READY                                                    |
-| `--stall-timeout <duration>`  | `iterate.stallTimeoutMinutes` in config | Override the stall-detection window (e.g. `--stall-timeout 1h`)                                      |
-| `--no-auto-mark-ready`        | false                                   | Skip converting draft → ready-for-review                                                             |
-| `--no-auto-cancel-actionable` | false                                   | Skip cancelling actionable failing runs                                                              |
-
-**Default (Markdown) output.** Every action emits an H1 heading, a bolded base-fields line, a bolded summary line, then an action-specific body. Zero counts (`skipped`, `filtered`, `inProgress`) are omitted in lean mode; `blockingBotReviewInProgress` and `isDraft` are only shown when `true`; `shouldCancel` is never shown. Example for `[WAIT]`:
-
-```markdown
-# PR #42 [WAIT]
-
-**status** `READY` · **merge** `CLEAN` · **state** `OPEN` · **repo** `owner/repo`
-**summary** 3 passing · **remainingSeconds** 540
-
-WAIT: 3 passing, 0 in-progress — 540s until auto-cancel
-
-## Instructions
-
-1. Recheck: rerun `pr-shepherd 42` to continue the active goal once after a fresh 30s–4m delay.
-```
-
-The `## Instructions` recheck command is the same regardless of calling agent. If the current command used `--ready-delay`, the rerun command includes the same flag.
-
-The `pr-shepherd [PR]` default command polls, so callers get the loop automatically. Use `pr-shepherd iterate [PR]` for a single tick.
-
-Example for `[FIX_CODE]` (richest action):
-
-```markdown
-# PR #42 [FIX_CODE]
-
-**status** `UNRESOLVED_COMMENTS` · **merge** `BLOCKED` · **state** `OPEN` · **repo** `owner/repo`
-**summary** 3 passing
-
-## Review threads
-
-### `threadId=PRRT_kwDOSGizTs58XB1L` — `src/commands/iterate/index.mts:42` (@alice)
-
-> The variable name is misleading.
->
-> Consider renaming `x` to `remainingSeconds`.
-
-## Failing checks
-
-- `24697658766` — `CI › lint / typecheck / test (22.x)`
-  > Run tests
-```
-
-Error: expected 'foo' to equal 'bar'
-at Object.<anonymous> (src/commands/iterate.test.mts:58:22)
-
-```
-
-## Post-fix push
-
-- base: `main`
-- resolve: `pr-shepherd resolve 42 --reply-thread-ids PRRT_kwDOSGizTs58XB1L --message "$DISMISS_MESSAGE" --require-sha "$HEAD_SHA"`
-
-## Instructions
-
-1. Apply code fixes: read and edit each file referenced under `## Review threads` and `## Actionable comments` above.
-2. For each failing check under `## Failing checks` with a run ID, examine the log tail in the fenced block to decide what to do:
-   - If the log tail shows a transient runner or infrastructure failure (network timeout, runner setup crash, OOM kill), run `gh run rerun <runId> --failed` and stop this iteration — CI will re-run automatically.
-   - If the log tail shows a real test or build failure, apply a code fix.
-   - If the fenced log block is absent, run `gh run view <runId> --log-failed` first to fetch it, then choose between rerun and fix above.
-3. Commit changed files: `git add <files> && git commit -m "<descriptive message>"`
-4. Keep the PR title and description current: if the changes alter the PR's scope or intent, run `gh pr edit 42 --title "<new title>" --body "<new body>"` to reflect them. Skip if the existing title/body still accurately describe the PR.
-5. Rebase and push: `git fetch origin && git rebase origin/main && git push --force-with-lease` — capture `HEAD_SHA=$(git rev-parse HEAD)`
-6. Run the `resolve:` command shown above, substituting "$HEAD_SHA" with the pushed commit SHA and $DISMISS_MESSAGE with a one-sentence description of what you changed.
-7. For any large decisions made, add or update a `## Shepherd Journal` section in the PR description (`gh pr edit 42 --body …`), appending entries under the existing heading if present.
-8. CI needs time to run on the new push. Recheck: rerun `pr-shepherd 42 --ready-delay 15m` to recheck once after a fresh 30s–4m delay.
-```
-
-See [actions.md](actions.md) for all five actions and their complete output shapes.
-
-Both `--format=text` (default Markdown) and `--format=json` carry equivalent information — every field exposed in JSON has a corresponding Markdown representation, and vice versa.
-
-Exit codes: `0` wait/mark_ready · `1` fix_code · `2` cancel · `3` escalate
-
-### pr-shepherd poll [PR]
-
-Loops `pr-shepherd [PR]` every `--interval` seconds until the action is non-WAIT or `--timeout` elapses. Useful for agents that cannot reliably schedule their own follow-up ticks.
-
-| Flag                    | Default | Description                                                                 |
-| ----------------------- | ------- | --------------------------------------------------------------------------- |
-| `--interval <duration>` | `30s`   | Sleep between ticks. Accepts `30s`, `2m`, `1h`, or bare integers (seconds). |
-| `--timeout <duration>`  | `5m`    | Maximum wall-clock wait. Returns the last WAIT result on timeout.           |
-
-All `pr-shepherd [PR]` flags (`--ready-delay`, `--stall-timeout`, `--no-auto-mark-ready`, `--no-auto-cancel-actionable`, `--verbose`, `--format`) are forwarded to each tick.
-
-Stdout is the final tick's output only; each WAIT tick writes a single dot to stderr. `--verbose` emits the detailed per-tick line instead.
-
-Exit codes: `0` wait/mark_ready · `1` fix_code · `2` cancel · `3` escalate
-
-**Notes:**
-
-- A long poll session is equivalent to N separately-scheduled ticks, including stall-guard behavior. The stall guard may escalate before `--timeout` fires if CI is stuck.
-- `mark_ready` exits the loop — the CLI already mutated state. Re-invoke if you want to continue.
+Prints the per-worktree append-only debug log path. The first non-help command that initializes logging creates the file.
 
 ```sh
-pr-shepherd poll 42                        # poll PR #42 every 30s for up to 5m
-pr-shepherd poll 42 --interval 1m          # check every minute
-pr-shepherd poll 42 --timeout 15m          # wait up to 15 minutes
-pr-shepherd poll --format=json             # infer PR, emit JSON on final tick
+pr-shepherd log-file
+pr-shepherd log-file --format=json
 ```
 
-### pr-shepherd log-file
+Logs include session headers, GraphQL request/response bodies, REST JSON request/response bodies, REST text metadata, and full CLI stdout. Auth headers are never logged.
 
-Prints the path of the per-worktree append-only debug log for the current repository. The file is created on the first invocation of any other subcommand.
+Set `PR_SHEPHERD_LOG_DISABLED=1` to disable logging. `PR_SHEPHERD_STATE_DIR` overrides the base state/log directory.
+
+## Clean
+
+Removes local Shepherd state from `$PR_SHEPHERD_STATE_DIR` (default `$TMPDIR/pr-shepherd-state`).
 
 ```sh
-pr-shepherd log-file             # prints path
-pr-shepherd log-file --format=json  # {"path":"…"}
+pr-shepherd clean current
+pr-shepherd clean pr 42
+pr-shepherd clean branch feature/foo
+pr-shepherd clean repo
+pr-shepherd clean all
+pr-shepherd clean current --dry-run
+pr-shepherd clean repo --format=json
 ```
 
-```
-/var/folders/…/pr-shepherd-state/owner-repo/worktrees/my-branch-3f4a9b21.md
-```
+| Variant         | What it removes                                                 |
+| --------------- | --------------------------------------------------------------- |
+| `pr [number]`   | One PR's state; defaults to current branch PR.                  |
+| `branch [name]` | Resolves a branch to its open PR, then removes that PR's state. |
+| `current`       | Alias for `branch` against the current branch.                  |
+| `repo`          | All state for the current repository, including worktree logs.  |
+| `all`           | All `pr-shepherd` state under the base directory.               |
 
-The log captures, for each CLI invocation:
-
-- A session header (ISO-8601 timestamp · pid · version · full argv)
-- Every GraphQL request and response (query, variables, response body)
-- Every REST JSON request and response (method, path, body, status)
-- Every `restText` request/response — metadata only (status · content-length), body never logged
-- Full stdout output (text or JSON) emitted by the subcommand
-
-All entries carry an ISO-8601 millisecond timestamp. HTTP response entries also show elapsed milliseconds. Auth headers are never written to the log.
-
-**Disable logging:** set `PR_SHEPHERD_LOG_DISABLED=1`. Logging is also automatically disabled when `CI=true` or when the first write fails.
-
-**Override base directory:** set `PR_SHEPHERD_STATE_DIR` (same env var as the loop-state directory). The log lives at `$PR_SHEPHERD_STATE_DIR/<owner>-<repo>/worktrees/<basename>-<sha8>.md`.
-
-Exit code: `0` on success · `1` if not in a git repo or repo identity cannot be resolved.
-
-### pr-shepherd clean \<variant\> [value]
-
-Removes pr-shepherd state files. State lives under `$PR_SHEPHERD_STATE_DIR` (default `$TMPDIR/pr-shepherd-state`) and includes per-PR seen markers, fix-attempt counters, stall fingerprints, and ready-delay timers.
-
-| Variant         | What it removes                                                                                                   |
-| --------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `pr [number]`   | State for a specific PR: `<base>/<owner>-<repo>/<pr>/`. Defaults to the current branch's open PR.                 |
-| `branch [name]` | Resolves the branch to its open PR, then removes that PR's state. Defaults to the current branch.                 |
-| `current`       | Alias for `branch` against the current branch.                                                                    |
-| `repo`          | All state for the current repository: `<base>/<owner>-<repo>/` (includes all PRs and the worktree debug-log dir). |
-| `all`           | All pr-shepherd state: `<base>/`.                                                                                 |
-
-```sh
-pr-shepherd clean current              # remove state for the current branch's PR
-pr-shepherd clean pr 42                # remove state for PR #42
-pr-shepherd clean branch feature/foo   # remove state for the PR on branch feature/foo
-pr-shepherd clean repo                 # remove all state for this repo
-pr-shepherd clean all                  # remove all pr-shepherd state
-pr-shepherd clean current --dry-run    # preview what would be removed
-pr-shepherd clean repo --format=json   # machine-readable output
-```
-
-`--dry-run` lists the paths that would be deleted without touching the filesystem. A nonexistent target is not an error — the command exits `0` and reports nothing to clean.
-
-Exit codes: `0` on success · `1` on error (invalid variant, no PR found, not in a git repo).
+`--dry-run` previews paths without deleting them. A nonexistent target exits `0` and reports nothing to clean.

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -53,7 +53,7 @@ State module: `src/state/seen-comments.mts`.
 
 ## `--require-sha` polling
 
-When `shepherd resolve --require-sha <SHA>` is used, shepherd polls `GET /repos/{owner}/{repo}/pulls/{pr}` for `headRefOid` until it matches `expectedSha`, then issues the resolve/minimize/dismiss mutations.
+When `shepherd resolve --require-sha <SHA>` is used, shepherd polls the GraphQL `get-pr-head-sha.gql` query for `headRefOid` until it matches `expectedSha`, then issues the resolve/minimize/dismiss mutations.
 
 **Why:** Without this guard, shepherd might auto-merge before the reviewer sees the fix. The polling ensures GitHub has received the push and updated the PR head before any mutations fire.
 
@@ -61,13 +61,14 @@ When `shepherd resolve --require-sha <SHA>` is used, shepherd polls `GET /repos/
 
 ## Mutation types
 
-All mutations live in `comments/resolve.mts`:
+Mutations are built in `comments/resolve.mts` and sent through GraphQL in batches:
 
-| Mutation         | GraphQL file                      | What it does                                                                        |
+| Mutation         | GraphQL mutation                  | What it does                                                                        |
 | ---------------- | --------------------------------- | ----------------------------------------------------------------------------------- |
-| Resolve thread   | `github/gql/resolve-thread.gql`   | Marks a review thread resolved                                                      |
-| Minimize comment | `github/gql/minimize-comment.gql` | Hides a PR comment or review summary (`PullRequestReview` implements `Minimizable`) |
-| Dismiss review   | `github/gql/dismiss-review.gql`   | Dismisses a CHANGES_REQUESTED review with a message                                 |
+| Reply to thread  | `addPullRequestReviewThreadReply` | Replies to a human-authored review thread                                           |
+| Resolve thread   | `resolveReviewThread`             | Marks a review thread resolved                                                      |
+| Minimize comment | `minimizeComment`                 | Hides a PR comment or review summary (`PullRequestReview` implements `Minimizable`) |
+| Dismiss review   | `dismissPullRequestReview`        | Dismisses a CHANGES_REQUESTED review with a message                                 |
 
 Review summary IDs (`PRR_…` from `reviewSummaries`) go through `--minimize-comment-ids`, not `--dismiss-review-ids`. The `dismiss` path is reserved for CHANGES_REQUESTED reviews.
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -53,7 +53,7 @@ State module: `src/state/seen-comments.mts`.
 
 ## `--require-sha` polling
 
-When `shepherd resolve --require-sha <SHA>` is used, shepherd polls the GraphQL `get-pr-head-sha.gql` query for `headRefOid` until it matches `expectedSha`, then issues the resolve/minimize/dismiss mutations.
+When `pr-shepherd resolve --require-sha <SHA>` is used, shepherd polls the GraphQL `get-pr-head-sha.gql` query for `headRefOid` until it matches `expectedSha`, then issues the resolve/minimize/dismiss mutations.
 
 **Why:** Without this guard, shepherd might auto-merge before the reviewer sees the fix. The polling ensures GitHub has received the push and updated the PR head before any mutations fire.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ actions:
 | `checks.ciTriggerEvents`             | `["pull_request", "pull_request_target"]` | Workflow `on:` events treated as PR CI (add `merge_group` for merge-queue repos)                                                                            |
 | `mergeStatus.blockingReviewerLogins` | `["copilot"]`                             | Reviewer logins whose pending review or outstanding review request blocks `mark_ready`                                                                      |
 | `actions.autoResolveOutdated`        | `true`                                    | Deprecated compatibility setting; outdated threads are surfaced before human-authored threads are replied to and bot/non-human threads are resolved         |
-| `actions.autoMarkReady`              | `true`                                    | Emit `mark_ready` when a draft PR's CI goes clean                                                                                                           |
+| `actions.autoMarkReady`              | `true`                                    | Emit `mark_ready` when a draft PR reaches a clean handoff state                                                                                             |
 | `actions.commitSuggestions`          | `true`                                    | Route `/pr-shepherd:resolve` through `commit-suggestion` (singular) for threads with a ` ```suggestion ` block                                              |
 
 ## `iterate`
@@ -175,7 +175,7 @@ Deprecated. Shepherd no longer auto-resolves outdated threads. Outdated threads 
 
 ### `actions.autoMarkReady` — default `true`
 
-When `true`, shepherd converts a draft PR to ready-for-review once all checks pass and the ready-delay has elapsed.
+When `true`, shepherd converts a draft PR to ready-for-review once all checks pass, no Shepherd-visible work remains, no configured blocking review is in progress, and the ready-delay has not yet elapsed. After the ready-delay elapses, the loop emits `cancel` instead.
 
 Disable if your team uses the draft state as a deliberate gate that requires a human to promote.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -62,12 +62,12 @@ rm $TMPDIR/pr-shepherd-state/acme-myrepo/42/ready-since.txt
 
 **Symptom:** Shepherd errors with `API rate limit exceeded` or `secondary rate limit`.
 
-**Cause:** Too many API calls. Common when the cache is bypassed frequently or non-terminal ticks are scheduled too aggressively.
+**Cause:** Too many API calls. Common when non-terminal ticks are scheduled too aggressively or many large PRs are being watched at once.
 
 **Fix options:**
 
-1. Pause or cancel the monitor loop if API budget is tight. Scheduling is dynamic and fixed to agent-chosen 1-4 minute waits, so there is no polling interval config to raise.
-2. Check `x-ratelimit-remaining` in the reporter JSON output to monitor consumption
+1. Pause or cancel the monitor loop if API budget is tight, or increase `poll --interval` / reduce `poll --timeout` for explicit poll sessions.
+2. Check rate-limit metadata in JSON output or the per-worktree log.
 3. For `resolve` mutate output, retry only the IDs listed under `Not resolved`,
    `Not minimized`, or `Not dismissed`; IDs listed as completed already succeeded.
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -77,10 +77,17 @@ All tunable constants live in `src/config.json`. Edit there — do not hardcode 
 
 ```json
 {
-  "cache": { "ttlSeconds": 300 },
-  "iterate": { "fixAttemptsPerThread": 3 },
+  "iterate": {
+    "fixAttemptsPerThread": 3,
+    "stallTimeoutMinutes": 60,
+    "minimizeApprovals": false,
+    "minimizeComments": "all"
+  },
   "watch": { "readyDelayMinutes": 10 },
-  "resolve": { "shaPoll": { "maxAttempts": 10, "intervalMs": 2000 } }
+  "resolve": {
+    "shaPoll": { "maxAttempts": 10, "intervalMs": 2000 },
+    "fetchReviewSummaries": true
+  }
 }
 ```
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,8 +6,8 @@ The module supports a focused automation loop for PR monitoring and deterministi
 
 ### CLI commands and invocation
 
-- Supports default invocation `pr-shepherd [PR]` for one iterate tick.
-- Supports explicit `pr-shepherd iterate [PR]` as the legacy alias spelling.
+- Supports default invocation `pr-shepherd [PR]` as the poll dispatcher.
+- Supports explicit `pr-shepherd iterate [PR]` for one single tick.
 - Supports `pr-shepherd resolve [PR]` fetch mode (via `--fetch` or when no mutation flags are passed).
 - Supports `pr-shepherd resolve [PR]` mutate mode with `--reply-thread-ids`, `--resolve-thread-ids`, `--minimize-comment-ids`, `--dismiss-review-ids`.
 - Supports `pr-shepherd commit-suggestion [PR] --thread-id <id> --message "<one-sentence headline>"` (or `--description`) for suggestion-thread patch generation.
@@ -64,7 +64,7 @@ The module supports a focused automation loop for PR monitoring and deterministi
 - Supports minimizing non-human minimizable objects by ID (`--minimize-comment-ids`), including review summaries/review IDs.
 - Supports dismissing `CHANGES_REQUESTED` reviews with a message (`--dismiss-review-ids` + `--message`).
 - Supports batching mutation IDs in groups of 10.
-- Supports explicit `--require-sha <sha>` polling before mutating so close/reopen actions follow the pushed commit.
+- Supports explicit `--require-sha <sha>` polling before mutating so replies/resolves/minimizes/dismissals follow the pushed commit.
 
 ### Suggestion-thread workflow
 
@@ -103,7 +103,7 @@ The module supports a focused automation loop for PR monitoring and deterministi
 
 ## References
 
-- Command surface and argument parsing: [src/cli-parser.mts](src/cli-parser.mts)
+- Command surface and argument parsing: `src/cli-parser.mts`
 - CLI usage reference: [docs/cli-usage.md](docs/cli-usage.md)
 - Action model and flow: [docs/actions.md](docs/actions.md), [docs/iterate-flow.md](docs/iterate-flow.md)
 - Configuration options: [docs/configuration.md](docs/configuration.md)

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -15,7 +15,7 @@ flowchart TD
   S3 -->|yes| S3X[gh run cancel failing runIds]
   S3X --> A_FIX([action: fix_code<br/>+ fix payload with failedStep/conclusion])
   S3 -->|no| S4{4. READY + CLEAN<br/>+ isDraft<br/>+ !copilot?}
-  S4 -->|yes| S4X[gh pr ready PR]
+  S4 -->|yes| S4X[markPullRequestReadyForReview<br/>GraphQL mutation]
   S4X --> A_MR([action: mark_ready])
   S4 -->|no| A_W([action: wait])
 
@@ -25,7 +25,7 @@ flowchart TD
   A_W --> DEC
 
   DEC -->|cancel/escalate| STOP["stop"]
-  DEC -->|fix_code| FIX[gh run view --log-failed →<br/>rerun or edit+commit →<br/>fetch + rebase + push →<br/>pr-shepherd resolve --require-sha HEAD]
+  DEC -->|fix_code| FIX[inspect CI as needed →<br/>rerun or edit+commit →<br/>rebase/push by repo convention →<br/>pr-shepherd resolve]
   FIX --> SLEEP[Schedule or sleep 30s-4m,<br/>then rerun]
   DEC -->|other| SLEEP
   SLEEP --> ITER

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -45,7 +45,7 @@ The generic paginator is in `github/pagination.mts`. It accepts a `direction` pa
 
 **When:** `--require-sha` flag is set on `resolve`.
 
-**Why:** Shepherd needs to verify GitHub has received a push before resolving threads. This polls `headRefOid` until it matches the expected SHA.
+**Why:** Shepherd needs to verify GitHub has received a push before resolving threads. This GraphQL query polls `headRefOid` until it matches the expected SHA.
 
 ### Startup-failure Actions runs
 

--- a/docs/iterate-flow.md
+++ b/docs/iterate-flow.md
@@ -83,7 +83,7 @@ Before the generic fingerprint check, `wait` results also inspect relevant in-pr
 
 All failing checks — including timeout, cancelled, startup-failure, and flaky failures — route here. The `fix` payload carries `conclusion` for each failing check; `workflowName`, `jobName`, and `failedStep` are populated only when triage runs (that is, not for cancelled or startup-failure checks). The agent runs `gh run view <runId> --log-failed` to fetch the full log when needed and decides whether to rerun (transient failure) or apply a code fix (real failure). Cancelled checks carry a `[conclusion: CANCELLED]` tag — the agent reruns with `gh run rerun <runId>` (no `--failed`) if the cancellation looks unintended. Startup failures carry a `[conclusion: STARTUP_FAILURE]` tag — the agent inspects metadata with `gh run view <runId>` and reruns with `gh run rerun <runId>` if the workflow should be attempted again.
 
-CONFLICTS is included here because the `fix_code` handler already runs `git fetch origin && git rebase origin/<BASE_BRANCH> && git push --force-with-lease`, so merge conflicts and review comments are resolved together in a single push rather than across two separate ticks.
+CONFLICTS is included here because the `fix_code` instructions tell the caller to rebase onto `origin/<BASE_BRANCH>` according to repository conventions, so merge conflicts and review comments can be resolved together in a single push rather than across two separate ticks.
 
 **Side-effects:** cancels stale CI runs (`gh run cancel <runId>`) for all failing checks.
 
@@ -95,7 +95,7 @@ CONFLICTS is included here because the `fix_code` handler already runs `git fetc
 
 **Check:** `report.status === 'READY'` AND `mergeStateStatus` is `CLEAN` (or `DRAFT` when `isDraft`) AND `!blockingBotReviewInProgress` AND `isDraft` AND `!shouldCancel`.
 
-**Side-effects:** `gh pr ready <PR>`
+**Side-effects:** calls GitHub's `markPullRequestReadyForReview` GraphQL mutation.
 
 **Emits:** `action: 'mark_ready'`
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,7 +4,7 @@
 
 Two skills are shipped for both Claude Code and Codex:
 
-- `pr-shepherd` is a thin poll dispatcher — it runs `pr-shepherd poll <PR>` and follows the `## Instructions` embedded in the output. All policy, state transitions, and per-action guidance live in the CLI output, not in the skill.
+- `pr-shepherd` is a thin poll dispatcher — it runs the default `pr-shepherd <PR>` command with a bounded interval/timeout and follows the `## Instructions` embedded in the output. All policy, state transitions, and per-action guidance live in the CLI output, not in the skill.
 - `mark-files-as-viewed` marks PR changed files as viewed in GitHub by invoking `pr-shepherd mark-files-as-viewed`.
 
 ## Claude Code
@@ -21,11 +21,10 @@ Use the skill inside a `/goal`:
 ```
 /goal /pr-shepherd:pr-shepherd        # infer PR from current branch
 /goal /pr-shepherd:pr-shepherd 42
-/goal /pr-shepherd:pr-shepherd 42 --ready-delay 15m
 /pr-shepherd:mark-files-as-viewed 42 tests
 ```
 
-The goal loop handles recurrence. The skill invokes `pr-shepherd poll <N>` and prints the output. For non-terminal actions, follow the CLI's `## Instructions`, then invoke `pr-shepherd poll <N>` again. `[CANCEL]` and `[ESCALATE]` stop the goal.
+The goal loop handles recurrence. The skill invokes the default poll dispatcher and prints the output. For non-terminal actions, follow the CLI's `## Instructions`, then invoke the skill again. `[CANCEL]` and `[ESCALATE]` stop the goal.
 
 ## Codex
 
@@ -60,7 +59,7 @@ Use the skill inside a `/goal`:
 $mark-files-as-viewed 42 tests
 ```
 
-Codex runs the same skill: invoke `pr-shepherd poll <N>`, follow the output, and continue until `[CANCEL]` or `[ESCALATE]`.
+Codex runs the same skill: invoke the default poll dispatcher, follow the output, and continue until `[CANCEL]` or `[ESCALATE]`.
 
 ## Resolve without iterating
 

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -4,9 +4,9 @@
 
 ## Overview
 
-pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. The skill always invokes `pr-shepherd poll <PR>`, which loops internally while the PR is in `[WAIT]` and returns whenever an actionable or terminal state appears.
+pr-shepherd iterates a PR to completion via the active goal loops of Claude Code and Codex. The skill invokes the default `pr-shepherd <PR>` command with a bounded interval/timeout. That default command is the poll dispatcher: it loops internally while the PR is in `[WAIT]` and returns whenever an actionable or terminal state appears.
 
-Each non-terminal action is followed by another `pr-shepherd poll <PR>` invocation. Do not run `while true` or unbounded polling loops outside of `pr-shepherd poll`.
+Each non-terminal action is followed by another default poll-dispatcher invocation. Do not run `while true` or unbounded polling loops outside of Shepherd's poll dispatcher.
 
 Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with `/goal /pr-shepherd:pr-shepherd`; Codex users invoke it with `/goal $pr-shepherd`.
 
@@ -19,17 +19,17 @@ Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with
    /goal $pr-shepherd <PR>              # Codex
    ```
 
-   The skill resolves the PR number and runs poll:
+   The skill resolves the PR number and runs the default poll dispatcher:
 
    ```bash
-   pr-shepherd poll <PR>
+   pr-shepherd <PR> --interval 45s --timeout 4m
    ```
 
 2. **CLI emits an action with `## Instructions`**
    The output begins with `# PR #N [ACTION]` and ends with a numbered `## Instructions` block. The skill follows those instructions exactly.
 
 3. **Non-terminal actions** (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`)
-   The active goal follows the `## Instructions` and then invokes `pr-shepherd poll <PR>` again. `[FIX_CODE]` output must be handled before the next poll invocation.
+   The active goal follows the `## Instructions` and then invokes the skill again. `[FIX_CODE]` output must be handled before the next poll invocation.
 
 4. **Terminal actions**
    - `[CANCEL]` — PR is merged/closed, or the ready-delay has elapsed. Goal stops.


### PR DESCRIPTION
## Summary
- refresh README and CLI usage around the current poll-first workflow
- fix stale docs for GraphQL SHA polling, mark-ready, dynamic resolve mutations, and git/caller responsibilities
- document newer visibility surfaces like check annotations, edited first-look items, review summaries, approvals, clean, and log-file

## Tests
- npm run format:check