### PR TITLE
fix: dedup changesRequestedReviews by latest-review-per-author

### DIFF
--- a/src/github/batch-parser-helpers.mts
+++ b/src/github/batch-parser-helpers.mts
@@ -34,7 +34,9 @@ export function extractCheckRunSummary(
 
 export function latestApprovedLogins(latest: Array<{ login: string; state: string }>): Set<string> {
   return new Set(
-    latest.filter((r) => r.state === "APPROVED" || r.state === "DISMISSED").map((r) => r.login),
+    latest
+      .filter((r) => r.login !== "unknown" && (r.state === "APPROVED" || r.state === "DISMISSED"))
+      .map((r) => r.login),
   );
 }
 

--- a/src/github/batch-parser-helpers.mts
+++ b/src/github/batch-parser-helpers.mts
@@ -32,6 +32,12 @@ export function extractCheckRunSummary(
   return firstLine || undefined;
 }
 
+export function latestApprovedLogins(latest: Array<{ login: string; state: string }>): Set<string> {
+  return new Set(
+    latest.filter((r) => r.state === "APPROVED" || r.state === "DISMISSED").map((r) => r.login),
+  );
+}
+
 export function mapStatusContextState(state: string): {
   status: CheckStatus;
   conclusion: CheckConclusion;

--- a/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
+++ b/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
@@ -10,9 +10,15 @@ import { fetchPrBatch } from "./batch.mts";
 
 registerHooks();
 
+async function fetchWithConfig(overrides: Parameters<typeof makeRawPr>[0]) {
+  mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(makeRawPr(overrides)));
+  const { data } = await fetchPrBatch(42, REPO);
+  return data;
+}
+
 describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () => {
   it("drops a CR review when the same author's latest review is APPROVED", async () => {
-    const pr = makeRawPr({
+    const data = await fetchWithConfig({
       latestReviews: {
         nodes: [{ author: { __typename: "Bot", login: "coderabbitai[bot]" }, state: "APPROVED" }],
       },
@@ -27,13 +33,11 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
         ],
       },
     });
-    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
-    const { data } = await fetchPrBatch(42, REPO);
     expect(data.changesRequestedReviews).toHaveLength(0);
   });
 
   it("drops a CR review when the same author's latest review is DISMISSED", async () => {
-    const pr = makeRawPr({
+    const data = await fetchWithConfig({
       latestReviews: {
         nodes: [{ author: { __typename: "User", login: "alice" }, state: "DISMISSED" }],
       },
@@ -42,13 +46,11 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
         nodes: [{ id: "PRR_CR_2", author: { __typename: "User", login: "alice" }, body: "stale" }],
       },
     });
-    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
-    const { data } = await fetchPrBatch(42, REPO);
     expect(data.changesRequestedReviews).toHaveLength(0);
   });
 
   it("keeps a CR review when the author has no subsequent APPROVED/DISMISSED review", async () => {
-    const pr = makeRawPr({
+    const data = await fetchWithConfig({
       latestReviews: {
         nodes: [{ author: { __typename: "User", login: "bob" }, state: "CHANGES_REQUESTED" }],
       },
@@ -59,14 +61,12 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
         ],
       },
     });
-    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
-    const { data } = await fetchPrBatch(42, REPO);
     expect(data.changesRequestedReviews).toHaveLength(1);
-    expect(data.changesRequestedReviews[0]!.id).toBe("PRR_CR_3");
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_3");
   });
 
   it("keeps the CR from one author and drops the CR from another who later approved", async () => {
-    const pr = makeRawPr({
+    const data = await fetchWithConfig({
       latestReviews: {
         nodes: [
           { author: { __typename: "User", login: "alice" }, state: "APPROVED" },
@@ -85,9 +85,21 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
         ],
       },
     });
-    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
-    const { data } = await fetchPrBatch(42, REPO);
     expect(data.changesRequestedReviews).toHaveLength(1);
-    expect(data.changesRequestedReviews[0]!.id).toBe("PRR_CR_B");
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_B");
+  });
+
+  it("keeps CR reviews from null-author accounts even if another null-author later approved", async () => {
+    const data = await fetchWithConfig({
+      latestReviews: {
+        nodes: [{ author: null, state: "APPROVED" }],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "PRR_CR_NULL", author: null, body: "needs work" }],
+      },
+    });
+    expect(data.changesRequestedReviews).toHaveLength(1);
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_NULL");
   });
 });

--- a/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
+++ b/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
@@ -102,4 +102,58 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
     expect(data.changesRequestedReviews).toHaveLength(1);
     expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_NULL");
   });
+
+  it("keeps a CR review when the same author's latest review is PENDING", async () => {
+    const data = await fetchWithConfig({
+      latestReviews: {
+        nodes: [{ author: { __typename: "Bot", login: "copilot[bot]" }, state: "PENDING" }],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          {
+            id: "PRR_CR_PEND",
+            author: { __typename: "Bot", login: "copilot[bot]" },
+            body: "issues",
+          },
+        ],
+      },
+    });
+    expect(data.changesRequestedReviews).toHaveLength(1);
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_PEND");
+  });
+
+  it("keeps a CR review when the same author's latest review is COMMENTED", async () => {
+    const data = await fetchWithConfig({
+      latestReviews: {
+        nodes: [{ author: { __typename: "User", login: "alice" }, state: "COMMENTED" }],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          {
+            id: "PRR_CR_CMT",
+            author: { __typename: "User", login: "alice" },
+            body: "still unresolved",
+          },
+        ],
+      },
+    });
+    expect(data.changesRequestedReviews).toHaveLength(1);
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_CMT");
+  });
+
+  it("keeps a CR review when the author does not appear in latestReviews", async () => {
+    const data = await fetchWithConfig({
+      latestReviews: { nodes: [] },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          { id: "PRR_CR_ONLY", author: { __typename: "User", login: "bob" }, body: "unaddressed" },
+        ],
+      },
+    });
+    expect(data.changesRequestedReviews).toHaveLength(1);
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_ONLY");
+  });
 });

--- a/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
+++ b/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  registerHooks,
+  REPO,
+  makeRawPr,
+  makeResponse,
+  mockGraphqlWithRateLimit,
+} from "../../test-helpers/github/batch-parsers.test-support.mts";
+import { fetchPrBatch } from "./batch.mts";
+
+registerHooks();
+
+describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () => {
+  it("drops a CR review when the same author's latest review is APPROVED", async () => {
+    const pr = makeRawPr({
+      latestReviews: {
+        nodes: [{ author: { __typename: "Bot", login: "coderabbitai[bot]" }, state: "APPROVED" }],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          {
+            id: "PRR_CR_1",
+            author: { __typename: "Bot", login: "coderabbitai[bot]" },
+            body: "please fix this",
+          },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.changesRequestedReviews).toHaveLength(0);
+  });
+
+  it("drops a CR review when the same author's latest review is DISMISSED", async () => {
+    const pr = makeRawPr({
+      latestReviews: {
+        nodes: [{ author: { __typename: "User", login: "alice" }, state: "DISMISSED" }],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [{ id: "PRR_CR_2", author: { __typename: "User", login: "alice" }, body: "stale" }],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.changesRequestedReviews).toHaveLength(0);
+  });
+
+  it("keeps a CR review when the author has no subsequent APPROVED/DISMISSED review", async () => {
+    const pr = makeRawPr({
+      latestReviews: {
+        nodes: [{ author: { __typename: "User", login: "bob" }, state: "CHANGES_REQUESTED" }],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          { id: "PRR_CR_3", author: { __typename: "User", login: "bob" }, body: "fix the tests" },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.changesRequestedReviews).toHaveLength(1);
+    expect(data.changesRequestedReviews[0]!.id).toBe("PRR_CR_3");
+  });
+
+  it("keeps the CR from one author and drops the CR from another who later approved", async () => {
+    const pr = makeRawPr({
+      latestReviews: {
+        nodes: [
+          { author: { __typename: "User", login: "alice" }, state: "APPROVED" },
+          { author: { __typename: "User", login: "bob" }, state: "CHANGES_REQUESTED" },
+        ],
+      },
+      changesRequestedReviews: {
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+        nodes: [
+          { id: "PRR_CR_A", author: { __typename: "User", login: "alice" }, body: "old cr" },
+          {
+            id: "PRR_CR_B",
+            author: { __typename: "User", login: "bob" },
+            body: "still needs work",
+          },
+        ],
+      },
+    });
+    mockGraphqlWithRateLimit.mockResolvedValue(makeResponse(pr));
+    const { data } = await fetchPrBatch(42, REPO);
+    expect(data.changesRequestedReviews).toHaveLength(1);
+    expect(data.changesRequestedReviews[0]!.id).toBe("PRR_CR_B");
+  });
+});

--- a/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
+++ b/src/github/batch-parsers.changesrequested-dedup.mock.test.mts
@@ -16,53 +16,52 @@ async function fetchWithConfig(overrides: Parameters<typeof makeRawPr>[0]) {
   return data;
 }
 
+const noPage = { pageInfo: { hasPreviousPage: false, startCursor: null } };
+
 describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () => {
-  it("drops a CR review when the same author's latest review is APPROVED", async () => {
+  it.each([
+    ["APPROVED", "coderabbitai[bot]", "Bot"],
+    ["DISMISSED", "alice", "User"],
+  ] as const)("drops CR when same author's latest review is %s", async (state, login, typename) => {
     const data = await fetchWithConfig({
-      latestReviews: {
-        nodes: [{ author: { __typename: "Bot", login: "coderabbitai[bot]" }, state: "APPROVED" }],
-      },
+      latestReviews: { nodes: [{ author: { __typename: typename, login }, state }] },
       changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-        nodes: [
-          {
-            id: "PRR_CR_1",
-            author: { __typename: "Bot", login: "coderabbitai[bot]" },
-            body: "please fix this",
-          },
-        ],
+        ...noPage,
+        nodes: [{ id: "PRR_CR", author: { __typename: typename, login }, body: "stale" }],
       },
     });
     expect(data.changesRequestedReviews).toHaveLength(0);
   });
 
-  it("drops a CR review when the same author's latest review is DISMISSED", async () => {
-    const data = await fetchWithConfig({
-      latestReviews: {
-        nodes: [{ author: { __typename: "User", login: "alice" }, state: "DISMISSED" }],
-      },
-      changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-        nodes: [{ id: "PRR_CR_2", author: { __typename: "User", login: "alice" }, body: "stale" }],
-      },
-    });
-    expect(data.changesRequestedReviews).toHaveLength(0);
-  });
+  it.each([
+    ["CHANGES_REQUESTED", "bob", "User", "PRR_CR_3"],
+    ["PENDING", "copilot[bot]", "Bot", "PRR_CR_PEND"],
+    ["COMMENTED", "alice", "User", "PRR_CR_CMT"],
+  ] as const)(
+    "keeps CR when same author's latest review is %s",
+    async (state, login, typename, id) => {
+      const data = await fetchWithConfig({
+        latestReviews: { nodes: [{ author: { __typename: typename, login }, state }] },
+        changesRequestedReviews: {
+          ...noPage,
+          nodes: [{ id, author: { __typename: typename, login }, body: "unresolved" }],
+        },
+      });
+      expect(data.changesRequestedReviews).toHaveLength(1);
+      expect(data.changesRequestedReviews[0].id).toBe(id);
+    },
+  );
 
-  it("keeps a CR review when the author has no subsequent APPROVED/DISMISSED review", async () => {
+  it("keeps CR when the author does not appear in latestReviews", async () => {
     const data = await fetchWithConfig({
-      latestReviews: {
-        nodes: [{ author: { __typename: "User", login: "bob" }, state: "CHANGES_REQUESTED" }],
-      },
+      latestReviews: { nodes: [] },
       changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-        nodes: [
-          { id: "PRR_CR_3", author: { __typename: "User", login: "bob" }, body: "fix the tests" },
-        ],
+        ...noPage,
+        nodes: [{ id: "PRR_CR_ONLY", author: { __typename: "User", login: "bob" }, body: "x" }],
       },
     });
     expect(data.changesRequestedReviews).toHaveLength(1);
-    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_3");
+    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_ONLY");
   });
 
   it("keeps the CR from one author and drops the CR from another who later approved", async () => {
@@ -74,14 +73,10 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
         ],
       },
       changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
+        ...noPage,
         nodes: [
-          { id: "PRR_CR_A", author: { __typename: "User", login: "alice" }, body: "old cr" },
-          {
-            id: "PRR_CR_B",
-            author: { __typename: "User", login: "bob" },
-            body: "still needs work",
-          },
+          { id: "PRR_CR_A", author: { __typename: "User", login: "alice" }, body: "old" },
+          { id: "PRR_CR_B", author: { __typename: "User", login: "bob" }, body: "active" },
         ],
       },
     });
@@ -91,69 +86,13 @@ describe("fetchPrBatch — changesRequestedReviews dedup via latestReviews", () 
 
   it("keeps CR reviews from null-author accounts even if another null-author later approved", async () => {
     const data = await fetchWithConfig({
-      latestReviews: {
-        nodes: [{ author: null, state: "APPROVED" }],
-      },
+      latestReviews: { nodes: [{ author: null, state: "APPROVED" }] },
       changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
+        ...noPage,
         nodes: [{ id: "PRR_CR_NULL", author: null, body: "needs work" }],
       },
     });
     expect(data.changesRequestedReviews).toHaveLength(1);
     expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_NULL");
-  });
-
-  it("keeps a CR review when the same author's latest review is PENDING", async () => {
-    const data = await fetchWithConfig({
-      latestReviews: {
-        nodes: [{ author: { __typename: "Bot", login: "copilot[bot]" }, state: "PENDING" }],
-      },
-      changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-        nodes: [
-          {
-            id: "PRR_CR_PEND",
-            author: { __typename: "Bot", login: "copilot[bot]" },
-            body: "issues",
-          },
-        ],
-      },
-    });
-    expect(data.changesRequestedReviews).toHaveLength(1);
-    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_PEND");
-  });
-
-  it("keeps a CR review when the same author's latest review is COMMENTED", async () => {
-    const data = await fetchWithConfig({
-      latestReviews: {
-        nodes: [{ author: { __typename: "User", login: "alice" }, state: "COMMENTED" }],
-      },
-      changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-        nodes: [
-          {
-            id: "PRR_CR_CMT",
-            author: { __typename: "User", login: "alice" },
-            body: "still unresolved",
-          },
-        ],
-      },
-    });
-    expect(data.changesRequestedReviews).toHaveLength(1);
-    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_CMT");
-  });
-
-  it("keeps a CR review when the author does not appear in latestReviews", async () => {
-    const data = await fetchWithConfig({
-      latestReviews: { nodes: [] },
-      changesRequestedReviews: {
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-        nodes: [
-          { id: "PRR_CR_ONLY", author: { __typename: "User", login: "bob" }, body: "unaddressed" },
-        ],
-      },
-    });
-    expect(data.changesRequestedReviews).toHaveLength(1);
-    expect(data.changesRequestedReviews[0].id).toBe("PRR_CR_ONLY");
   });
 });

--- a/src/github/batch-parsers.mts
+++ b/src/github/batch-parsers.mts
@@ -20,6 +20,7 @@ import {
   extractRunId,
   extractCheckRunSummary,
   mapStatusContextState,
+  latestApprovedLogins,
 } from "./batch-parser-helpers.mts";
 
 export function parseRawPr(
@@ -40,7 +41,7 @@ export function parseRawPr(
     login: n.author?.login ?? "unknown",
     state: n.state,
   }));
-
+  const crDone = latestApprovedLogins(latestReviews);
   const reviewThreads: ReviewThread[] = rawThreadPages.map((t) => {
     const comment = t.comments.nodes[0];
     const comments = t.comments.nodes.map((c) => ({
@@ -81,12 +82,14 @@ export function parseRawPr(
     createdAtUnix: parseCreatedAt(c.createdAt),
   }));
 
-  const changesRequestedReviews: Review[] = rawReviewNodes.map((r) => ({
-    id: r.id,
-    author: r.author?.login ?? "unknown",
-    authorType: mapAuthorType(r.author?.__typename, r.author?.login),
-    body: r.body,
-  }));
+  const changesRequestedReviews: Review[] = rawReviewNodes
+    .filter((r) => !crDone.has(r.author?.login ?? "unknown"))
+    .map((r) => ({
+      id: r.id,
+      author: r.author?.login ?? "unknown",
+      authorType: mapAuthorType(r.author?.__typename, r.author?.login),
+      body: r.body,
+    }));
 
   const reviewSummaries: Review[] = rawReviewSummaryNodes
     .filter((r) => !r.isMinimized && r.body.trim() !== "")

--- a/src/github/gql/batch-pr.gql
+++ b/src/github/gql/batch-pr.gql
@@ -49,6 +49,9 @@ query BatchPr(
           }
         }
       }
+      # Not paginated — capped at 100 distinct reviewers; PRs with more are not plausible
+      # in practice. Used to derive which CHANGES_REQUESTED rows are superseded by a later
+      # APPROVED/DISMISSED review from the same author.
       latestReviews(last: 100) {
         nodes {
           author {

--- a/test-cases/fixtures/47-cancel-bot-cr-superseded-by-approval/input.json
+++ b/test-cases/fixtures/47-cancel-bot-cr-superseded-by-approval/input.json
@@ -1,0 +1,21 @@
+{
+  "batchData": {
+    "latestReviews": [{ "login": "coderabbitai[bot]", "state": "APPROVED" }],
+    "changesRequestedReviews": [],
+    "checks": [
+      {
+        "name": "CI / tests",
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "event": "pull_request",
+        "detailsUrl": "https://github.com/owner/repo/actions/runs/100",
+        "runId": "100"
+      }
+    ]
+  },
+  "readyDelayState": {
+    "isReady": true,
+    "shouldCancel": true,
+    "remainingSeconds": 0
+  }
+}

--- a/test-cases/snapshots/47-cancel-bot-cr-superseded-by-approval/output.json
+++ b/test-cases/snapshots/47-cancel-bot-cr-superseded-by-approval/output.json
@@ -1,0 +1,1 @@
+{"action":"cancel","pr":42,"repo":"owner/repo","status":"READY","state":"OPEN","mergeStateStatus":"CLEAN","summary":{"passing":1},"baseBranch":"main","reason":"ready-delay-elapsed","log":"CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping","instructions":["Stop — the active goal is complete."]}

--- a/test-cases/snapshots/47-cancel-bot-cr-superseded-by-approval/output.text.md
+++ b/test-cases/snapshots/47-cancel-bot-cr-superseded-by-approval/output.text.md
@@ -1,0 +1,10 @@
+# PR #42 [CANCEL] — ready-delay-elapsed
+
+**status** `READY` · **merge** `CLEAN` · **state** `OPEN` · **repo** `owner/repo`
+**summary** 1 passing
+
+CANCEL: PR #42 has been ready for review — ready-delay elapsed, stopping
+
+## Instructions
+
+1. Stop — the active goal is complete.


### PR DESCRIPTION
## Summary

- When a reviewer (typically a bot like CodeRabbit) submits `CHANGES_REQUESTED` and then later `APPROVED`, GitHub retains the older CR row in the `reviews(states: CHANGES_REQUESTED)` GraphQL connection. `changesRequestedReviewCount` was using the raw `.length` of that connection, so the stale CR kept `status` pinned at `UNRESOLVED_COMMENTS` regardless of the later approval.
- This blocked the `isCleanReadyHandoff` gate permanently, preventing the ready-delay countdown from starting, and eventually triggering a stall-timeout ESCALATE on an otherwise fully-green PR.
- Fix: in `parseRawPr`, filter `rawReviewNodes` through `latestApprovedLogins` — a Set of author logins whose most-recent review (from the already-fetched `latestReviews` field, which GitHub guarantees is per-author-latest) is `APPROVED` or `DISMISSED`. Stale CR rows from those authors are dropped at parse time, so count, display, and stall fingerprint all see the correct state.

## Test plan

- [ ] New test file `batch-parsers.changesrequested-dedup.mock.test.mts` covers: CR-then-APPROVED (filtered), CR-then-DISMISSED (filtered), CR-only (kept), two-author mixed case (correct per-author filtering), null-author safety.
- [ ] Full 1166-test suite passes.
- [ ] `oxlint`, `tsc --noEmit`, `oxfmt --check` all clean; `batch-parsers.mts` stays at 200 lines.

## Shepherd Journal

- [Copilot thread PRRT_kwDOSGizTs6FiD1Z](https://github.com/jonathanong/pr-shepherd/pull/256#discussion_r3320939797): "unknown" login in crDone set — already addressed in the second commit via `r.login !== "unknown"` guard in `latestApprovedLogins`. Null-author CR reviews are kept; null-author APPROVED/DISMISSED reviews do not suppress them.
- [Copilot thread PRRT_kwDOSGizTs6FiD1w](https://github.com/jonathanong/pr-shepherd/pull/256#discussion_r3320939825): `latestReviews(last: 100)` pagination — accepted limitation. PRs with >100 distinct reviewers do not exist in practice. Documented the cap in a GQL comment matching the existing `reviewRequests` pattern.
- [Codex thread PRRT_kwDOSGizTs6FiEX9](https://github.com/jonathanong/pr-shepherd/pull/256#discussion_r3320942857): Same `latestReviews(last: 100)` concern raised on the first commit (before the GQL doc comment). Same decision: accepted limitation, already documented in the GQL file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)