### PR TITLE
feat: add <!-- pr-shepherd --> marker to prevent self-reply loops

### DIFF
--- a/src/commands/resolve-mutate.mts
+++ b/src/commands/resolve-mutate.mts
@@ -9,6 +9,7 @@ import {
 } from "../comments/authors.mts";
 import { markReplySeen } from "../state/seen-comments.mts";
 import { threadTranscriptBody } from "../threads/transcript.mts";
+import { addPrShepherdMarker } from "../comments/marker.mts";
 import type { ResolveOptions } from "../types.mts";
 import type { ResolveCommandOptions } from "./resolve.mts";
 
@@ -69,6 +70,7 @@ export async function runResolveMutate(
   if (skippedHumanDismissals.length > 0) result.skippedHumanDismissals = skippedHumanDismissals;
   if (skippedNonHumanReplies.length > 0) result.skippedNonHumanReplies = skippedNonHumanReplies;
   if (opts.dismissMessage) {
+    const markedMessage = addPrShepherdMarker(opts.dismissMessage);
     await Promise.all(
       result.repliedThreads.map((id) => {
         const thread = threadById.get(id);
@@ -78,8 +80,8 @@ export async function runResolveMutate(
           { owner: repo.owner, repo: repo.name, pr: prNumber },
           id,
           previousBody,
-          threadTranscriptBody(thread, [opts.dismissMessage!]),
-          opts.dismissMessage!,
+          threadTranscriptBody(thread, [markedMessage]),
+          markedMessage,
         );
       }),
     );

--- a/src/commands/resolve.runresolvemutate-forwards-options.mock.test.mts
+++ b/src/commands/resolve.runresolvemutate-forwards-options.mock.test.mts
@@ -10,6 +10,7 @@ import {
   mockMarkReplySeen,
 } from "../../test-helpers/commands/resolve.test-support.mts";
 import { runResolveMutate } from "./resolve.mts";
+import { addPrShepherdMarker } from "../comments/marker.mts";
 
 registerHooks();
 
@@ -165,8 +166,8 @@ describe("runResolveMutate — forwards options", () => {
       { owner: "owner", repo: "repo", pr: 42 },
       "t-human",
       "top body",
-      "top body\n\n--- thread comment ---\n\ndone",
-      "done",
+      `top body\n\n--- thread comment ---\n\n${addPrShepherdMarker("done")}`,
+      addPrShepherdMarker("done"),
     );
   });
 });

--- a/src/comments/marker.mts
+++ b/src/comments/marker.mts
@@ -1,7 +1,7 @@
 const PR_SHEPHERD_MARKER = "<!-- pr-shepherd -->";
 
 export function hasPrShepherdMarker(body: string): boolean {
-  return body.includes(PR_SHEPHERD_MARKER);
+  return body.startsWith(PR_SHEPHERD_MARKER);
 }
 
 export function addPrShepherdMarker(body: string): string {

--- a/src/comments/marker.mts
+++ b/src/comments/marker.mts
@@ -1,4 +1,4 @@
-export const PR_SHEPHERD_MARKER = "<!-- pr-shepherd -->";
+const PR_SHEPHERD_MARKER = "<!-- pr-shepherd -->";
 
 export function hasPrShepherdMarker(body: string): boolean {
   return body.includes(PR_SHEPHERD_MARKER);

--- a/src/comments/marker.mts
+++ b/src/comments/marker.mts
@@ -1,0 +1,9 @@
+export const PR_SHEPHERD_MARKER = "<!-- pr-shepherd -->";
+
+export function hasPrShepherdMarker(body: string): boolean {
+  return body.includes(PR_SHEPHERD_MARKER);
+}
+
+export function addPrShepherdMarker(body: string): string {
+  return `${PR_SHEPHERD_MARKER}\n${body}`;
+}

--- a/src/comments/marker.test.mts
+++ b/src/comments/marker.test.mts
@@ -8,8 +8,8 @@ describe("hasPrShepherdMarker", () => {
     expect(hasPrShepherdMarker(`${MARKER}\nsome reply`)).toBe(true);
   });
 
-  it("returns true when marker appears at the end", () => {
-    expect(hasPrShepherdMarker(`some text\n${MARKER}`)).toBe(true);
+  it("returns false when marker appears mid-body (not at start)", () => {
+    expect(hasPrShepherdMarker(`some text\n${MARKER}`)).toBe(false);
   });
 
   it("returns false when body has no marker", () => {

--- a/src/comments/marker.test.mts
+++ b/src/comments/marker.test.mts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { PR_SHEPHERD_MARKER, hasPrShepherdMarker, addPrShepherdMarker } from "./marker.mts";
+import { hasPrShepherdMarker, addPrShepherdMarker } from "./marker.mts";
+
+const MARKER = "<!-- pr-shepherd -->";
 
 describe("hasPrShepherdMarker", () => {
   it("returns true when body contains the marker", () => {
-    expect(hasPrShepherdMarker(`${PR_SHEPHERD_MARKER}\nsome reply`)).toBe(true);
+    expect(hasPrShepherdMarker(`${MARKER}\nsome reply`)).toBe(true);
   });
 
   it("returns true when marker appears at the end", () => {
-    expect(hasPrShepherdMarker(`some text\n${PR_SHEPHERD_MARKER}`)).toBe(true);
+    expect(hasPrShepherdMarker(`some text\n${MARKER}`)).toBe(true);
   });
 
   it("returns false when body has no marker", () => {
@@ -21,7 +23,7 @@ describe("hasPrShepherdMarker", () => {
 
 describe("addPrShepherdMarker", () => {
   it("prepends the marker followed by a newline", () => {
-    expect(addPrShepherdMarker("my reply")).toBe(`${PR_SHEPHERD_MARKER}\nmy reply`);
+    expect(addPrShepherdMarker("my reply")).toBe(`${MARKER}\nmy reply`);
   });
 
   it("resulting body contains the marker", () => {

--- a/src/comments/marker.test.mts
+++ b/src/comments/marker.test.mts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { PR_SHEPHERD_MARKER, hasPrShepherdMarker, addPrShepherdMarker } from "./marker.mts";
+
+describe("hasPrShepherdMarker", () => {
+  it("returns true when body contains the marker", () => {
+    expect(hasPrShepherdMarker(`${PR_SHEPHERD_MARKER}\nsome reply`)).toBe(true);
+  });
+
+  it("returns true when marker appears at the end", () => {
+    expect(hasPrShepherdMarker(`some text\n${PR_SHEPHERD_MARKER}`)).toBe(true);
+  });
+
+  it("returns false when body has no marker", () => {
+    expect(hasPrShepherdMarker("just a regular comment")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasPrShepherdMarker("")).toBe(false);
+  });
+});
+
+describe("addPrShepherdMarker", () => {
+  it("prepends the marker followed by a newline", () => {
+    expect(addPrShepherdMarker("my reply")).toBe(`${PR_SHEPHERD_MARKER}\nmy reply`);
+  });
+
+  it("resulting body contains the marker", () => {
+    const result = addPrShepherdMarker("some text");
+    expect(hasPrShepherdMarker(result)).toBe(true);
+  });
+
+  it("preserves the original message after the marker", () => {
+    const message = "multi\nline\nmessage";
+    const result = addPrShepherdMarker(message);
+    expect(result.endsWith(message)).toBe(true);
+  });
+});

--- a/src/comments/resolve.applyresolveoptions-mutations.mock.test.mts
+++ b/src/comments/resolve.applyresolveoptions-mutations.mock.test.mts
@@ -7,6 +7,7 @@ import {
   mockGraphql,
 } from "../../test-helpers/comments/resolve.test-support.mts";
 import { applyResolveOptions } from "./resolve.mts";
+import { addPrShepherdMarker } from "./marker.mts";
 
 registerHooks();
 
@@ -158,6 +159,24 @@ describe("applyResolveOptions — mutations", () => {
       "PRR_1: dismiss returned null",
       "Not dismissed: PRR_2 is a COMMENTED review. Use --minimize-comment-ids instead; --dismiss-review-ids is only for CHANGES_REQUESTED reviews.",
     ]);
+  });
+  it("prepends pr-shepherd marker to thread reply bodies", async () => {
+    await applyResolveOptions(1, REPO, {
+      replyThreadIds: ["t-1"],
+      dismissMessage: "Addressed in the latest commit.",
+    });
+    const doc = mockGraphql.mock.calls[0]?.[0] as string;
+    const markedBody = addPrShepherdMarker("Addressed in the latest commit.");
+    expect(doc).toContain(JSON.stringify(markedBody));
+  });
+  it("does not prepend pr-shepherd marker to dismiss review bodies", async () => {
+    await applyResolveOptions(1, REPO, {
+      dismissReviewIds: ["r-1"],
+      dismissMessage: "Addressed in the latest commit.",
+    });
+    const doc = mockGraphql.mock.calls[0]?.[0] as string;
+    expect(doc).toContain("dismissPullRequestReview");
+    expect(doc).not.toContain("<!-- pr-shepherd -->");
   });
   it("treats malformed commented-dismiss path entries as overlapping aliases for single dismiss attempts", async () => {
     mockGraphql.mockResolvedValueOnce({

--- a/src/comments/resolve.mts
+++ b/src/comments/resolve.mts
@@ -132,9 +132,9 @@ function buildBulkMutation(
   dismissMessage: string,
 ): string {
   const ops: string[] = [];
+  const replyBody = addPrShepherdMarker(dismissMessage);
 
   for (let i = 0; i < replyIds.length; i++) {
-    const replyBody = addPrShepherdMarker(dismissMessage);
     ops.push(
       `  p${i}: addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: ${JSON.stringify(replyIds[i])}, body: ${JSON.stringify(replyBody)} }) { comment { id } }`,
     );

--- a/src/comments/resolve.mts
+++ b/src/comments/resolve.mts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { graphqlWithRateLimit, type RepoInfo } from "../github/client.mts";
 import type { ResolveOptions } from "../types.mts";
+import { addPrShepherdMarker } from "./marker.mts";
 import {
   isRateLimitMessage,
   rateLimitFromError,
@@ -133,8 +134,9 @@ function buildBulkMutation(
   const ops: string[] = [];
 
   for (let i = 0; i < replyIds.length; i++) {
+    const replyBody = addPrShepherdMarker(dismissMessage);
     ops.push(
-      `  p${i}: addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: ${JSON.stringify(replyIds[i])}, body: ${JSON.stringify(dismissMessage)} }) { comment { id } }`,
+      `  p${i}: addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: ${JSON.stringify(replyIds[i])}, body: ${JSON.stringify(replyBody)} }) { comment { id } }`,
     );
   }
 

--- a/src/comments/thread-visibility.marker.test.mts
+++ b/src/comments/thread-visibility.marker.test.mts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { classifyThreadVisibility } from "./thread-visibility.mts";
+import { hashBody } from "../state/seen-comments.mts";
+import { addPrShepherdMarker } from "./marker.mts";
+import type { ReviewThread, ReviewThreadComment } from "../types.mts";
+
+function makeComment(
+  id: string,
+  body: string,
+  overrides: Partial<ReviewThreadComment> = {},
+): ReviewThreadComment {
+  return {
+    id,
+    isMinimized: false,
+    author: "reviewer",
+    authorType: "User",
+    body,
+    url: "",
+    createdAtUnix: 1,
+    ...overrides,
+  };
+}
+
+function makeThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    isMinimized: false,
+    path: "src/foo.mts",
+    line: 10,
+    startLine: null,
+    author: "reviewer",
+    authorType: "User",
+    body: "body",
+    url: "",
+    createdAtUnix: 1,
+    ...overrides,
+  };
+}
+
+describe("classifyThreadVisibility — pr-shepherd marker", () => {
+  it("suppresses active thread where the last comment has the marker", () => {
+    const thread = makeThread({
+      id: "t1",
+      comments: [
+        makeComment("c1", "reviewer comment"),
+        makeComment("c2", addPrShepherdMarker("addressed in latest commit")),
+      ],
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.activeThreads).toEqual([]);
+  });
+
+  it("surfaces active thread when a human replied after pr-shepherd", () => {
+    const thread = makeThread({
+      id: "t1",
+      comments: [
+        makeComment("c1", "reviewer comment"),
+        makeComment("c2", addPrShepherdMarker("addressed in latest commit")),
+        makeComment("c3", "thanks, looks good but also fix X", { author: "reviewer" }),
+      ],
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.activeThreads.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("surfaces the whole thread when re-surfaced after human reply", () => {
+    const thread = makeThread({
+      id: "t1",
+      comments: [
+        makeComment("c1", "reviewer comment"),
+        makeComment("c2", addPrShepherdMarker("addressed in latest commit")),
+        makeComment("c3", "thanks but also fix X"),
+      ],
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.activeThreads[0]?.comments).toHaveLength(3);
+  });
+
+  it("only surfaces re-surfaced thread once via seen-marker", () => {
+    const body1 = "reviewer comment";
+    const body2 = addPrShepherdMarker("addressed");
+    const body3 = "thanks but also fix X";
+    const transcript = [body1, body2, body3].join("\n\n--- thread comment ---\n\n");
+    const thread = makeThread({
+      id: "t1",
+      comments: [makeComment("c1", body1), makeComment("c2", body2), makeComment("c3", body3)],
+    });
+    const seenMap = new Map([["t1", { seenAt: 1000, bodyHash: hashBody(transcript) }]]);
+
+    const result = classifyThreadVisibility([thread], seenMap);
+
+    expect(result.activeThreads).toEqual([]);
+  });
+
+  it("suppresses outdated first-look thread ending with marker", () => {
+    const thread = makeThread({
+      id: "t1",
+      isOutdated: true,
+      comments: [
+        makeComment("c1", "reviewer comment"),
+        makeComment("c2", addPrShepherdMarker("addressed")),
+      ],
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.firstLookThreads).toEqual([]);
+  });
+
+  it("suppresses resolved first-look thread ending with marker", () => {
+    const thread = makeThread({
+      id: "t1",
+      isResolved: true,
+      comments: [
+        makeComment("c1", "reviewer comment"),
+        makeComment("c2", addPrShepherdMarker("addressed")),
+      ],
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.firstLookThreads).toEqual([]);
+  });
+
+  it("does not suppress resolution-only thread ending with marker", () => {
+    const thread = makeThread({
+      id: "t1",
+      isOutdated: true,
+      comments: [
+        makeComment("c1", "reviewer comment"),
+        makeComment("c2", addPrShepherdMarker("addressed")),
+      ],
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.resolutionOnlyThreads.map((t) => t.id)).toEqual(["t1"]);
+  });
+
+  it("suppresses active thread with only a body (no comments array) ending with marker", () => {
+    const thread = makeThread({
+      id: "t1",
+      body: addPrShepherdMarker("pr-shepherd started this thread"),
+      comments: undefined,
+    });
+
+    const result = classifyThreadVisibility([thread], new Map());
+
+    expect(result.activeThreads).toEqual([]);
+  });
+});

--- a/src/comments/thread-visibility.mts
+++ b/src/comments/thread-visibility.mts
@@ -1,6 +1,7 @@
 import { classifyItem, type SeenMarker } from "../state/seen-comments.mts";
 import { threadTranscriptBody } from "../threads/transcript.mts";
 import { isConfiguredBotAuthor, type NormalizedBotUsernames } from "./authors.mts";
+import { hasPrShepherdMarker } from "./marker.mts";
 import type { FirstLookThread, ReviewThread } from "../types.mts";
 
 interface ThreadVisibility {
@@ -8,6 +9,14 @@ interface ThreadVisibility {
   resolutionOnlyThreads: ReviewThread[];
   firstLookThreads: FirstLookThread[];
   toMarkSeen: ReviewThread[];
+}
+
+function threadEndedByShepherd(thread: ReviewThread): boolean {
+  const comments = thread.comments;
+  if (comments && comments.length > 0) {
+    return hasPrShepherdMarker(comments[comments.length - 1]!.body);
+  }
+  return hasPrShepherdMarker(thread.body);
 }
 
 function withEdited<T extends ReviewThread>(thread: T, edited: boolean): T {
@@ -28,6 +37,7 @@ function classifyFirstLookThread(
   seenMap: Map<string, SeenMarker>,
   firstLookStatus: FirstLookThread["firstLookStatus"],
 ): FirstLookThread | null {
+  if (threadEndedByShepherd(thread)) return null;
   const visible = classifyVisibleThread(thread, seenMap);
   if (visible === null) return null;
   return { ...visible, firstLookStatus };
@@ -42,6 +52,7 @@ export function classifyThreadVisibility(
   const activeThreads = unresolvedThreads
     .filter((t) => !t.isOutdated && !t.isMinimized)
     .flatMap((t) => {
+      if (threadEndedByShepherd(t)) return [];
       if (isConfiguredBotAuthor(t, botUsernames)) return [t];
       const visible = classifyVisibleThread(t, seenMap);
       return visible ? [visible] : [];


### PR DESCRIPTION
## Summary

- Adds `<!-- pr-shepherd -->` HTML comment marker to every thread reply pr-shepherd posts, making its comments identifiable regardless of author type or state file availability
- Suppresses active and first-look threads where the last comment has the marker — pr-shepherd already responded, so no new human activity to process
- Threads are re-surfaced in full when a human replies after pr-shepherd (last comment no longer has the marker)
- Updates `markReplySeen` to hash the marked body so the file-based seen-marker system stays consistent with the actual posted content
- Adds `src/comments/marker.mts` with `hasPrShepherdMarker` / `addPrShepherdMarker` utilities

Fixes the infinite self-reply loop seen in https://github.com/jonathanong/no-mistakes/pull/256.

## Test plan

- [ ] `npx vitest run src/comments/marker.test.mts` — marker utility tests
- [ ] `npx vitest run src/comments/thread-visibility.marker.test.mts` — marker-based thread suppression/re-surfacing
- [ ] `npx vitest run` — full suite passes (1141 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- **[Sourcery review PRR_kwDOSGizTs8AAAABA8uAGg](https://github.com/jonathanong/pr-shepherd/pull/253)** — Addressed the `includes` vs `startsWith` suggestion. Since pr-shepherd always prepends the marker, `startsWith` is strictly more precise: it avoids false positives if the marker string happens to appear mid-body in human-written text. Changed `hasPrShepherdMarker` to use `startsWith` and updated the corresponding test.
- **[Codex thread PRRT_kwDOSGizTs6EnxWl](https://github.com/jonathanong/pr-shepherd/pull/253#discussion_r3299848525)** — Outdated. Codex reviewed commit `89ba742473` which used `includes`; we already switched to `startsWith` in the refactor commit (`a3eec83`) before Codex's review landed.