### PR TITLE
feat: validate --resolve-thread-ids and --require-sha formats; fix seen-marker for auto-minimized comments

### DIFF
--- a/src/cli-parser.main-resolve.mock.test.mts
+++ b/src/cli-parser.main-resolve.mock.test.mts
@@ -22,11 +22,7 @@ describe("main — resolve", () => {
     ["--fetch", ["--fetch"], "--fetch has been removed"],
     ["only --message", ["--message", "Done"], "an action flag is required"],
     ["empty action ID list", ["--resolve-thread-ids", ""], "an action flag is required"],
-    [
-      "short SHA",
-      ["--resolve-thread-ids", "PRRT_1", "--require-sha", "abc1234"],
-      "40-character",
-    ],
+    ["short SHA", ["--resolve-thread-ids", "PRRT_1", "--require-sha", "abc1234"], "40-character"],
   ])("errors for %s", async (_label, args, message) => {
     await expectResolveError(args, message);
   });

--- a/src/cli-parser.main-resolve.mock.test.mts
+++ b/src/cli-parser.main-resolve.mock.test.mts
@@ -22,8 +22,49 @@ describe("main — resolve", () => {
     ["--fetch", ["--fetch"], "--fetch has been removed"],
     ["only --message", ["--message", "Done"], "an action flag is required"],
     ["empty action ID list", ["--resolve-thread-ids", ""], "an action flag is required"],
+    [
+      "short SHA",
+      ["--resolve-thread-ids", "PRRT_1", "--require-sha", "abc1234"],
+      "40-character",
+    ],
   ])("errors for %s", async (_label, args, message) => {
     await expectResolveError(args, message);
+  });
+
+  it("warns on PRRC_ thread IDs but still calls runResolveMutate", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      repliedThreads: [],
+      resolvedThreads: ["PRRC_1"],
+      minimizedComments: [],
+      dismissedReviews: [],
+      errors: [],
+    });
+    await main(["node", "shepherd", "resolve", "42", "--resolve-thread-ids", "PRRC_1"]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("comment IDs (PRRC_*)"));
+    expect(mockRunResolveMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a valid 40-char SHA without warnings", async () => {
+    mockRunResolveMutate.mockResolvedValue({
+      repliedThreads: [],
+      resolvedThreads: ["PRRT_1"],
+      minimizedComments: [],
+      dismissedReviews: [],
+      errors: [],
+    });
+    const sha = "a".repeat(40);
+    await main([
+      "node",
+      "shepherd",
+      "resolve",
+      "42",
+      "--resolve-thread-ids",
+      "PRRT_1",
+      "--require-sha",
+      sha,
+    ]);
+    expect(mockRunResolveMutate).toHaveBeenCalledTimes(1);
+    expect(stderrSpy).not.toHaveBeenCalled();
   });
 
   it("calls runResolveMutate when --resolve-thread-ids is given", async () => {

--- a/src/cli-parser.mts
+++ b/src/cli-parser.mts
@@ -37,6 +37,7 @@ import {
   handleMarkFilesAsViewed,
 } from "./cli/handlers.mts";
 import { handlePoll } from "./cli/poll-handler.mts";
+import { warnPrrcThreadIds, validateRequireSha } from "./cli/resolve-validators.mts";
 import { setupLog } from "./log/setup.mts";
 
 // ---------------------------------------------------------------------------
@@ -151,6 +152,9 @@ async function handleResolve(args: string[]): Promise<void> {
   const dismissReviewIds = parseList(getFlag(extra, "--dismiss-review-ids"));
   const dismissMessage = getFlag(extra, "--message") ?? undefined;
   const requireSha = getFlag(extra, "--require-sha") ?? undefined;
+
+  warnPrrcThreadIds(resolveThreadIds);
+  if (!validateRequireSha(requireSha)) return;
 
   if (hasFlag(extra, "--fetch")) {
     process.stderr.write(

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -10,14 +10,16 @@ Usage:
                             [--require-sha SHA] [--format text|json]
 
 Flags:
-  --resolve-thread-ids <ids>      Comma-separated review thread IDs to resolve.
+  --resolve-thread-ids <ids>      Comma-separated review thread IDs (PRRT_*) to resolve.
                                   Human-authored thread IDs are skipped; use --reply-thread-ids.
+                                  Note: comment IDs (PRRC_*) from gh api are not thread IDs and will fail.
   --reply-thread-ids <ids>        Comma-separated human review thread IDs to reply to.
   --minimize-comment-ids <ids>    Comma-separated issue/review comment IDs to minimize.
   --dismiss-review-ids <ids>      Comma-separated CHANGES_REQUESTED review IDs to dismiss.
   --message <text>                Reply/dismiss message. Required with --reply-thread-ids
                                   or --dismiss-review-ids.
   --require-sha <sha>             Wait until GitHub reports this PR head SHA before mutating.
+                                  Must be a full 40-character hex SHA. Use $(git rev-parse HEAD).
   --format text|json              Output format. Default: text.
   --help, -h                      Print this help and exit before GitHub I/O.
 

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -19,7 +19,7 @@ Flags:
   --message <text>                Reply/dismiss message. Required with --reply-thread-ids
                                   or --dismiss-review-ids.
   --require-sha <sha>             Wait until GitHub reports this PR head SHA before mutating.
-                                  Must be a full 40-character hex SHA. Use $(git rev-parse HEAD).
+                                  Must be a full 40-character lowercase hex SHA. Use $(git rev-parse HEAD).
   --format text|json              Output format. Default: text.
   --help, -h                      Print this help and exit before GitHub I/O.
 

--- a/src/cli/resolve-validators.mts
+++ b/src/cli/resolve-validators.mts
@@ -1,0 +1,19 @@
+export function warnPrrcThreadIds(ids: string[]): string[] {
+  const prrcIds = ids.filter((id) => id.startsWith("PRRC_"));
+  if (prrcIds.length > 0) {
+    process.stderr.write(
+      `pr-shepherd: resolve: warning: --resolve-thread-ids contains comment IDs (PRRC_*) instead of thread IDs (PRRT_*): ${prrcIds.join(", ")}. The resolveReviewThread mutation requires PRRT_* thread IDs. Run a GraphQL query for pullRequest.reviewThreads to get the correct IDs.\n`,
+    );
+  }
+  return prrcIds;
+}
+
+export function validateRequireSha(sha: string | undefined): boolean {
+  if (sha === undefined) return true;
+  if (/^[0-9a-f]{40}$/.test(sha)) return true;
+  process.stderr.write(
+    `pr-shepherd: resolve: --require-sha must be a full 40-character lowercase hex SHA, got "${sha}". Short SHAs will never match GitHub's headRefOid. Use $(git rev-parse HEAD) to get the full SHA.\n`,
+  );
+  process.exitCode = 1;
+  return false;
+}

--- a/src/cli/resolve-validators.test.mts
+++ b/src/cli/resolve-validators.test.mts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { warnPrrcThreadIds, validateRequireSha } from "./resolve-validators.mts";
+
+describe("warnPrrcThreadIds", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it("returns empty and does not warn for an empty list", () => {
+    expect(warnPrrcThreadIds([])).toEqual([]);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns empty and does not warn for PRRT_ IDs only", () => {
+    expect(warnPrrcThreadIds(["PRRT_abc", "PRRT_def"])).toEqual([]);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns PRRC_ IDs and warns on stderr", () => {
+    const result = warnPrrcThreadIds(["PRRT_1", "PRRC_2", "PRRC_3"]);
+    expect(result).toEqual(["PRRC_2", "PRRC_3"]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("PRRC_2, PRRC_3"));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("PRRC_*"));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("PRRT_*"));
+  });
+
+  it("warns when all IDs are PRRC_", () => {
+    expect(warnPrrcThreadIds(["PRRC_1"])).toEqual(["PRRC_1"]);
+    expect(stderrSpy).toHaveBeenCalled();
+  });
+});
+
+describe("validateRequireSha", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    process.exitCode = undefined;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+  afterEach(() => {
+    process.exitCode = undefined;
+    stderrSpy.mockRestore();
+  });
+
+  it("returns true for undefined (flag absent)", () => {
+    expect(validateRequireSha(undefined)).toBe(true);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns true for a valid 40-char lowercase hex SHA", () => {
+    expect(validateRequireSha("a".repeat(40))).toBe(true);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("rejects a 7-char short SHA", () => {
+    expect(validateRequireSha("abc1234")).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("40-character"));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("abc1234"));
+  });
+
+  it("rejects a 40-char uppercase hex string", () => {
+    expect(validateRequireSha("A".repeat(40))).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("40-character"));
+  });
+
+  it("rejects a 40-char string with non-hex characters", () => {
+    expect(validateRequireSha("g".repeat(40))).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects a 39-char string", () => {
+    expect(validateRequireSha("a".repeat(39))).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects an empty string", () => {
+    expect(validateRequireSha("")).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/src/commands/check.runcheck-first-look-comments.mock.test.mts
+++ b/src/commands/check.runcheck-first-look-comments.mock.test.mts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  registerHooks,
+  BASE_OPTS,
+  defaultConfig,
+  makeBatchData,
+  mockFetchPrBatch,
+  mockLoadConfig,
+  mockLoadSeenMap,
+  mockMarkSeen,
+  makeComment,
+} from "../../test-helpers/commands/check.test-support.mts";
+import { hashBody } from "../state/seen-comments.mts";
+import { runCheck } from "./check.mts";
+
+registerHooks();
+
+describe("runCheck — first-look comments", () => {
+  it("surfaces unseen minimized comment in comments.firstLook", async () => {
+    const minimized = makeComment({ id: "c-min", isMinimized: true });
+    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [minimized] }) });
+    mockLoadSeenMap.mockResolvedValue(new Map());
+
+    const report = await runCheck(BASE_OPTS);
+    expect(report.comments.firstLook).toHaveLength(1);
+    expect(report.comments.firstLook[0]?.firstLookStatus).toBe("minimized");
+  });
+  it("marker-gates visible comments excluded by minimizeComments policy", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeComments = "bots";
+    mockLoadConfig.mockReturnValue(cfg);
+    const human = makeComment({
+      id: "c-human",
+      author: "alice",
+      authorType: "User",
+      body: "please consider this",
+    });
+    const bot = makeComment({
+      id: "c-bot",
+      author: "app",
+      authorType: "Bot",
+      body: "automated note",
+    });
+    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [human, bot] }) });
+    mockLoadSeenMap.mockResolvedValue(new Map());
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.comments.actionable.map((c) => c.id)).toEqual(["c-human", "c-bot"]);
+    expect(report.comments.minimizeIds).toEqual(["c-bot"]);
+    expect(mockMarkSeen).toHaveBeenCalledWith(
+      expect.any(Object),
+      "c-human",
+      "please consider this",
+    );
+    expect(mockMarkSeen).toHaveBeenCalledWith(expect.any(Object), "c-bot", "automated note");
+  });
+  it("suppresses minimized bot comment that was already seen as actionable", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeComments = "bots";
+    mockLoadConfig.mockReturnValue(cfg);
+    const bot = makeComment({
+      id: "c-bot",
+      author: "app",
+      authorType: "Bot",
+      body: "automated note",
+      isMinimized: true,
+    });
+    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [bot] }) });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([["c-bot", { seenAt: 1000, bodyHash: hashBody("automated note") }]]),
+    );
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.comments.firstLook).toEqual([]);
+  });
+  it("suppresses unchanged visible comments excluded by minimizeComments policy", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeComments = "bots";
+    mockLoadConfig.mockReturnValue(cfg);
+    const human = makeComment({
+      id: "c-human",
+      authorType: "User",
+      body: "already seen",
+    });
+    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [human] }) });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([["c-human", { seenAt: 1000, bodyHash: hashBody("already seen") }]]),
+    );
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.comments.actionable).toEqual([]);
+    expect(report.comments.minimizeIds).toEqual([]);
+  });
+  it("re-surfaces edited visible comments excluded by minimizeComments policy", async () => {
+    const cfg = defaultConfig();
+    cfg.iterate.minimizeComments = "none";
+    mockLoadConfig.mockReturnValue(cfg);
+    const comment = makeComment({ id: "c-human", authorType: "User", body: "new text" });
+    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [comment] }) });
+    mockLoadSeenMap.mockResolvedValue(
+      new Map([["c-human", { seenAt: 1000, bodyHash: hashBody("old text") }]]),
+    );
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.comments.actionable).toMatchObject([{ id: "c-human", edited: true }]);
+    expect(report.comments.minimizeIds).toEqual([]);
+    expect(mockMarkSeen).toHaveBeenCalledWith(expect.any(Object), "c-human", "new text");
+  });
+});

--- a/src/commands/check.runcheck-first-look-items.mock.test.mts
+++ b/src/commands/check.runcheck-first-look-items.mock.test.mts
@@ -2,15 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   registerHooks,
   BASE_OPTS,
-  defaultConfig,
   makeBatchData,
   mockAutoResolveOutdated,
   mockFetchPrBatch,
-  mockLoadConfig,
   mockLoadSeenMap,
   mockMarkSeen,
   makeThread,
-  makeComment,
 } from "../../test-helpers/commands/check.test-support.mts";
 import { hashBody } from "../state/seen-comments.mts";
 import { runCheck } from "./check.mts";
@@ -21,7 +18,6 @@ describe("runCheck — first-look items", () => {
   it("surfaces unseen outdated thread in threads.firstLook", async () => {
     const outdated = makeThread({ id: "t-outdated", isOutdated: true });
     mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ reviewThreads: [outdated] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
     const report = await runCheck(BASE_OPTS);
     expect(report.threads.firstLook).toHaveLength(1);
     expect(report.threads.firstLook[0]?.id).toBe("t-outdated");
@@ -31,7 +27,6 @@ describe("runCheck — first-look items", () => {
   it("surfaces unseen active thread in threads.actionable and marks it seen", async () => {
     const active = makeThread({ id: "t-active", body: "active feedback" });
     mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ reviewThreads: [active] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
 
     const report = await runCheck(BASE_OPTS);
 
@@ -68,7 +63,6 @@ describe("runCheck — first-look items", () => {
   it("does not auto-resolve outdated threads during check", async () => {
     const outdated = makeThread({ id: "t-auto", isOutdated: true });
     mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ reviewThreads: [outdated] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
     mockAutoResolveOutdated.mockResolvedValue({ resolved: ["t-auto"], errors: [] });
     const report = await runCheck({ ...BASE_OPTS, autoResolve: true });
     expect(mockAutoResolveOutdated).not.toHaveBeenCalled();
@@ -78,7 +72,6 @@ describe("runCheck — first-look items", () => {
   it("surfaces unseen resolved thread in threads.firstLook", async () => {
     const resolved = makeThread({ id: "t-resolved", isResolved: true });
     mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ reviewThreads: [resolved] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
     const report = await runCheck(BASE_OPTS);
     expect(report.threads.firstLook).toHaveLength(1);
     expect(report.threads.firstLook[0]?.firstLookStatus).toBe("resolved");
@@ -86,84 +79,9 @@ describe("runCheck — first-look items", () => {
   it("surfaces unseen minimized thread in threads.firstLook", async () => {
     const minimized = makeThread({ id: "t-minimized", isMinimized: true });
     mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ reviewThreads: [minimized] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
     const report = await runCheck(BASE_OPTS);
     expect(report.threads.firstLook).toHaveLength(1);
     expect(report.threads.firstLook[0]?.firstLookStatus).toBe("minimized");
-  });
-  it("surfaces unseen minimized comment in comments.firstLook", async () => {
-    const minimized = makeComment({ id: "c-min", isMinimized: true });
-    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [minimized] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
-
-    const report = await runCheck(BASE_OPTS);
-    expect(report.comments.firstLook).toHaveLength(1);
-    expect(report.comments.firstLook[0]?.firstLookStatus).toBe("minimized");
-  });
-  it("marker-gates visible comments excluded by minimizeComments policy", async () => {
-    const cfg = defaultConfig();
-    cfg.iterate.minimizeComments = "bots";
-    mockLoadConfig.mockReturnValue(cfg);
-    const human = makeComment({
-      id: "c-human",
-      author: "alice",
-      authorType: "User",
-      body: "please consider this",
-    });
-    const bot = makeComment({
-      id: "c-bot",
-      author: "app",
-      authorType: "Bot",
-      body: "automated note",
-    });
-    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [human, bot] }) });
-    mockLoadSeenMap.mockResolvedValue(new Map());
-
-    const report = await runCheck(BASE_OPTS);
-
-    expect(report.comments.actionable.map((c) => c.id)).toEqual(["c-human", "c-bot"]);
-    expect(report.comments.minimizeIds).toEqual(["c-bot"]);
-    expect(mockMarkSeen).toHaveBeenCalledWith(
-      expect.any(Object),
-      "c-human",
-      "please consider this",
-    );
-    expect(mockMarkSeen).not.toHaveBeenCalledWith(expect.any(Object), "c-bot", expect.anything());
-  });
-  it("suppresses unchanged visible comments excluded by minimizeComments policy", async () => {
-    const cfg = defaultConfig();
-    cfg.iterate.minimizeComments = "bots";
-    mockLoadConfig.mockReturnValue(cfg);
-    const human = makeComment({
-      id: "c-human",
-      authorType: "User",
-      body: "already seen",
-    });
-    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [human] }) });
-    mockLoadSeenMap.mockResolvedValue(
-      new Map([["c-human", { seenAt: 1000, bodyHash: hashBody("already seen") }]]),
-    );
-
-    const report = await runCheck(BASE_OPTS);
-
-    expect(report.comments.actionable).toEqual([]);
-    expect(report.comments.minimizeIds).toEqual([]);
-  });
-  it("re-surfaces edited visible comments excluded by minimizeComments policy", async () => {
-    const cfg = defaultConfig();
-    cfg.iterate.minimizeComments = "none";
-    mockLoadConfig.mockReturnValue(cfg);
-    const comment = makeComment({ id: "c-human", authorType: "User", body: "new text" });
-    mockFetchPrBatch.mockResolvedValue({ data: makeBatchData({ comments: [comment] }) });
-    mockLoadSeenMap.mockResolvedValue(
-      new Map([["c-human", { seenAt: 1000, bodyHash: hashBody("old text") }]]),
-    );
-
-    const report = await runCheck(BASE_OPTS);
-
-    expect(report.comments.actionable).toMatchObject([{ id: "c-human", edited: true }]);
-    expect(report.comments.minimizeIds).toEqual([]);
-    expect(mockMarkSeen).toHaveBeenCalledWith(expect.any(Object), "c-human", "new text");
   });
   it("suppresses already-seen items (unchanged hash)", async () => {
     const outdated = makeThread({ id: "t-outdated", isOutdated: true, body: "fix this" });

--- a/src/comments/visible-comments.mts
+++ b/src/comments/visible-comments.mts
@@ -23,7 +23,7 @@ export function classifyVisibleComments(
     if (shouldMinimizeAuthor(c.authorType, minimizeComments, c.author, botUsernames)) {
       actionable.push(c);
       minimizeIds.push(c.id);
-      toMarkSeen.push(c);
+      toMarkSeen.push(c); // prevents re-surfacing as first-look after GitHub marks it minimized
       continue;
     }
     const cls = classifyItem(c.id, c.body, seenMap);

--- a/src/comments/visible-comments.mts
+++ b/src/comments/visible-comments.mts
@@ -23,6 +23,7 @@ export function classifyVisibleComments(
     if (shouldMinimizeAuthor(c.authorType, minimizeComments, c.author, botUsernames)) {
       actionable.push(c);
       minimizeIds.push(c.id);
+      toMarkSeen.push(c);
       continue;
     }
     const cls = classifyItem(c.id, c.body, seenMap);

--- a/src/comments/visible-comments.test.mts
+++ b/src/comments/visible-comments.test.mts
@@ -18,17 +18,17 @@ function makeComment(overrides: Partial<PrComment> = {}): PrComment {
 }
 
 describe("classifyVisibleComments", () => {
-  it("queues auto-minimized comments without marking them seen", () => {
+  it("queues auto-minimized comments and marks them seen", () => {
     const comment = makeComment({ id: "c-bot", authorType: "Bot" });
 
     const result = classifyVisibleComments([comment], new Map(), "bots");
 
     expect(result.actionable).toEqual([comment]);
     expect(result.minimizeIds).toEqual(["c-bot"]);
-    expect(result.toMarkSeen).toEqual([]);
+    expect(result.toMarkSeen).toEqual([comment]);
   });
 
-  it("queues configured bot comments without marking them seen", () => {
+  it("queues configured bot comments and marks them seen", () => {
     const comment = makeComment({
       id: "c-bot",
       author: "CodeRabbitAI",
@@ -44,7 +44,7 @@ describe("classifyVisibleComments", () => {
 
     expect(result.actionable).toEqual([comment]);
     expect(result.minimizeIds).toEqual(["c-bot"]);
-    expect(result.toMarkSeen).toEqual([]);
+    expect(result.toMarkSeen).toEqual([comment]);
   });
 
   it("returns new non-auto-minimized comments and marks them seen", () => {

--- a/test-helpers/commands/check.test-support.mts
+++ b/test-helpers/commands/check.test-support.mts
@@ -161,6 +161,7 @@ export function registerHooks(): void {
     mockGetMergeableState.mockResolvedValue({ mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" });
     mockFetchStartupFailureChecks.mockResolvedValue([]);
     mockFetchCheckRunAnnotations.mockResolvedValue([]);
+    mockLoadSeenMap.mockResolvedValue(new Map());
   });
 }
 


### PR DESCRIPTION
## Summary

**Thread ID / SHA validation:**
- Warn on stderr when `--resolve-thread-ids` receives `PRRC_*` comment IDs instead of `PRRT_*` thread IDs — the `resolveReviewThread` mutation requires thread IDs
- Hard-fail (exit 1) when `--require-sha` receives a non-40-char SHA — short SHAs can never match GitHub's `headRefOid` via strict equality, causing a silent 18-second timeout with a misleading error
- Update `--help` text for both flags to document format requirements

**Seen-marker fix:**
- Bot comments matched by the `minimizeComments` policy were surfaced as actionable but never written to the seen-marker store, causing them to re-appear as first-look items with `[status: minimized]` on the next fetch after `resolve --minimize-comment-ids` ran
- Fix: add these comments to `toMarkSeen` in `classifyVisibleComments` so a seen marker is written on first display
- Split the 220-line `check.runcheck-first-look-items` test file into two files (threads vs comments) to stay under the 200-line lint limit

## Test plan

- [ ] Unit tests for `warnPrrcThreadIds` and `validateRequireSha` in `src/cli/resolve-validators.test.mts`
- [ ] Integration tests in `src/cli-parser.main-resolve.mock.test.mts`: short SHA rejected, PRRC_ warning but resolve still runs, valid 40-char SHA accepted
- [ ] New test "suppresses minimized bot comment that was already seen as actionable" covers the seen-marker regression
- [ ] Full test suite: 241 files, 1155 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- 2026-05-25: [Gemini quota warning](https://github.com/jonathanong/pr-shepherd/pull/254#issuecomment-4538178819) — quota limit notice, no code finding. Minimized.
- 2026-05-25: [CodeRabbit rate-limit comment](https://github.com/jonathanong/pr-shepherd/pull/254#issuecomment-4538179056) — rate limit notice, no code finding. Minimized.
- 2026-05-25: [Sourcery reviewer guide](https://github.com/jonathanong/pr-shepherd/pull/254#issuecomment-4538180075) — automated reviewer guide, no action required. Minimized.
- 2026-05-25: Sourcery review `PRR_kwDOSGizTs8AAAABA9X3ow` — addressed both findings: added `mockLoadSeenMap.mockResolvedValue(new Map())` reset to `registerHooks` beforeEach (vi.clearAllMocks() doesn't reset implementations), and added a brief inline comment for the seen-marker invariant. Minimized.
- 2026-05-25: [SonarQube quality gate passed](https://github.com/jonathanong/pr-shepherd/pull/254#issuecomment-4539103231) — quality gate passed, no code finding. Minimized.
- 2026-05-25: Copilot review `PRR_kwDOSGizTs8AAAABA97zzw` — [thread](https://github.com/jonathanong/pr-shepherd/pull/254#discussion_r3300779629) correct: help text said "hex SHA" but validator enforces lowercase only. Fixed to "lowercase hex SHA". Resolved.