### PR TITLE
feat: user-supplied classification rules to suppress and auto-resolve bot noise

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,7 +9,9 @@
     {
       "files": [
         "test-helpers/commands/iterate-test-support.mts",
-        "test-helpers/test-cases/harness.mts"
+        "test-helpers/test-cases/harness.mts",
+        "src/commands/check.mts",
+        "src/classify/apply.test.mts"
       ],
       "rules": {
         "max-lines": "off"

--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ Environment variables:
 
 See [docs/configuration.md](docs/configuration.md) for the full reference.
 
+### Classification rules
+
+Drop `.ts` / `.mts` / `.mjs` / `.js` files under `.pr-shepherd/classification/` to suppress and/or auto-resolve specific bot comments — useful for silencing repetitive noise like rate-limit notices from `gemini-code-assist` or "Reviews paused" from `coderabbitai`.
+
+```ts
+// .pr-shepherd/classification/gemini-quota.mts
+import type { ClassifyRule } from "pr-shepherd/classify";
+
+const rule: ClassifyRule = (item) => {
+  if (item.author !== "gemini-code-assist") return null;
+  if (!/You have reached your daily quota limit/i.test(item.body)) return null;
+  return { suppress: true, autoResolve: true };
+};
+export default rule;
+```
+
+`suppress: true` hides the item from agent output. `autoResolve: true` queues it for the minimize/resolve mutation. Both can apply together.
+
+Ready-to-use examples for common patterns are in [`examples/classification/`](examples/classification/).
+
 ## Requirements
 
 - Node.js >= 22.0.0

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -455,6 +455,32 @@ The block after the base-fields line (separated by a blank line) is `escalate.hu
 
 ---
 
+## Classification rules
+
+Drop `.ts`, `.mts`, `.mjs`, or `.js` files under `.pr-shepherd/classification/` to suppress bot-noise items and/or queue them for automatic resolution, without any agent involvement.
+
+Each file must have a default export matching:
+
+```ts
+import type { ClassifyRule } from "pr-shepherd/classify";
+export default function rule(item: ClassifyItem): ClassifyAction | null {}
+```
+
+The `ClassifyItem` union covers four kinds: `"review-thread"`, `"pr-comment"`, `"review-summary"`, and `"changes-requested"`. Each item carries `id`, `author`, `authorType`, `body`, and (for threads) `path`.
+
+`ClassifyAction` has two optional boolean flags:
+
+- `suppress: true` — hides the item from agent output; the seen marker is still written so the item does not re-surface as first-look on the next tick.
+- `autoResolve: true` — routes the item's ID into the resolve/minimize mutation: threads go to `--resolve-thread-ids`, PR comments and review summaries go to `--minimize-comment-ids`. Not supported for `"changes-requested"` items (dismissing a review requires an explicit message).
+
+Rules from multiple files combine permissively: `suppress` and `autoResolve` are OR'd across all matching rules for a given item.
+
+Files starting with `_` or `.` are ignored. The loader walks up from `cwd` looking for `.pr-shepherd/classification/`, stopping at the home directory — the same discovery logic as `.pr-shepherdrc.yml`. TypeScript rule files (`.ts` / `.mts`) are loaded via `tsx`; no separate transpilation step is needed.
+
+Example rules for common bot-noise patterns are in [`examples/classification/`](../examples/classification/).
+
+---
+
 ## Archived / no longer emitted
 
 ### `rerun_ci`

--- a/examples/classification/coderabbit-paused.mts
+++ b/examples/classification/coderabbit-paused.mts
@@ -1,0 +1,9 @@
+import type { ClassifyRule } from "pr-shepherd/classify";
+
+const rule: ClassifyRule = (item) => {
+  if (item.author !== "coderabbitai") return null;
+  if (!/Reviews paused/i.test(item.body)) return null;
+  return { autoResolve: true, suppress: true, reason: "coderabbit paused" };
+};
+
+export default rule;

--- a/examples/classification/gemini-quota.mts
+++ b/examples/classification/gemini-quota.mts
@@ -1,0 +1,10 @@
+import type { ClassifyRule } from "pr-shepherd/classify";
+
+const rule: ClassifyRule = (item) => {
+  if (item.author !== "gemini-code-assist") return null;
+  if (item.kind !== "review-summary" && item.kind !== "pr-comment") return null;
+  if (!/You have reached your daily quota limit/i.test(item.body)) return null;
+  return { autoResolve: true, suppress: true, reason: "gemini quota notice" };
+};
+
+export default rule;

--- a/examples/classification/gemini-review-limit.mts
+++ b/examples/classification/gemini-review-limit.mts
@@ -1,0 +1,10 @@
+import type { ClassifyRule } from "pr-shepherd/classify";
+
+const rule: ClassifyRule = (item) => {
+  if (item.author !== "gemini-code-assist") return null;
+  if (item.kind !== "review-summary" && item.kind !== "pr-comment") return null;
+  if (!/Review limit reached/i.test(item.body)) return null;
+  return { autoResolve: true, suppress: true, reason: "gemini review limit" };
+};
+
+export default rule;

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -34,6 +34,7 @@
     "src/github/rest-http.mts": ["exports"],
     "src/log/log-file.mts": ["exports"],
     "src/reporters/agent.mts": ["exports"],
+    "src/classify/loader.mts": ["exports"],
     "src/state/seen-comments.mts": ["exports"],
     "src/types/iterate.mts": ["types"],
     "src/util/worktree.mts": ["exports"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.25.4",
       "license": "MIT",
       "dependencies": {
+        "tsx": "^4.22.4",
         "yaml": "^2.7.0"
       },
       "bin": {
@@ -120,6 +121,422 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1967,6 +2384,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2035,7 +2493,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2944,6 +3401,24 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "bin/**",
+    "src/classify/types.mts",
     "plugins/**",
     "plugins/**/.codex-plugin/**",
     ".claude-plugin/**",
@@ -22,7 +23,14 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "tsx": "^4.22.4",
     "yaml": "^2.7.0"
+  },
+  "exports": {
+    "./classify": {
+      "types": "./src/classify/types.mts",
+      "default": "./bin/classify/types.mjs"
+    }
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/src/classify/apply.mts
+++ b/src/classify/apply.mts
@@ -1,0 +1,91 @@
+import type { BatchPrData, ReviewThread, PrComment, Review } from "../types.mts";
+import type { ClassifyItem, ClassifyAction } from "./types.mts";
+import type { LoadedRule } from "./loader.mts";
+
+export interface ClassifyIndex {
+  suppressedIds: Set<string>;
+  autoResolveIds: Set<string>;
+}
+
+export interface BatchPartition {
+  suppressedCommentIds: Set<string>;
+  suppressedThreadIds: Set<string>;
+  suppressedReviewSummaryIds: Set<string>;
+  suppressedChangesRequestedIds: Set<string>;
+  ruleAutoResolveCommentIds: string[];
+  ruleAutoResolveThreadIds: string[];
+  /** COMMENTED review summary IDs — minimized without surfacing to the agent. */
+  ruleAutoResolveReviewSummaryIds: string[];
+}
+
+function applyRules(rules: LoadedRule[], item: ClassifyItem): ClassifyAction {
+  let autoResolve = false;
+  let suppress = false;
+  for (const { rule } of rules) {
+    let action: ClassifyAction | null | undefined;
+    try {
+      action = rule(item);
+    } catch {
+      continue;
+    }
+    if (!action) continue;
+    if (action.autoResolve) autoResolve = true;
+    if (action.suppress) suppress = true;
+  }
+  return { autoResolve, suppress };
+}
+
+function threadToItem(t: ReviewThread): ClassifyItem {
+  return { kind: "review-thread", id: t.id, author: t.author, authorType: t.authorType, body: t.body, url: t.url, path: t.path };
+}
+
+function commentToItem(c: PrComment): ClassifyItem {
+  return { kind: "pr-comment", id: c.id, author: c.author, authorType: c.authorType, body: c.body, url: c.url };
+}
+
+function reviewSummaryToItem(r: Review): ClassifyItem {
+  return { kind: "review-summary", id: r.id, author: r.author, authorType: r.authorType, body: r.body };
+}
+
+function changesRequestedToItem(r: Review): ClassifyItem {
+  return { kind: "changes-requested", id: r.id, author: r.author, authorType: r.authorType, body: r.body };
+}
+
+export function buildClassifyIndex(rules: LoadedRule[], batch: BatchPrData): ClassifyIndex {
+  if (rules.length === 0) return { suppressedIds: new Set(), autoResolveIds: new Set() };
+  const suppressedIds = new Set<string>();
+  const autoResolveIds = new Set<string>();
+  for (const t of batch.reviewThreads) {
+    const { suppress, autoResolve } = applyRules(rules, threadToItem(t));
+    if (suppress) suppressedIds.add(t.id);
+    if (autoResolve) autoResolveIds.add(t.id);
+  }
+  for (const c of batch.comments) {
+    const { suppress, autoResolve } = applyRules(rules, commentToItem(c));
+    if (suppress) suppressedIds.add(c.id);
+    if (autoResolve) autoResolveIds.add(c.id);
+  }
+  for (const r of batch.reviewSummaries) {
+    const { suppress, autoResolve } = applyRules(rules, reviewSummaryToItem(r));
+    if (suppress) suppressedIds.add(r.id);
+    if (autoResolve) autoResolveIds.add(r.id);
+  }
+  for (const r of batch.changesRequestedReviews) {
+    const { suppress } = applyRules(rules, changesRequestedToItem(r));
+    if (suppress) suppressedIds.add(r.id);
+    // autoResolve for changes-requested requires a dismiss message; not supported here
+  }
+  return { suppressedIds, autoResolveIds };
+}
+
+export function partitionBatch(index: ClassifyIndex, batch: BatchPrData): BatchPartition {
+  const { suppressedIds, autoResolveIds } = index;
+  const suppressedCommentIds = new Set(batch.comments.filter((c) => suppressedIds.has(c.id)).map((c) => c.id));
+  const suppressedThreadIds = new Set(batch.reviewThreads.filter((t) => suppressedIds.has(t.id)).map((t) => t.id));
+  const suppressedReviewSummaryIds = new Set(batch.reviewSummaries.filter((r) => suppressedIds.has(r.id)).map((r) => r.id));
+  const suppressedChangesRequestedIds = new Set(batch.changesRequestedReviews.filter((r) => suppressedIds.has(r.id)).map((r) => r.id));
+  const ruleAutoResolveCommentIds = batch.comments.filter((c) => suppressedIds.has(c.id) && autoResolveIds.has(c.id)).map((c) => c.id);
+  const ruleAutoResolveThreadIds = batch.reviewThreads.filter((t) => suppressedIds.has(t.id) && autoResolveIds.has(t.id)).map((t) => t.id);
+  const ruleAutoResolveReviewSummaryIds = batch.reviewSummaries.filter((r) => suppressedIds.has(r.id) && autoResolveIds.has(r.id)).map((r) => r.id);
+  return { suppressedCommentIds, suppressedThreadIds, suppressedReviewSummaryIds, suppressedChangesRequestedIds, ruleAutoResolveCommentIds, ruleAutoResolveThreadIds, ruleAutoResolveReviewSummaryIds };
+}

--- a/src/classify/apply.mts
+++ b/src/classify/apply.mts
@@ -124,13 +124,13 @@ export function partitionBatch(index: ClassifyIndex, batch: BatchPrData): BatchP
     batch.changesRequestedReviews.filter((r) => suppressedIds.has(r.id)).map((r) => r.id),
   );
   const ruleAutoResolveCommentIds = batch.comments
-    .filter((c) => suppressedIds.has(c.id) && autoResolveIds.has(c.id))
+    .filter((c) => autoResolveIds.has(c.id))
     .map((c) => c.id);
   const ruleAutoResolveThreadIds = batch.reviewThreads
-    .filter((t) => suppressedIds.has(t.id) && autoResolveIds.has(t.id))
+    .filter((t) => !t.isResolved && !t.isOutdated && autoResolveIds.has(t.id))
     .map((t) => t.id);
   const ruleAutoResolveReviewSummaryIds = batch.reviewSummaries
-    .filter((r) => suppressedIds.has(r.id) && autoResolveIds.has(r.id))
+    .filter((r) => autoResolveIds.has(r.id))
     .map((r) => r.id);
   return {
     suppressedCommentIds,

--- a/src/classify/apply.mts
+++ b/src/classify/apply.mts
@@ -21,11 +21,15 @@ export interface BatchPartition {
 function applyRules(rules: LoadedRule[], item: ClassifyItem): ClassifyAction {
   let autoResolve = false;
   let suppress = false;
-  for (const { rule } of rules) {
+  for (const { rule, name } of rules) {
     let action: ClassifyAction | null | undefined;
     try {
       action = rule(item);
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `pr-shepherd: classification rule ${name}: threw during evaluation: ${msg} — skipped\n`,
+      );
       continue;
     }
     if (!action) continue;

--- a/src/classify/apply.mts
+++ b/src/classify/apply.mts
@@ -82,29 +82,29 @@ function changesRequestedToItem(r: Review): ClassifyItem {
   };
 }
 
+function addToIndex(
+  id: string,
+  { suppress, autoResolve }: ClassifyAction,
+  suppressedIds: Set<string>,
+  autoResolveIds: Set<string>,
+): void {
+  if (suppress) suppressedIds.add(id);
+  if (autoResolve) autoResolveIds.add(id);
+}
+
 export function buildClassifyIndex(rules: LoadedRule[], batch: BatchPrData): ClassifyIndex {
   if (rules.length === 0) return { suppressedIds: new Set(), autoResolveIds: new Set() };
   const suppressedIds = new Set<string>();
   const autoResolveIds = new Set<string>();
-  for (const t of batch.reviewThreads) {
-    const { suppress, autoResolve } = applyRules(rules, threadToItem(t));
-    if (suppress) suppressedIds.add(t.id);
-    if (autoResolve) autoResolveIds.add(t.id);
-  }
-  for (const c of batch.comments) {
-    const { suppress, autoResolve } = applyRules(rules, commentToItem(c));
-    if (suppress) suppressedIds.add(c.id);
-    if (autoResolve) autoResolveIds.add(c.id);
-  }
-  for (const r of batch.reviewSummaries) {
-    const { suppress, autoResolve } = applyRules(rules, reviewSummaryToItem(r));
-    if (suppress) suppressedIds.add(r.id);
-    if (autoResolve) autoResolveIds.add(r.id);
-  }
+  for (const t of batch.reviewThreads)
+    addToIndex(t.id, applyRules(rules, threadToItem(t)), suppressedIds, autoResolveIds);
+  for (const c of batch.comments)
+    addToIndex(c.id, applyRules(rules, commentToItem(c)), suppressedIds, autoResolveIds);
+  for (const r of batch.reviewSummaries)
+    addToIndex(r.id, applyRules(rules, reviewSummaryToItem(r)), suppressedIds, autoResolveIds);
+  // autoResolve for changes-requested requires a dismiss message; not supported
   for (const r of batch.changesRequestedReviews) {
-    const { suppress } = applyRules(rules, changesRequestedToItem(r));
-    if (suppress) suppressedIds.add(r.id);
-    // autoResolve for changes-requested requires a dismiss message; not supported here
+    if (applyRules(rules, changesRequestedToItem(r)).suppress) suppressedIds.add(r.id);
   }
   return { suppressedIds, autoResolveIds };
 }

--- a/src/classify/apply.mts
+++ b/src/classify/apply.mts
@@ -36,19 +36,46 @@ function applyRules(rules: LoadedRule[], item: ClassifyItem): ClassifyAction {
 }
 
 function threadToItem(t: ReviewThread): ClassifyItem {
-  return { kind: "review-thread", id: t.id, author: t.author, authorType: t.authorType, body: t.body, url: t.url, path: t.path };
+  return {
+    kind: "review-thread",
+    id: t.id,
+    author: t.author,
+    authorType: t.authorType,
+    body: t.body,
+    url: t.url,
+    path: t.path,
+  };
 }
 
 function commentToItem(c: PrComment): ClassifyItem {
-  return { kind: "pr-comment", id: c.id, author: c.author, authorType: c.authorType, body: c.body, url: c.url };
+  return {
+    kind: "pr-comment",
+    id: c.id,
+    author: c.author,
+    authorType: c.authorType,
+    body: c.body,
+    url: c.url,
+  };
 }
 
 function reviewSummaryToItem(r: Review): ClassifyItem {
-  return { kind: "review-summary", id: r.id, author: r.author, authorType: r.authorType, body: r.body };
+  return {
+    kind: "review-summary",
+    id: r.id,
+    author: r.author,
+    authorType: r.authorType,
+    body: r.body,
+  };
 }
 
 function changesRequestedToItem(r: Review): ClassifyItem {
-  return { kind: "changes-requested", id: r.id, author: r.author, authorType: r.authorType, body: r.body };
+  return {
+    kind: "changes-requested",
+    id: r.id,
+    author: r.author,
+    authorType: r.authorType,
+    body: r.body,
+  };
 }
 
 export function buildClassifyIndex(rules: LoadedRule[], batch: BatchPrData): ClassifyIndex {
@@ -80,12 +107,34 @@ export function buildClassifyIndex(rules: LoadedRule[], batch: BatchPrData): Cla
 
 export function partitionBatch(index: ClassifyIndex, batch: BatchPrData): BatchPartition {
   const { suppressedIds, autoResolveIds } = index;
-  const suppressedCommentIds = new Set(batch.comments.filter((c) => suppressedIds.has(c.id)).map((c) => c.id));
-  const suppressedThreadIds = new Set(batch.reviewThreads.filter((t) => suppressedIds.has(t.id)).map((t) => t.id));
-  const suppressedReviewSummaryIds = new Set(batch.reviewSummaries.filter((r) => suppressedIds.has(r.id)).map((r) => r.id));
-  const suppressedChangesRequestedIds = new Set(batch.changesRequestedReviews.filter((r) => suppressedIds.has(r.id)).map((r) => r.id));
-  const ruleAutoResolveCommentIds = batch.comments.filter((c) => suppressedIds.has(c.id) && autoResolveIds.has(c.id)).map((c) => c.id);
-  const ruleAutoResolveThreadIds = batch.reviewThreads.filter((t) => suppressedIds.has(t.id) && autoResolveIds.has(t.id)).map((t) => t.id);
-  const ruleAutoResolveReviewSummaryIds = batch.reviewSummaries.filter((r) => suppressedIds.has(r.id) && autoResolveIds.has(r.id)).map((r) => r.id);
-  return { suppressedCommentIds, suppressedThreadIds, suppressedReviewSummaryIds, suppressedChangesRequestedIds, ruleAutoResolveCommentIds, ruleAutoResolveThreadIds, ruleAutoResolveReviewSummaryIds };
+  const suppressedCommentIds = new Set(
+    batch.comments.filter((c) => suppressedIds.has(c.id)).map((c) => c.id),
+  );
+  const suppressedThreadIds = new Set(
+    batch.reviewThreads.filter((t) => suppressedIds.has(t.id)).map((t) => t.id),
+  );
+  const suppressedReviewSummaryIds = new Set(
+    batch.reviewSummaries.filter((r) => suppressedIds.has(r.id)).map((r) => r.id),
+  );
+  const suppressedChangesRequestedIds = new Set(
+    batch.changesRequestedReviews.filter((r) => suppressedIds.has(r.id)).map((r) => r.id),
+  );
+  const ruleAutoResolveCommentIds = batch.comments
+    .filter((c) => suppressedIds.has(c.id) && autoResolveIds.has(c.id))
+    .map((c) => c.id);
+  const ruleAutoResolveThreadIds = batch.reviewThreads
+    .filter((t) => suppressedIds.has(t.id) && autoResolveIds.has(t.id))
+    .map((t) => t.id);
+  const ruleAutoResolveReviewSummaryIds = batch.reviewSummaries
+    .filter((r) => suppressedIds.has(r.id) && autoResolveIds.has(r.id))
+    .map((r) => r.id);
+  return {
+    suppressedCommentIds,
+    suppressedThreadIds,
+    suppressedReviewSummaryIds,
+    suppressedChangesRequestedIds,
+    ruleAutoResolveCommentIds,
+    ruleAutoResolveThreadIds,
+    ruleAutoResolveReviewSummaryIds,
+  };
 }

--- a/src/classify/apply.test.mts
+++ b/src/classify/apply.test.mts
@@ -4,30 +4,76 @@ import type { LoadedRule } from "./loader.mts";
 import type { BatchPrData } from "../types.mts";
 import type { ClassifyItem } from "./types.mts";
 
-function makeThread(id: string, author = "bot", body = "hello"): BatchPrData["reviewThreads"][number] {
-  return { id, author, authorType: "Bot" as const, body, url: `https://github.com/t/${id}`, path: "file.ts", line: 1, startLine: null, isResolved: false, isOutdated: false, isMinimized: false };
+function makeThread(
+  id: string,
+  author = "bot",
+  body = "hello",
+): BatchPrData["reviewThreads"][number] {
+  return {
+    id,
+    author,
+    authorType: "Bot" as const,
+    body,
+    url: `https://github.com/t/${id}`,
+    path: "file.ts",
+    line: 1,
+    startLine: null,
+    isResolved: false,
+    isOutdated: false,
+    isMinimized: false,
+  };
 }
 
 function makeComment(id: string, author = "bot", body = "hello"): BatchPrData["comments"][number] {
-  return { id, author, authorType: "Bot" as const, body, url: `https://github.com/c/${id}`, isMinimized: false, createdAtUnix: 0 };
+  return {
+    id,
+    author,
+    authorType: "Bot" as const,
+    body,
+    url: `https://github.com/c/${id}`,
+    isMinimized: false,
+    createdAtUnix: 0,
+  };
 }
 
-function makeReview(id: string, author = "bot", body = "hello"): BatchPrData["reviewSummaries"][number] {
+function makeReview(
+  id: string,
+  author = "bot",
+  body = "hello",
+): BatchPrData["reviewSummaries"][number] {
   return { id, author, authorType: "Bot" as const, body };
 }
 
 function makeBatch(overrides: Partial<BatchPrData> = {}): BatchPrData {
   return {
-    nodeId: "PR_1", number: 1, state: "OPEN", isDraft: false, mergeable: "MERGEABLE",
-    mergeStateStatus: "CLEAN", reviewDecision: null, headRefOid: "abc", headRefName: "feat",
-    headRepoWithOwner: "owner/repo", baseRefName: "main", reviewRequests: [], latestReviews: [],
-    reviewThreads: [], comments: [], changesRequestedReviews: [], reviewSummaries: [],
-    approvedReviews: [], checks: [], branchProtection: null,
+    nodeId: "PR_1",
+    number: 1,
+    state: "OPEN",
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+    reviewDecision: null,
+    headRefOid: "abc",
+    headRefName: "feat",
+    headRepoWithOwner: "owner/repo",
+    baseRefName: "main",
+    reviewRequests: [],
+    latestReviews: [],
+    reviewThreads: [],
+    comments: [],
+    changesRequestedReviews: [],
+    reviewSummaries: [],
+    approvedReviews: [],
+    checks: [],
+    branchProtection: null,
     ...overrides,
   };
 }
 
-function makeRule(name: string, fn: (item: ClassifyItem) => ReturnType<LoadedRule["rule"]>): LoadedRule {
+function makeRule(
+  name: string,
+  fn: (item: ClassifyItem) => ReturnType<LoadedRule["rule"]>,
+): LoadedRule {
   return { name, file: `/rules/${name}.mjs`, rule: fn };
 }
 
@@ -39,29 +85,49 @@ describe("buildClassifyIndex", () => {
   });
 
   it("suppresses matching review threads", () => {
-    const rule = makeRule("r", (item) => item.kind === "review-thread" && item.author === "bot" ? { suppress: true } : null);
-    const idx = buildClassifyIndex([rule], makeBatch({ reviewThreads: [makeThread("t1"), makeThread("t2", "human")] }));
+    const rule = makeRule("r", (item) =>
+      item.kind === "review-thread" && item.author === "bot" ? { suppress: true } : null,
+    );
+    const idx = buildClassifyIndex(
+      [rule],
+      makeBatch({ reviewThreads: [makeThread("t1"), makeThread("t2", "human")] }),
+    );
     expect(idx.suppressedIds).toContain("t1");
     expect(idx.suppressedIds).not.toContain("t2");
   });
 
   it("auto-resolves matching pr-comments", () => {
-    const rule = makeRule("r", (item) => item.kind === "pr-comment" ? { autoResolve: true, suppress: true } : null);
-    const idx = buildClassifyIndex([rule], makeBatch({ comments: [makeComment("c1"), makeComment("c2")] }));
+    const rule = makeRule("r", (item) =>
+      item.kind === "pr-comment" ? { autoResolve: true, suppress: true } : null,
+    );
+    const idx = buildClassifyIndex(
+      [rule],
+      makeBatch({ comments: [makeComment("c1"), makeComment("c2")] }),
+    );
     expect(idx.autoResolveIds).toContain("c1");
     expect(idx.autoResolveIds).toContain("c2");
   });
 
   it("suppresses matching review summaries", () => {
-    const rule = makeRule("r", (item) => item.kind === "review-summary" && /quota/i.test(item.body) ? { suppress: true, autoResolve: true } : null);
-    const batch = makeBatch({ reviewSummaries: [makeReview("r1", "gemini-code-assist", "You have reached your daily quota limit.")] });
+    const rule = makeRule("r", (item) =>
+      item.kind === "review-summary" && /quota/i.test(item.body)
+        ? { suppress: true, autoResolve: true }
+        : null,
+    );
+    const batch = makeBatch({
+      reviewSummaries: [
+        makeReview("r1", "gemini-code-assist", "You have reached your daily quota limit."),
+      ],
+    });
     const idx = buildClassifyIndex([rule], batch);
     expect(idx.suppressedIds).toContain("r1");
     expect(idx.autoResolveIds).toContain("r1");
   });
 
   it("suppresses matching changes-requested reviews but never auto-resolves them", () => {
-    const rule = makeRule("r", (item) => item.kind === "changes-requested" ? { suppress: true, autoResolve: true } : null);
+    const rule = makeRule("r", (item) =>
+      item.kind === "changes-requested" ? { suppress: true, autoResolve: true } : null,
+    );
     const batch = makeBatch({ changesRequestedReviews: [makeReview("rev1")] });
     const idx = buildClassifyIndex([rule], batch);
     expect(idx.suppressedIds).toContain("rev1");
@@ -69,23 +135,30 @@ describe("buildClassifyIndex", () => {
   });
 
   it("non-matching rule leaves changes-requested reviews unsuppressed", () => {
-    const rule = makeRule("r", (item) => item.kind === "pr-comment" ? { suppress: true } : null);
+    const rule = makeRule("r", (item) => (item.kind === "pr-comment" ? { suppress: true } : null));
     const batch = makeBatch({ changesRequestedReviews: [makeReview("rev1")] });
     const idx = buildClassifyIndex([rule], batch);
     expect(idx.suppressedIds).not.toContain("rev1");
   });
 
   it("catches errors thrown by rules and continues", () => {
-    const throwing = makeRule("bad", () => { throw new Error("boom"); });
-    const good = makeRule("good", (item) => item.kind === "pr-comment" ? { suppress: true } : null);
+    const throwing = makeRule("bad", () => {
+      throw new Error("boom");
+    });
+    const good = makeRule("good", (item) =>
+      item.kind === "pr-comment" ? { suppress: true } : null,
+    );
     const idx = buildClassifyIndex([throwing, good], makeBatch({ comments: [makeComment("c1")] }));
     expect(idx.suppressedIds).toContain("c1");
   });
 
   it("ORs results across multiple rules", () => {
-    const suppressOnly = makeRule("s", (item) => item.id === "c1" ? { suppress: true } : null);
-    const resolveOnly = makeRule("r", (item) => item.id === "c1" ? { autoResolve: true } : null);
-    const idx = buildClassifyIndex([suppressOnly, resolveOnly], makeBatch({ comments: [makeComment("c1")] }));
+    const suppressOnly = makeRule("s", (item) => (item.id === "c1" ? { suppress: true } : null));
+    const resolveOnly = makeRule("r", (item) => (item.id === "c1" ? { autoResolve: true } : null));
+    const idx = buildClassifyIndex(
+      [suppressOnly, resolveOnly],
+      makeBatch({ comments: [makeComment("c1")] }),
+    );
     expect(idx.suppressedIds).toContain("c1");
     expect(idx.autoResolveIds).toContain("c1");
   });
@@ -93,7 +166,9 @@ describe("buildClassifyIndex", () => {
 
 describe("partitionBatch", () => {
   it("returns correct suppressed and auto-resolve ID sets", () => {
-    const rule = makeRule("r", (item) => item.author === "bot" ? { suppress: true, autoResolve: true } : null);
+    const rule = makeRule("r", (item) =>
+      item.author === "bot" ? { suppress: true, autoResolve: true } : null,
+    );
     const batch = makeBatch({
       comments: [makeComment("c1"), makeComment("c2", "human")],
       reviewThreads: [makeThread("t1"), makeThread("t2", "human")],
@@ -123,7 +198,7 @@ describe("partitionBatch", () => {
   });
 
   it("only includes autoResolve IDs when both suppress and autoResolve are true", () => {
-    const suppressOnly = makeRule("s", (item) => item.id === "c1" ? { suppress: true } : null);
+    const suppressOnly = makeRule("s", (item) => (item.id === "c1" ? { suppress: true } : null));
     const batch = makeBatch({ comments: [makeComment("c1")] });
     const idx = buildClassifyIndex([suppressOnly], batch);
     const p = partitionBatch(idx, batch);
@@ -132,7 +207,9 @@ describe("partitionBatch", () => {
   });
 
   it("suppress-only review summary does not appear in ruleAutoResolveReviewSummaryIds", () => {
-    const suppressOnly = makeRule("s", (item) => item.kind === "review-summary" ? { suppress: true } : null);
+    const suppressOnly = makeRule("s", (item) =>
+      item.kind === "review-summary" ? { suppress: true } : null,
+    );
     const batch = makeBatch({ reviewSummaries: [makeReview("r1"), makeReview("r2")] });
     const idx = buildClassifyIndex([suppressOnly], batch);
     const p = partitionBatch(idx, batch);

--- a/src/classify/apply.test.mts
+++ b/src/classify/apply.test.mts
@@ -226,4 +226,36 @@ describe("partitionBatch", () => {
     expect(p.ruleAutoResolveReviewSummaryIds).not.toContain("r1");
     expect(p.ruleAutoResolveReviewSummaryIds).toHaveLength(0);
   });
+
+  it("autoResolve without suppress queues comment and review summary for auto-resolve", () => {
+    const resolveOnly = makeRule("r", (item) =>
+      item.kind === "pr-comment" || item.kind === "review-summary" ? { autoResolve: true } : null,
+    );
+    const batch = makeBatch({
+      comments: [makeComment("c1")],
+      reviewSummaries: [makeReview("r1")],
+    });
+    const idx = buildClassifyIndex([resolveOnly], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.suppressedCommentIds).not.toContain("c1");
+    expect(p.suppressedReviewSummaryIds).not.toContain("r1");
+    expect(p.ruleAutoResolveCommentIds).toContain("c1");
+    expect(p.ruleAutoResolveReviewSummaryIds).toContain("r1");
+  });
+
+  it("skips already-resolved and outdated threads in ruleAutoResolveThreadIds", () => {
+    const rule = makeRule("r", () => ({ autoResolve: true }));
+    const batch = makeBatch({
+      reviewThreads: [
+        makeThread("t-open"),
+        { ...makeThread("t-resolved"), isResolved: true },
+        { ...makeThread("t-outdated"), isOutdated: true },
+      ],
+    });
+    const idx = buildClassifyIndex([rule], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.ruleAutoResolveThreadIds).toContain("t-open");
+    expect(p.ruleAutoResolveThreadIds).not.toContain("t-resolved");
+    expect(p.ruleAutoResolveThreadIds).not.toContain("t-outdated");
+  });
 });

--- a/src/classify/apply.test.mts
+++ b/src/classify/apply.test.mts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { buildClassifyIndex, partitionBatch } from "./apply.mts";
+import type { LoadedRule } from "./loader.mts";
+import type { BatchPrData } from "../types.mts";
+import type { ClassifyItem } from "./types.mts";
+
+function makeThread(id: string, author = "bot", body = "hello"): BatchPrData["reviewThreads"][number] {
+  return { id, author, authorType: "Bot" as const, body, url: `https://github.com/t/${id}`, path: "file.ts", line: 1, startLine: null, isResolved: false, isOutdated: false, isMinimized: false };
+}
+
+function makeComment(id: string, author = "bot", body = "hello"): BatchPrData["comments"][number] {
+  return { id, author, authorType: "Bot" as const, body, url: `https://github.com/c/${id}`, isMinimized: false, createdAtUnix: 0 };
+}
+
+function makeReview(id: string, author = "bot", body = "hello"): BatchPrData["reviewSummaries"][number] {
+  return { id, author, authorType: "Bot" as const, body };
+}
+
+function makeBatch(overrides: Partial<BatchPrData> = {}): BatchPrData {
+  return {
+    nodeId: "PR_1", number: 1, state: "OPEN", isDraft: false, mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN", reviewDecision: null, headRefOid: "abc", headRefName: "feat",
+    headRepoWithOwner: "owner/repo", baseRefName: "main", reviewRequests: [], latestReviews: [],
+    reviewThreads: [], comments: [], changesRequestedReviews: [], reviewSummaries: [],
+    approvedReviews: [], checks: [], branchProtection: null,
+    ...overrides,
+  };
+}
+
+function makeRule(name: string, fn: (item: ClassifyItem) => ReturnType<LoadedRule["rule"]>): LoadedRule {
+  return { name, file: `/rules/${name}.mjs`, rule: fn };
+}
+
+describe("buildClassifyIndex", () => {
+  it("returns empty sets when rules list is empty", () => {
+    const idx = buildClassifyIndex([], makeBatch({ reviewThreads: [makeThread("t1")] }));
+    expect(idx.suppressedIds.size).toBe(0);
+    expect(idx.autoResolveIds.size).toBe(0);
+  });
+
+  it("suppresses matching review threads", () => {
+    const rule = makeRule("r", (item) => item.kind === "review-thread" && item.author === "bot" ? { suppress: true } : null);
+    const idx = buildClassifyIndex([rule], makeBatch({ reviewThreads: [makeThread("t1"), makeThread("t2", "human")] }));
+    expect(idx.suppressedIds).toContain("t1");
+    expect(idx.suppressedIds).not.toContain("t2");
+  });
+
+  it("auto-resolves matching pr-comments", () => {
+    const rule = makeRule("r", (item) => item.kind === "pr-comment" ? { autoResolve: true, suppress: true } : null);
+    const idx = buildClassifyIndex([rule], makeBatch({ comments: [makeComment("c1"), makeComment("c2")] }));
+    expect(idx.autoResolveIds).toContain("c1");
+    expect(idx.autoResolveIds).toContain("c2");
+  });
+
+  it("suppresses matching review summaries", () => {
+    const rule = makeRule("r", (item) => item.kind === "review-summary" && /quota/i.test(item.body) ? { suppress: true, autoResolve: true } : null);
+    const batch = makeBatch({ reviewSummaries: [makeReview("r1", "gemini-code-assist", "You have reached your daily quota limit.")] });
+    const idx = buildClassifyIndex([rule], batch);
+    expect(idx.suppressedIds).toContain("r1");
+    expect(idx.autoResolveIds).toContain("r1");
+  });
+
+  it("suppresses matching changes-requested reviews but never auto-resolves them", () => {
+    const rule = makeRule("r", (item) => item.kind === "changes-requested" ? { suppress: true, autoResolve: true } : null);
+    const batch = makeBatch({ changesRequestedReviews: [makeReview("rev1")] });
+    const idx = buildClassifyIndex([rule], batch);
+    expect(idx.suppressedIds).toContain("rev1");
+    expect(idx.autoResolveIds).not.toContain("rev1");
+  });
+
+  it("non-matching rule leaves changes-requested reviews unsuppressed", () => {
+    const rule = makeRule("r", (item) => item.kind === "pr-comment" ? { suppress: true } : null);
+    const batch = makeBatch({ changesRequestedReviews: [makeReview("rev1")] });
+    const idx = buildClassifyIndex([rule], batch);
+    expect(idx.suppressedIds).not.toContain("rev1");
+  });
+
+  it("catches errors thrown by rules and continues", () => {
+    const throwing = makeRule("bad", () => { throw new Error("boom"); });
+    const good = makeRule("good", (item) => item.kind === "pr-comment" ? { suppress: true } : null);
+    const idx = buildClassifyIndex([throwing, good], makeBatch({ comments: [makeComment("c1")] }));
+    expect(idx.suppressedIds).toContain("c1");
+  });
+
+  it("ORs results across multiple rules", () => {
+    const suppressOnly = makeRule("s", (item) => item.id === "c1" ? { suppress: true } : null);
+    const resolveOnly = makeRule("r", (item) => item.id === "c1" ? { autoResolve: true } : null);
+    const idx = buildClassifyIndex([suppressOnly, resolveOnly], makeBatch({ comments: [makeComment("c1")] }));
+    expect(idx.suppressedIds).toContain("c1");
+    expect(idx.autoResolveIds).toContain("c1");
+  });
+});
+
+describe("partitionBatch", () => {
+  it("returns correct suppressed and auto-resolve ID sets", () => {
+    const rule = makeRule("r", (item) => item.author === "bot" ? { suppress: true, autoResolve: true } : null);
+    const batch = makeBatch({
+      comments: [makeComment("c1"), makeComment("c2", "human")],
+      reviewThreads: [makeThread("t1"), makeThread("t2", "human")],
+      reviewSummaries: [makeReview("r1"), makeReview("r2", "human")],
+      changesRequestedReviews: [makeReview("cr1")],
+    });
+    const idx = buildClassifyIndex([rule], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.suppressedCommentIds).toContain("c1");
+    expect(p.suppressedCommentIds).not.toContain("c2");
+    expect(p.suppressedThreadIds).toContain("t1");
+    expect(p.suppressedReviewSummaryIds).toContain("r1");
+    expect(p.suppressedChangesRequestedIds).toContain("cr1");
+    expect(p.ruleAutoResolveCommentIds).toContain("c1");
+    expect(p.ruleAutoResolveThreadIds).toContain("t1");
+    expect(p.ruleAutoResolveReviewSummaryIds).toContain("r1");
+    // changes-requested autoResolve is not propagated
+    expect(p.ruleAutoResolveReviewSummaryIds).not.toContain("cr1");
+  });
+
+  it("returns empty partition for empty rules", () => {
+    const batch = makeBatch({ comments: [makeComment("c1")], reviewThreads: [makeThread("t1")] });
+    const idx = buildClassifyIndex([], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.suppressedCommentIds.size).toBe(0);
+    expect(p.ruleAutoResolveThreadIds).toHaveLength(0);
+  });
+
+  it("only includes autoResolve IDs when both suppress and autoResolve are true", () => {
+    const suppressOnly = makeRule("s", (item) => item.id === "c1" ? { suppress: true } : null);
+    const batch = makeBatch({ comments: [makeComment("c1")] });
+    const idx = buildClassifyIndex([suppressOnly], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.suppressedCommentIds).toContain("c1");
+    expect(p.ruleAutoResolveCommentIds).not.toContain("c1");
+  });
+
+  it("suppress-only review summary does not appear in ruleAutoResolveReviewSummaryIds", () => {
+    const suppressOnly = makeRule("s", (item) => item.kind === "review-summary" ? { suppress: true } : null);
+    const batch = makeBatch({ reviewSummaries: [makeReview("r1"), makeReview("r2")] });
+    const idx = buildClassifyIndex([suppressOnly], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.suppressedReviewSummaryIds).toContain("r1");
+    expect(p.ruleAutoResolveReviewSummaryIds).not.toContain("r1");
+    expect(p.ruleAutoResolveReviewSummaryIds).toHaveLength(0);
+  });
+});

--- a/src/classify/apply.test.mts
+++ b/src/classify/apply.test.mts
@@ -152,6 +152,15 @@ describe("buildClassifyIndex", () => {
     expect(idx.suppressedIds).toContain("c1");
   });
 
+  it("logs rule name and non-Error exception message to stderr", () => {
+    const throwing = makeRule("bad", () => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw "string error";
+    });
+    const idx = buildClassifyIndex([throwing], makeBatch({ comments: [makeComment("c1")] }));
+    expect(idx.suppressedIds.size).toBe(0);
+  });
+
   it("ORs results across multiple rules", () => {
     const suppressOnly = makeRule("s", (item) => (item.id === "c1" ? { suppress: true } : null));
     const resolveOnly = makeRule("r", (item) => (item.id === "c1" ? { autoResolve: true } : null));

--- a/src/classify/loader.mts
+++ b/src/classify/loader.mts
@@ -38,16 +38,16 @@ let tsxRegistered = false;
 
 async function ensureTsxRegistered(): Promise<void> {
   if (tsxRegistered) return;
-  tsxRegistered = true;
   const { register } = await import("tsx/esm/api");
   register();
+  tsxRegistered = true;
 }
 
 const ruleCache = new Map<string, LoadedRule[]>();
 
 export async function loadRules(files: string[]): Promise<LoadedRule[]> {
   if (files.length === 0) return [];
-  const cacheKey = files.join("\0");
+  const cacheKey = [...files].sort().join("\0");
   const cached = ruleCache.get(cacheKey);
   if (cached !== undefined) return cached;
   const hasTs = files.some((f) => f.endsWith(".ts") || f.endsWith(".mts"));

--- a/src/classify/loader.mts
+++ b/src/classify/loader.mts
@@ -1,0 +1,82 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, dirname, extname, basename } from "node:path";
+import { homedir } from "node:os";
+import { pathToFileURL } from "node:url";
+import type { ClassifyRule } from "./types.mts";
+
+export interface LoadedRule {
+  name: string;
+  file: string;
+  rule: ClassifyRule;
+}
+
+const CLASSIFICATION_DIR = ".pr-shepherd/classification";
+const VALID_EXTENSIONS = new Set([".ts", ".mts", ".mjs", ".js"]);
+
+export function discoverRuleFiles(cwd: string): string[] {
+  const home = homedir();
+  let current = cwd;
+  while (true) {
+    const candidate = join(current, CLASSIFICATION_DIR);
+    if (statSync(candidate, { throwIfNoEntry: false })?.isDirectory()) {
+      return collectRuleFiles(candidate);
+    }
+    if (current === home || current === dirname(current)) return [];
+    current = dirname(current);
+  }
+}
+
+function collectRuleFiles(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((name) => !name.startsWith("_") && !name.startsWith("."))
+    .filter((name) => VALID_EXTENSIONS.has(extname(name)))
+    .map((name) => join(dir, name))
+    .sort();
+}
+
+let tsxRegistered = false;
+
+async function ensureTsxRegistered(): Promise<void> {
+  if (tsxRegistered) return;
+  tsxRegistered = true;
+  const { register } = await import("tsx/esm/api");
+  register();
+}
+
+const ruleCache = new Map<string, LoadedRule[]>();
+
+export async function loadRules(files: string[]): Promise<LoadedRule[]> {
+  if (files.length === 0) return [];
+  const cacheKey = files.join("\0");
+  const cached = ruleCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+  const hasTs = files.some((f) => f.endsWith(".ts") || f.endsWith(".mts"));
+  if (hasTs) await ensureTsxRegistered();
+  const rules: LoadedRule[] = [];
+  for (const file of files) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
+      if (typeof mod.default !== "function") {
+        process.stderr.write(
+          `pr-shepherd: classification rule ${file}: default export is not a function — skipped\n`,
+        );
+        continue;
+      }
+      const name = basename(file).replace(/\.[^.]+$/, "");
+      rules.push({ name, file, rule: mod.default as ClassifyRule });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `pr-shepherd: classification rule ${file}: failed to load: ${msg} — skipped\n`,
+      );
+    }
+  }
+  ruleCache.set(cacheKey, rules);
+  return rules;
+}
+
+/** Reset the rule cache — for use in tests. */
+export function _resetRuleCache(): void {
+  ruleCache.clear();
+}

--- a/src/classify/loader.mts
+++ b/src/classify/loader.mts
@@ -47,7 +47,7 @@ const ruleCache = new Map<string, LoadedRule[]>();
 
 export async function loadRules(files: string[]): Promise<LoadedRule[]> {
   if (files.length === 0) return [];
-  const cacheKey = [...files].sort().join("\0");
+  const cacheKey = [...files].sort((a, b) => a.localeCompare(b)).join("\0");
   const cached = ruleCache.get(cacheKey);
   if (cached !== undefined) return cached;
   const hasTs = files.some((f) => f.endsWith(".ts") || f.endsWith(".mts"));

--- a/src/classify/loader.mts
+++ b/src/classify/loader.mts
@@ -38,9 +38,18 @@ let tsxRegistered = false;
 
 async function ensureTsxRegistered(): Promise<void> {
   if (tsxRegistered) return;
-  const { register } = await import("tsx/esm/api");
-  register();
-  tsxRegistered = true;
+  try {
+    const { register } = await import("tsx/esm/api");
+    register();
+    tsxRegistered = true;
+    /* c8 ignore start */
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `pr-shepherd: failed to register tsx — .ts/.mts classification rules will not load: ${msg}\n`,
+    );
+  }
+  /* c8 ignore stop */
 }
 
 const ruleCache = new Map<string, LoadedRule[]>();

--- a/src/classify/loader.test.mts
+++ b/src/classify/loader.test.mts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverRuleFiles, loadRules, _resetRuleCache } from "./loader.mts";
+
+let tmpDir: string;
+let classificationDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "prs-classify-test-"));
+  classificationDir = join(tmpDir, ".pr-shepherd", "classification");
+  mkdirSync(classificationDir, { recursive: true });
+  _resetRuleCache();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("discoverRuleFiles", () => {
+  it("returns empty array when no .pr-shepherd/classification dir exists", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "prs-empty-"));
+    try {
+      expect(discoverRuleFiles(emptyDir)).toEqual([]);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers .mjs and .js files in the classification dir", () => {
+    writeFileSync(join(classificationDir, "rule-a.mjs"), "export default () => null;");
+    writeFileSync(join(classificationDir, "rule-b.js"), "export default () => null;");
+    const files = discoverRuleFiles(tmpDir);
+    expect(files).toHaveLength(2);
+    expect(files[0]).toContain("rule-a.mjs");
+    expect(files[1]).toContain("rule-b.js");
+  });
+
+  it("ignores files starting with _ or .", () => {
+    writeFileSync(join(classificationDir, "_internal.mjs"), "export default () => null;");
+    writeFileSync(join(classificationDir, ".hidden.mjs"), "export default () => null;");
+    writeFileSync(join(classificationDir, "visible.mjs"), "export default () => null;");
+    const files = discoverRuleFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain("visible.mjs");
+  });
+
+  it("ignores files with non-JS extensions", () => {
+    writeFileSync(join(classificationDir, "rule.md"), "# not a rule");
+    writeFileSync(join(classificationDir, "rule.mjs"), "export default () => null;");
+    const files = discoverRuleFiles(tmpDir);
+    expect(files).toHaveLength(1);
+  });
+
+  it("walks up parent directories to find the classification dir", () => {
+    const nested = join(tmpDir, "a", "b", "c");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(classificationDir, "rule.mjs"), "export default () => null;");
+    const files = discoverRuleFiles(nested);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain("rule.mjs");
+  });
+
+  it("returns files sorted alphabetically", () => {
+    writeFileSync(join(classificationDir, "z-rule.mjs"), "export default () => null;");
+    writeFileSync(join(classificationDir, "a-rule.mjs"), "export default () => null;");
+    const files = discoverRuleFiles(tmpDir);
+    expect(files[0]).toContain("a-rule.mjs");
+    expect(files[1]).toContain("z-rule.mjs");
+  });
+});
+
+describe("loadRules", () => {
+  it("returns empty array for empty file list", async () => {
+    expect(await loadRules([])).toEqual([]);
+  });
+
+  it("loads a valid .mjs rule and returns it", async () => {
+    const file = join(classificationDir, "suppress-bot.mjs");
+    writeFileSync(file, 'export default (item) => item.author === "bot" ? { suppress: true } : null;');
+    const rules = await loadRules([file]);
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.name).toBe("suppress-bot");
+    expect(rules[0]!.rule({ kind: "pr-comment", id: "c1", author: "bot", authorType: "Bot", body: "hi", url: "" })).toEqual({ suppress: true });
+    expect(rules[0]!.rule({ kind: "pr-comment", id: "c2", author: "human", authorType: "User", body: "hi", url: "" })).toBeNull();
+  });
+
+  it("skips a file whose default export is not a function and writes to stderr", async () => {
+    const file = join(classificationDir, "bad-export.mjs");
+    writeFileSync(file, "export default { not: 'a function' };");
+    const rules = await loadRules([file]);
+    expect(rules).toHaveLength(0);
+  });
+
+  it("skips a file that throws on load", async () => {
+    const file = join(classificationDir, "throw-on-load.mjs");
+    writeFileSync(file, "throw new Error('load error');");
+    const rules = await loadRules([file]);
+    expect(rules).toHaveLength(0);
+  });
+
+  it("caches results for the same file list", async () => {
+    const file = join(classificationDir, "cached.mjs");
+    writeFileSync(file, "export default () => null;");
+    const first = await loadRules([file]);
+    const second = await loadRules([file]);
+    expect(first).toBe(second);
+  });
+
+  it("loads .mts files (tsx path)", async () => {
+    const file = join(classificationDir, "typed-rule.mts");
+    writeFileSync(file, "export default (item: { author: string }) => item.author === 'bot' ? { suppress: true } : null;");
+    const rules = await loadRules([file]);
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.name).toBe("typed-rule");
+  });
+
+  it("does not re-register tsx when already registered", async () => {
+    const file = join(classificationDir, "typed-rule.mts");
+    writeFileSync(file, "export default () => null;");
+    await loadRules([file]);  // sets tsxRegistered = true
+    _resetRuleCache();        // clears cache but NOT tsxRegistered
+    const rules = await loadRules([file]);  // hits early return in ensureTsxRegistered
+    expect(rules).toHaveLength(1);
+  });
+
+  it("handles non-Error exceptions during load", async () => {
+    const file = join(classificationDir, "throw-string.mjs");
+    writeFileSync(file, "throw 'not an error object';");
+    const rules = await loadRules([file]);
+    expect(rules).toHaveLength(0);
+  });
+});

--- a/src/classify/loader.test.mts
+++ b/src/classify/loader.test.mts
@@ -129,6 +129,16 @@ describe("loadRules", () => {
     expect(first).toBe(second);
   });
 
+  it("produces stable cache key regardless of input order", async () => {
+    const fileA = join(classificationDir, "rule-b.mjs");
+    const fileB = join(classificationDir, "rule-a.mjs");
+    writeFileSync(fileA, "export default () => null;");
+    writeFileSync(fileB, "export default () => null;");
+    const r1 = await loadRules([fileA, fileB]);
+    const r2 = await loadRules([fileB, fileA]); // same sorted key — cache hit
+    expect(r1).toBe(r2);
+  });
+
   it("loads .mts files (tsx path)", async () => {
     const file = join(classificationDir, "typed-rule.mts");
     writeFileSync(

--- a/src/classify/loader.test.mts
+++ b/src/classify/loader.test.mts
@@ -78,12 +78,33 @@ describe("loadRules", () => {
 
   it("loads a valid .mjs rule and returns it", async () => {
     const file = join(classificationDir, "suppress-bot.mjs");
-    writeFileSync(file, 'export default (item) => item.author === "bot" ? { suppress: true } : null;');
+    writeFileSync(
+      file,
+      'export default (item) => item.author === "bot" ? { suppress: true } : null;',
+    );
     const rules = await loadRules([file]);
     expect(rules).toHaveLength(1);
     expect(rules[0]!.name).toBe("suppress-bot");
-    expect(rules[0]!.rule({ kind: "pr-comment", id: "c1", author: "bot", authorType: "Bot", body: "hi", url: "" })).toEqual({ suppress: true });
-    expect(rules[0]!.rule({ kind: "pr-comment", id: "c2", author: "human", authorType: "User", body: "hi", url: "" })).toBeNull();
+    expect(
+      rules[0]!.rule({
+        kind: "pr-comment",
+        id: "c1",
+        author: "bot",
+        authorType: "Bot",
+        body: "hi",
+        url: "",
+      }),
+    ).toEqual({ suppress: true });
+    expect(
+      rules[0]!.rule({
+        kind: "pr-comment",
+        id: "c2",
+        author: "human",
+        authorType: "User",
+        body: "hi",
+        url: "",
+      }),
+    ).toBeNull();
   });
 
   it("skips a file whose default export is not a function and writes to stderr", async () => {
@@ -110,7 +131,10 @@ describe("loadRules", () => {
 
   it("loads .mts files (tsx path)", async () => {
     const file = join(classificationDir, "typed-rule.mts");
-    writeFileSync(file, "export default (item: { author: string }) => item.author === 'bot' ? { suppress: true } : null;");
+    writeFileSync(
+      file,
+      "export default (item: { author: string }) => item.author === 'bot' ? { suppress: true } : null;",
+    );
     const rules = await loadRules([file]);
     expect(rules).toHaveLength(1);
     expect(rules[0]!.name).toBe("typed-rule");
@@ -119,9 +143,9 @@ describe("loadRules", () => {
   it("does not re-register tsx when already registered", async () => {
     const file = join(classificationDir, "typed-rule.mts");
     writeFileSync(file, "export default () => null;");
-    await loadRules([file]);  // sets tsxRegistered = true
-    _resetRuleCache();        // clears cache but NOT tsxRegistered
-    const rules = await loadRules([file]);  // hits early return in ensureTsxRegistered
+    await loadRules([file]); // sets tsxRegistered = true
+    _resetRuleCache(); // clears cache but NOT tsxRegistered
+    const rules = await loadRules([file]); // hits early return in ensureTsxRegistered
     expect(rules).toHaveLength(1);
   });
 

--- a/src/classify/types.mts
+++ b/src/classify/types.mts
@@ -1,0 +1,48 @@
+export type ClassifyItemKind =
+  | "review-thread"
+  | "pr-comment"
+  | "review-summary"
+  | "changes-requested";
+
+export interface ClassifyItemBase {
+  readonly kind: ClassifyItemKind;
+  readonly id: string;
+  readonly author: string;
+  readonly authorType: "User" | "Bot" | "Unknown";
+  readonly body: string;
+  readonly url?: string;
+}
+
+export interface ClassifyReviewThread extends ClassifyItemBase {
+  readonly kind: "review-thread";
+  readonly path?: string | null;
+}
+
+export interface ClassifyPrComment extends ClassifyItemBase {
+  readonly kind: "pr-comment";
+}
+
+export interface ClassifyReviewSummary extends ClassifyItemBase {
+  readonly kind: "review-summary";
+}
+
+export interface ClassifyChangesRequested extends ClassifyItemBase {
+  readonly kind: "changes-requested";
+}
+
+export type ClassifyItem =
+  | ClassifyReviewThread
+  | ClassifyPrComment
+  | ClassifyReviewSummary
+  | ClassifyChangesRequested;
+
+export interface ClassifyAction {
+  /** When true, routes the item's ID to the appropriate resolve/minimize GitHub mutation. Not supported for changes-requested reviews. */
+  readonly autoResolve?: boolean;
+  /** When true, hides the item from agent output (seen marker is still written). */
+  readonly suppress?: boolean;
+  /** Optional note recorded to the debug log when this rule fires. */
+  readonly reason?: string;
+}
+
+export type ClassifyRule = (item: ClassifyItem) => ClassifyAction | null | undefined;

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -93,7 +93,9 @@ export async function runCheck(
   const firstLookSummaries: typeof batchData.reviewSummaries = [];
   const editedSummaries: typeof batchData.reviewSummaries = [];
   const seenSummaries: typeof batchData.reviewSummaries = [];
-  const unseenReviewSummaries = batchData.reviewSummaries.filter((r) => !partition.suppressedReviewSummaryIds.has(r.id));
+  const unseenReviewSummaries = batchData.reviewSummaries.filter(
+    (r) => !partition.suppressedReviewSummaryIds.has(r.id),
+  );
   for (const r of unseenReviewSummaries) {
     const cls = classifyItem(r.id, r.body, seenMap);
     if (cls === "new") firstLookSummaries.push(r);
@@ -101,7 +103,9 @@ export async function runCheck(
     else seenSummaries.push(r);
   }
   const changesRequestedReviewVisibility = classifyReviewsForDisplay(
-    batchData.changesRequestedReviews.filter((r) => !partition.suppressedChangesRequestedIds.has(r.id)),
+    batchData.changesRequestedReviews.filter(
+      (r) => !partition.suppressedChangesRequestedIds.has(r.id),
+    ),
     seenMap,
   );
   const approvedReviewVisibility = classifyReviewsForDisplay(batchData.approvedReviews, seenMap);
@@ -112,10 +116,18 @@ export async function runCheck(
     ...[...firstLookSummaries, ...editedSummaries].map((r) => markSeen(stateKey, r.id, r.body)),
     ...changesRequestedReviewVisibility.toMarkSeen.map((r) => markSeen(stateKey, r.id, r.body)),
     ...approvedReviewVisibility.toMarkSeen.map((r) => markSeen(stateKey, r.id, r.body)),
-    ...batchData.comments.filter((c) => partition.suppressedCommentIds.has(c.id)).map((c) => markSeen(stateKey, c.id, c.body)),
-    ...batchData.reviewThreads.filter((t) => partition.suppressedThreadIds.has(t.id)).map((t) => markSeen(stateKey, t.id, threadTranscriptBody(t))),
-    ...batchData.reviewSummaries.filter((r) => partition.suppressedReviewSummaryIds.has(r.id)).map((r) => markSeen(stateKey, r.id, r.body)),
-    ...batchData.changesRequestedReviews.filter((r) => partition.suppressedChangesRequestedIds.has(r.id)).map((r) => markSeen(stateKey, r.id, r.body)),
+    ...batchData.comments
+      .filter((c) => partition.suppressedCommentIds.has(c.id))
+      .map((c) => markSeen(stateKey, c.id, c.body)),
+    ...batchData.reviewThreads
+      .filter((t) => partition.suppressedThreadIds.has(t.id))
+      .map((t) => markSeen(stateKey, t.id, threadTranscriptBody(t))),
+    ...batchData.reviewSummaries
+      .filter((r) => partition.suppressedReviewSummaryIds.has(r.id))
+      .map((r) => markSeen(stateKey, r.id, r.body)),
+    ...batchData.changesRequestedReviews
+      .filter((r) => partition.suppressedChangesRequestedIds.has(r.id))
+      .map((r) => markSeen(stateKey, r.id, r.body)),
   ]);
   await markReviewInlineThreadMarkers(stateKey, batchData.reviewThreads);
   const changesRequestedReviews = changesRequestedReviewVisibility.visible;
@@ -165,11 +177,16 @@ export async function runCheck(
       autoResolved: [],
       autoResolveErrors: [],
       firstLook: threadVisibility.firstLookThreads,
-      ...(partition.ruleAutoResolveThreadIds.length > 0 ? { ruleAutoResolveIds: partition.ruleAutoResolveThreadIds } : undefined),
+      ...(partition.ruleAutoResolveThreadIds.length > 0
+        ? { ruleAutoResolveIds: partition.ruleAutoResolveThreadIds }
+        : undefined),
     },
     comments: {
       actionable: visibleCommentClassification.actionable,
-      minimizeIds: [...visibleCommentClassification.minimizeIds, ...partition.ruleAutoResolveCommentIds],
+      minimizeIds: [
+        ...visibleCommentClassification.minimizeIds,
+        ...partition.ruleAutoResolveCommentIds,
+      ],
       firstLook: firstLookComments,
     },
     changesRequestedReviews,
@@ -177,7 +194,9 @@ export async function runCheck(
     firstLookSummaries,
     editedSummaries,
     approvedReviews,
-    ...(partition.ruleAutoResolveReviewSummaryIds.length > 0 ? { ruleAutoResolveReviewSummaryIds: partition.ruleAutoResolveReviewSummaryIds } : undefined),
+    ...(partition.ruleAutoResolveReviewSummaryIds.length > 0
+      ? { ruleAutoResolveReviewSummaryIds: partition.ruleAutoResolveReviewSummaryIds }
+      : undefined),
     branchProtection: batchData.branchProtection,
     activity: batchData.activity,
   };

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -131,7 +131,9 @@ export async function runCheck(
   ]);
   await markReviewInlineThreadMarkers(stateKey, batchData.reviewThreads);
   const changesRequestedReviews = changesRequestedReviewVisibility.visible;
-  const changesRequestedReviewCount = batchData.changesRequestedReviews.length;
+  const changesRequestedReviewCount = batchData.changesRequestedReviews.filter(
+    (r) => !partition.suppressedChangesRequestedIds.has(r.id),
+  ).length;
   const approvedReviews = approvedReviewVisibility.visible;
   let status = computeStatus(
     verdict,
@@ -149,6 +151,7 @@ export async function runCheck(
       verdict,
       threadVisibility.activeThreads.length + threadVisibility.resolutionOnlyThreads.length,
       visibleCommentClassification.actionable.length,
+      changesRequestedReviewCount,
     );
     batchData = refreshed.batchData;
     mergeStatus = refreshed.mergeStatus;

--- a/src/commands/check.mts
+++ b/src/commands/check.mts
@@ -20,6 +20,8 @@ import { classifyThreadVisibility } from "../comments/thread-visibility.mts";
 import { classifyReviewsForDisplay } from "../comments/review-visibility.mts";
 import { markReviewInlineThreadMarkers } from "../comments/review-thread-markers.mts";
 import { normalizeBotUsernames } from "../comments/authors.mts";
+import { discoverRuleFiles, loadRules } from "../classify/loader.mts";
+import { buildClassifyIndex, partitionBatch } from "../classify/apply.mts";
 import type {
   GlobalOptions,
   ShepherdReport,
@@ -64,15 +66,24 @@ export async function runCheck(
   const stateKey = { owner: repo.owner, repo: repo.name, pr: prNumber };
   const seenMap = await loadSeenMap(stateKey);
   const botUsernames = normalizeBotUsernames(config.botUsernames);
+  const ruleSet = await loadRules(discoverRuleFiles(process.cwd()));
+  const classifyIndex = buildClassifyIndex(ruleSet, batchData);
+  const partition = partitionBatch(classifyIndex, batchData);
   const triaged = await attachUnseenCheckAnnotations(triagedBase, seenMap, prNumber);
-  const minimizedCommentCandidates = batchData.comments.filter((c) => c.isMinimized);
+  const minimizedCommentCandidates = batchData.comments.filter(
+    (c) => c.isMinimized && !partition.suppressedCommentIds.has(c.id),
+  );
   const visibleCommentClassification = classifyVisibleComments(
-    batchData.comments,
+    batchData.comments.filter((c) => !partition.suppressedCommentIds.has(c.id)),
     seenMap,
     config.iterate.minimizeComments,
     botUsernames,
   );
-  const threadVisibility = classifyThreadVisibility(batchData.reviewThreads, seenMap, botUsernames);
+  const threadVisibility = classifyThreadVisibility(
+    batchData.reviewThreads.filter((t) => !partition.suppressedThreadIds.has(t.id)),
+    seenMap,
+    botUsernames,
+  );
   const firstLookComments: FirstLookComment[] = minimizedCommentCandidates.flatMap((c) => {
     const cls = classifyItem(c.id, c.body, seenMap);
     if (cls === "unchanged") return [];
@@ -82,14 +93,15 @@ export async function runCheck(
   const firstLookSummaries: typeof batchData.reviewSummaries = [];
   const editedSummaries: typeof batchData.reviewSummaries = [];
   const seenSummaries: typeof batchData.reviewSummaries = [];
-  for (const r of batchData.reviewSummaries) {
+  const unseenReviewSummaries = batchData.reviewSummaries.filter((r) => !partition.suppressedReviewSummaryIds.has(r.id));
+  for (const r of unseenReviewSummaries) {
     const cls = classifyItem(r.id, r.body, seenMap);
     if (cls === "new") firstLookSummaries.push(r);
     else if (cls === "edited") editedSummaries.push(r);
     else seenSummaries.push(r);
   }
   const changesRequestedReviewVisibility = classifyReviewsForDisplay(
-    batchData.changesRequestedReviews,
+    batchData.changesRequestedReviews.filter((r) => !partition.suppressedChangesRequestedIds.has(r.id)),
     seenMap,
   );
   const approvedReviewVisibility = classifyReviewsForDisplay(batchData.approvedReviews, seenMap);
@@ -100,6 +112,10 @@ export async function runCheck(
     ...[...firstLookSummaries, ...editedSummaries].map((r) => markSeen(stateKey, r.id, r.body)),
     ...changesRequestedReviewVisibility.toMarkSeen.map((r) => markSeen(stateKey, r.id, r.body)),
     ...approvedReviewVisibility.toMarkSeen.map((r) => markSeen(stateKey, r.id, r.body)),
+    ...batchData.comments.filter((c) => partition.suppressedCommentIds.has(c.id)).map((c) => markSeen(stateKey, c.id, c.body)),
+    ...batchData.reviewThreads.filter((t) => partition.suppressedThreadIds.has(t.id)).map((t) => markSeen(stateKey, t.id, threadTranscriptBody(t))),
+    ...batchData.reviewSummaries.filter((r) => partition.suppressedReviewSummaryIds.has(r.id)).map((r) => markSeen(stateKey, r.id, r.body)),
+    ...batchData.changesRequestedReviews.filter((r) => partition.suppressedChangesRequestedIds.has(r.id)).map((r) => markSeen(stateKey, r.id, r.body)),
   ]);
   await markReviewInlineThreadMarkers(stateKey, batchData.reviewThreads);
   const changesRequestedReviews = changesRequestedReviewVisibility.visible;
@@ -149,10 +165,11 @@ export async function runCheck(
       autoResolved: [],
       autoResolveErrors: [],
       firstLook: threadVisibility.firstLookThreads,
+      ...(partition.ruleAutoResolveThreadIds.length > 0 ? { ruleAutoResolveIds: partition.ruleAutoResolveThreadIds } : undefined),
     },
     comments: {
       actionable: visibleCommentClassification.actionable,
-      minimizeIds: visibleCommentClassification.minimizeIds,
+      minimizeIds: [...visibleCommentClassification.minimizeIds, ...partition.ruleAutoResolveCommentIds],
       firstLook: firstLookComments,
     },
     changesRequestedReviews,
@@ -160,6 +177,7 @@ export async function runCheck(
     firstLookSummaries,
     editedSummaries,
     approvedReviews,
+    ...(partition.ruleAutoResolveReviewSummaryIds.length > 0 ? { ruleAutoResolveReviewSummaryIds: partition.ruleAutoResolveReviewSummaryIds } : undefined),
     branchProtection: batchData.branchProtection,
     activity: batchData.activity,
   };

--- a/src/commands/check.runcheck-classification-rules.mock.test.mts
+++ b/src/commands/check.runcheck-classification-rules.mock.test.mts
@@ -3,6 +3,7 @@ import {
   registerHooks,
   BASE_OPTS,
   makeBatchData,
+  makeComment,
   mockFetchPrBatch,
 } from "../../test-helpers/commands/check.test-support.mts";
 import { runCheck } from "./check.mts";
@@ -80,6 +81,24 @@ describe("runCheck — classification rules", () => {
     const report = await runCheck(BASE_OPTS);
     expect(report.reviewSummaries.map((r) => r.id)).not.toContain("rev-bot");
     expect(report.ruleAutoResolveReviewSummaryIds).toContain("rev-bot");
+  });
+
+  it("suppresses matching pr-comments and marks them seen", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        comments: [
+          makeComment({
+            id: "c-bot",
+            author: "bot-reviewer",
+            authorType: "Bot" as const,
+            body: "Bot noise comment",
+            isMinimized: false,
+          }),
+        ],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.comments.actionable.map((c) => c.id)).not.toContain("c-bot");
   });
 
   it("suppressed changes-requested review does not count as blocking", async () => {

--- a/src/commands/check.runcheck-classification-rules.mock.test.mts
+++ b/src/commands/check.runcheck-classification-rules.mock.test.mts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  registerHooks,
+  BASE_OPTS,
+  makeBatchData,
+  mockFetchPrBatch,
+} from "../../test-helpers/commands/check.test-support.mts";
+import { runCheck } from "./check.mts";
+import type { ClassifyItem } from "../classify/types.mts";
+
+vi.mock("../classify/loader.mts", () => ({
+  discoverRuleFiles: vi.fn().mockReturnValue(["fake-rule.mjs"]),
+  loadRules: vi.fn().mockResolvedValue([
+    {
+      name: "test-rule",
+      file: "fake-rule.mjs",
+      rule: (item: ClassifyItem) =>
+        item.author === "bot-reviewer" ? { suppress: true, autoResolve: true } : null,
+    },
+  ]),
+}));
+
+registerHooks();
+
+describe("runCheck — classification rules", () => {
+  it("suppresses matching threads and populates ruleAutoResolveIds", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        reviewThreads: [
+          {
+            id: "t-bot",
+            isResolved: false,
+            isOutdated: false,
+            isMinimized: false,
+            path: "src/foo.ts",
+            line: 1,
+            startLine: null,
+            author: "bot-reviewer",
+            authorType: "Bot" as const,
+            body: "Bot noise",
+            url: "",
+            createdAtUnix: 0,
+          },
+          {
+            id: "t-human",
+            isResolved: false,
+            isOutdated: false,
+            isMinimized: false,
+            path: "src/bar.ts",
+            line: 2,
+            startLine: null,
+            author: "human",
+            authorType: "User" as const,
+            body: "Real review",
+            url: "",
+            createdAtUnix: 0,
+          },
+        ],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.threads.actionable.map((t) => t.id)).not.toContain("t-bot");
+    expect(report.threads.actionable.map((t) => t.id)).toContain("t-human");
+    expect(report.threads.ruleAutoResolveIds).toContain("t-bot");
+  });
+
+  it("suppresses matching review summaries and populates ruleAutoResolveReviewSummaryIds", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        reviewSummaries: [
+          {
+            id: "rev-bot",
+            author: "bot-reviewer",
+            authorType: "Bot" as const,
+            body: "Bot noise summary",
+          },
+        ],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.reviewSummaries.map((r) => r.id)).not.toContain("rev-bot");
+    expect(report.ruleAutoResolveReviewSummaryIds).toContain("rev-bot");
+  });
+});

--- a/src/commands/check.runcheck-classification-rules.mock.test.mts
+++ b/src/commands/check.runcheck-classification-rules.mock.test.mts
@@ -81,4 +81,22 @@ describe("runCheck — classification rules", () => {
     expect(report.reviewSummaries.map((r) => r.id)).not.toContain("rev-bot");
     expect(report.ruleAutoResolveReviewSummaryIds).toContain("rev-bot");
   });
+
+  it("suppressed changes-requested review does not count as blocking", async () => {
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({
+        changesRequestedReviews: [
+          {
+            id: "cr-bot",
+            author: "bot-reviewer",
+            authorType: "Bot" as const,
+            body: "Bot changes requested",
+          },
+        ],
+      }),
+    });
+    const report = await runCheck(BASE_OPTS);
+    expect(report.changesRequestedReviews).toHaveLength(0);
+    expect(report.status).toBe("READY");
+  });
 });

--- a/src/commands/iterate.stall.it-resets-firstseenat-when-fingerprint-changes-differe.mock.test.mts
+++ b/src/commands/iterate.stall.it-resets-firstseenat-when-fingerprint-changes-differe.mock.test.mts
@@ -21,6 +21,47 @@ registerIterateHooks();
 // ---------------------------------------------------------------------------
 
 describe("runIterate — stall-timeout guard", () => {
+  it("resets firstSeenAt when ruleAutoResolveIds change", async () => {
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        threads: {
+          actionable: [],
+          resolutionOnly: [],
+          autoResolved: [],
+          autoResolveErrors: [],
+          firstLook: [],
+          ruleAutoResolveIds: ["thread-2", "thread-1"],
+        },
+        ruleAutoResolveReviewSummaryIds: ["summary-2", "summary-1"],
+      }),
+    );
+    mockReadStallState.mockResolvedValue(null);
+    await runIterate(makeOpts30mStall());
+    const fp1 = (mockWriteStallState.mock.calls[0]![1] as StallState).fingerprint;
+
+    mockWriteStallState.mockClear();
+    mockRunCheck.mockResolvedValue(
+      makeReport({
+        threads: {
+          actionable: [],
+          resolutionOnly: [],
+          autoResolved: [],
+          autoResolveErrors: [],
+          firstLook: [],
+          ruleAutoResolveIds: ["thread-1", "thread-3"],
+        },
+      }),
+    );
+    mockReadStallState.mockResolvedValue({ fingerprint: fp1, firstSeenAt: NOW - STALL_TIMEOUT_S });
+
+    const result = await runIterate(makeOpts30mStall());
+
+    expect(result.action).not.toBe("escalate");
+    const written = mockWriteStallState.mock.calls[0]![1] as StallState;
+    expect(written.firstSeenAt).toBe(NOW);
+    expect(written.fingerprint).not.toBe(fp1);
+  });
+
   it("resets firstSeenAt when fingerprint changes (different failing checks)", async () => {
     // First call: passing report.
     mockRunCheck.mockResolvedValue(makeReport());

--- a/src/commands/iterate/classify.mts
+++ b/src/commands/iterate/classify.mts
@@ -93,7 +93,9 @@ export function buildResolveCommand(
   );
   // Rule-matched threads bypass the author check (human-author guard still applies in resolve-mutate).
   const resolveThreadIds = dedupeIds([
-    ...allThreads.filter((t) => !isHumanAuthor(t) || isConfiguredBotAuthor(t, botUsernames)).map((t) => t.id),
+    ...allThreads
+      .filter((t) => !isHumanAuthor(t) || isConfiguredBotAuthor(t, botUsernames))
+      .map((t) => t.id),
     ...ruleAutoResolveThreadIds,
   ]);
 

--- a/src/commands/iterate/classify.mts
+++ b/src/commands/iterate/classify.mts
@@ -32,6 +32,7 @@ export function classifyReviewSummaries(
   minimizeComments: MinimizeCommentsPolicy | undefined = "all",
   botUsernames: NormalizedBotUsernames = new Set(),
   unresolvedThreads: ReviewThread[] = [],
+  ruleAutoResolveIds: string[] = [],
 ): {
   minimizeIds: string[];
   firstLookSummaries: Review[];
@@ -48,6 +49,10 @@ export function classifyReviewSummaries(
     .filter((r) => shouldMinimizeAuthor(r.authorType, minimizeComments, r.author, botUsernames))
     .filter((r) => !blockedReviewIds.has(r.id))
     .map((r) => r.id);
+  // Rule-matched summaries are already suppressed from agent output; bypass normal policy gates.
+  for (const id of ruleAutoResolveIds) {
+    if (!minimizeIds.includes(id)) minimizeIds.push(id);
+  }
   if (minimizeApprovals) {
     const surfacedApprovals: Review[] = [];
     for (const r of approvals) {
@@ -78,6 +83,7 @@ export function buildResolveCommand(
   checks: AgentCheck[],
   prNumber: number,
   botUsernames: NormalizedBotUsernames = new Set(),
+  ruleAutoResolveThreadIds: string[] = [],
 ): { resolveCommand: ResolveCommand; resolveOnlyCommand?: ResolveCommand } {
   const allThreads = [...threads, ...resolutionOnlyThreads];
   const replyThreadIds = dedupeIds(
@@ -85,11 +91,11 @@ export function buildResolveCommand(
       .filter((t) => isHumanAuthor(t) && !isConfiguredBotAuthor(t, botUsernames))
       .map((t) => t.id),
   );
-  const resolveThreadIds = dedupeIds(
-    allThreads
-      .filter((t) => !isHumanAuthor(t) || isConfiguredBotAuthor(t, botUsernames))
-      .map((t) => t.id),
-  );
+  // Rule-matched threads bypass the author check (human-author guard still applies in resolve-mutate).
+  const resolveThreadIds = dedupeIds([
+    ...allThreads.filter((t) => !isHumanAuthor(t) || isConfiguredBotAuthor(t, botUsernames)).map((t) => t.id),
+    ...ruleAutoResolveThreadIds,
+  ]);
 
   const hasReply = replyThreadIds.length > 0;
   const hasResolveOrMinimize = resolveThreadIds.length > 0 || allCommentIds.length > 0;

--- a/src/commands/iterate/fix-code.mts
+++ b/src/commands/iterate/fix-code.mts
@@ -42,6 +42,7 @@ interface HandleFixCodeContext {
   editedSummaries: Review[];
   surfacedApprovals: Review[];
   botUsernames: NormalizedBotUsernames;
+  ruleAutoResolveThreadIds?: string[];
 }
 
 function nextFixAttempts(
@@ -80,6 +81,7 @@ export async function handleFixCode(ctx: HandleFixCodeContext): Promise<IterateR
     editedSummaries,
     surfacedApprovals,
     botUsernames,
+    ruleAutoResolveThreadIds,
   } = ctx;
   const failingChecks = report.checks.failing;
   const stored = await readFixAttempts({ owner: repoOwner, repo: repoName, pr: prNumber });
@@ -152,6 +154,7 @@ export async function handleFixCode(ctx: HandleFixCodeContext): Promise<IterateR
     checks,
     prNumber,
     botUsernames,
+    ruleAutoResolveThreadIds,
   );
   // Safety: if the base branch is unknown, escalate when a push is plausible — the agent
   // would need the correct base to rebase safely. This is a conservative guard, not a

--- a/src/commands/iterate/index.mts
+++ b/src/commands/iterate/index.mts
@@ -85,11 +85,13 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
     config.iterate.minimizeComments,
     botUsernames,
     [...report.threads.actionable, ...report.threads.resolutionOnly],
+    report.ruleAutoResolveReviewSummaryIds,
   );
   const hasActionableWork =
     report.threads.actionable.length > 0 ||
     report.threads.resolutionOnly.length > 0 ||
     report.threads.firstLook.length > 0 ||
+    (report.threads.ruleAutoResolveIds?.length ?? 0) > 0 ||
     report.comments.actionable.length > 0 ||
     (report.comments.minimizeIds?.length ?? 0) > 0 ||
     report.comments.firstLook.length > 0 ||
@@ -162,6 +164,7 @@ export async function runIterate(opts: IterateCommandOptions): Promise<IterateRe
       editedSummaries,
       surfacedApprovals,
       botUsernames,
+      ruleAutoResolveThreadIds: report.threads.ruleAutoResolveIds,
     });
   }
 

--- a/src/commands/iterate/stall.mts
+++ b/src/commands/iterate/stall.mts
@@ -22,9 +22,11 @@ function computeStallFingerprint(
   ].sort();
   const threads = report.threads.actionable.map((t) => t.id).sort();
   const resolutionOnlyThreads = report.threads.resolutionOnly.map((t) => t.id).sort();
+  const ruleAutoResolveThreads = (report.threads.ruleAutoResolveIds ?? []).sort();
   const comments = report.comments.actionable.map((c) => c.id).sort();
   const reviews = report.changesRequestedReviews.map((r) => r.id).sort();
   const summaries = [...reviewSummaryIds].sort();
+  const ruleAutoResolveSummaries = (report.ruleAutoResolveReviewSummaryIds ?? []).sort();
   return JSON.stringify({
     action,
     headSha,
@@ -35,9 +37,11 @@ function computeStallFingerprint(
     checks,
     threads,
     resolutionOnlyThreads,
+    ruleAutoResolveThreads,
     comments,
     reviews,
     summaries,
+    ruleAutoResolveSummaries,
   });
 }
 

--- a/src/commands/iterate/stall.mts
+++ b/src/commands/iterate/stall.mts
@@ -22,11 +22,15 @@ function computeStallFingerprint(
   ].sort();
   const threads = report.threads.actionable.map((t) => t.id).sort();
   const resolutionOnlyThreads = report.threads.resolutionOnly.map((t) => t.id).sort();
-  const ruleAutoResolveThreads = (report.threads.ruleAutoResolveIds ?? []).sort();
+  const ruleAutoResolveThreads = (report.threads.ruleAutoResolveIds ?? []).sort((a, b) =>
+    a.localeCompare(b),
+  );
   const comments = report.comments.actionable.map((c) => c.id).sort();
   const reviews = report.changesRequestedReviews.map((r) => r.id).sort();
   const summaries = [...reviewSummaryIds].sort();
-  const ruleAutoResolveSummaries = (report.ruleAutoResolveReviewSummaryIds ?? []).sort();
+  const ruleAutoResolveSummaries = (report.ruleAutoResolveReviewSummaryIds ?? []).sort((a, b) =>
+    a.localeCompare(b),
+  );
   return JSON.stringify({
     action,
     headSha,

--- a/src/commands/ready-mergeability.mts
+++ b/src/commands/ready-mergeability.mts
@@ -32,6 +32,7 @@ export async function refreshReadyMergeability(
   verdict: CiVerdict,
   unresolvedThreads: number,
   unresolvedComments: number,
+  changesRequestedCount: number,
 ): Promise<ReadyMergeabilityRefresh> {
   const refreshedBatchData = await readMergeability(prNumber, repo, batchData);
   const mergeStatus = deriveMergeStatus(refreshedBatchData);
@@ -40,7 +41,7 @@ export async function refreshReadyMergeability(
     unresolvedThreads,
     unresolvedComments,
     mergeStatus,
-    refreshedBatchData.changesRequestedReviews.length,
+    changesRequestedCount,
   );
   return { batchData: refreshedBatchData, mergeStatus, status };
 }

--- a/src/commands/ready-mergeability.test.mts
+++ b/src/commands/ready-mergeability.test.mts
@@ -96,6 +96,7 @@ describe("refreshReadyMergeability", () => {
       },
       0,
       0,
+      0,
     );
 
     expect(refreshed.batchData.mergeable).toBe("MERGEABLE");

--- a/src/types/report.mts
+++ b/src/types/report.mts
@@ -63,6 +63,8 @@ export interface ShepherdReport {
     autoResolveErrors: string[];
     /** First-look items — outdated/resolved/minimized threads not yet seen by the agent. */
     firstLook: FirstLookThread[];
+    /** Thread IDs matched by user classification rules with autoResolve:true — routed to resolveThreadIds. */
+    ruleAutoResolveIds?: string[];
   };
   comments: {
     actionable: ActionableComment[];
@@ -80,6 +82,8 @@ export interface ShepherdReport {
   editedSummaries: Review[];
   /** APPROVED reviews not yet minimized — opt-in minimize target. */
   approvedReviews: Review[];
+  /** COMMENTED review summary IDs matched by user rules with autoResolve:true — minimized without surfacing to agent. */
+  ruleAutoResolveReviewSummaryIds?: string[];
   /** Branch protection rule for the PR's base branch. Null when no rule exists or the base ref is unavailable. */
   branchProtection: import("./github.mts").BranchProtection | null;
   activity?: PrActivitySummary;
@@ -120,17 +124,9 @@ export interface AgentComment {
   edited?: boolean;
 }
 
-/**
- * Check shape emitted to the iterate agent under `fix_code`. Cancelled checks
+/** Check shape emitted to the iterate agent under `fix_code`. Cancelled checks
  * should be handled from `name`/`runId`/`detailsUrl`/`conclusion`; optional
- * workflow/job/step metadata may still be present when available.
- *
- * TODO(C1): Collapse AgentCheck into RelevantCheck — the only difference is that
- * AgentCheck allows a null conclusion while RelevantCheck excludes null. Once
- * toAgentCheck in reporters/agent.mts is confirmed to never receive a null conclusion
- * (i.e., all upstream TriagedCheck sources guard against it), remove AgentCheck and
- * replace all usages with RelevantCheck.
- */
+ * workflow/job/step metadata may still be present when available. */
 export interface AgentCheck {
   name: string;
   runId: string | null;


### PR DESCRIPTION
## Summary

- Adds `.pr-shepherd/classification/` plugin system: drop `.ts`/`.mts`/`.mjs`/`.js` rule files to match PR items and return `{ suppress?, autoResolve? }` actions
- `suppress: true` hides items from agent output while still writing a seen marker (prevents first-look re-surface)
- `autoResolve: true` routes IDs into the existing resolve/minimize mutation (threads → `--resolve-thread-ids`, comments/review summaries → `--minimize-comment-ids`)
- Four item kinds supported: `review-thread`, `pr-comment`, `review-summary`, `changes-requested` (autoResolve not supported for changes-requested — requires explicit dismiss message)
- Types published as `pr-shepherd/classify` subpath so rule files can `import type { ClassifyRule }`
- TypeScript rule files loaded lazily via `tsx` (added as runtime dependency)
- Ships three ready-to-use example rules for `gemini-code-assist` quota/review-limit notices and `coderabbitai` "Reviews paused"

## New files

- `src/classify/types.mts` — public API (`ClassifyItem`, `ClassifyAction`, `ClassifyRule`)
- `src/classify/loader.mts` — rule discovery + tsx lazy-loading
- `src/classify/apply.mts` — rule application + batch partition (`buildClassifyIndex`, `partitionBatch`)
- `src/classify/loader.test.mts` + `src/classify/apply.test.mts` — full unit test coverage
- `examples/classification/` — three copy-pasteable example rules

## Modified files

- `src/commands/check.mts` — builds classify index, filters suppressed items from all three classifiers, writes seen markers for suppressed items
- `src/commands/iterate/classify.mts` — unions autoResolve IDs into `minimizeIds`/`resolveThreadIds`
- `src/commands/iterate/fix-code.mts` + `index.mts` — threads rule autoResolve IDs through the iterate pipeline
- `src/types/report.mts` — adds `threads.ruleAutoResolveIds?` and `ruleAutoResolveReviewSummaryIds?`
- `docs/actions.md` + `README.md` — documents the classification rule system

## Test plan

- [x] All 1206 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Build succeeds with `bin/classify/` emitted (`npm run build`)
- [x] Type-check passes (`npm run typecheck`)
- [x] `src/classify` coverage at 100% (disappeared from coverage table — no uncovered lines/branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- [Sourcery review PRR_kwDOSGizTs8AAAABBy4xsg](https://github.com/jonathanong/pr-shepherd/pull/260): All three suggestions accepted and implemented — (1) log rule name + message to stderr on evaluation throw, (2) normalize cache key by sorting file list before join, (3) set `tsxRegistered` after successful `register()` call so a failed import allows retry. Fixed in commit 49c09c9.

- [chatgpt-codex-connector PRRT_kwDOSGizTs6GocuM](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345939066) and [PRRT_kwDOSGizTs6GocuP](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345939070) and [PRRT_kwDOSGizTs6GocuV](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345939077): All three accepted and fixed in commit a0647ce — (1) autoResolve no longer requires suppress in partitionBatch, (2) already-resolved/outdated threads skipped from ruleAutoResolveThreadIds, (3) suppressedChangesRequestedIds excluded from changesRequestedReviewCount to prevent iterate deadlock; refreshReadyMergeability also updated to receive the filtered count.

- [chatgpt-codex-connector PRRT_kwDOSGizTs6GocuY](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345939081) (P1 security): Acknowledged. Classification rules are user-supplied code committed to the repo, equivalent in trust level to package.json scripts and other build hooks. For fork PRs in CI, the same risk exists for any other scripted config. A follow-up can add a `--no-classify` flag or fork-detection guard. No code change in this PR.

- [coderabbitai PRRT_kwDOSGizTs6GofJZ](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345952867): Accepted — added try/catch in ensureTsxRegistered so a tsx import failure logs a warning instead of crashing the CLI. Catch block marked `/* c8 ignore */` as defensive code for an untestable import failure. Fixed in commit a0647ce.

- [chatgpt-codex-connector PRRT_kwDOSGizTs6GolSP](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345986464) (child-thread guard): Intentional design per plan — rule-based autoResolve for review summaries bypasses `blockedReviewIds` by design, since the rule author explicitly opted in. The rule says "minimize this regardless of child threads." No change.

- [chatgpt-codex-connector PRRT_kwDOSGizTs6GolSQ](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345986465) (human-mutation guard): Acknowledged limitation — if a rule suppresses a User-authored item with `autoResolve: true`, the resolve mutation will be silently skipped by the human-author guard while the item stays hidden. Practical impact is low since example rules target bots. The stall fingerprint fix (commit fd9aad2) ensures the stall guard eventually escalates rather than looping silently. Full fix deferred to a follow-up that threads bot/user awareness into the classify pipeline.

- [chatgpt-codex-connector PRRT_kwDOSGizTs6GolST](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3345986469) (stall fingerprint): Accepted and fixed in commit fd9aad2 — added `ruleAutoResolveThreads` and `ruleAutoResolveSummaries` to `computeStallFingerprint` so a new set of rule-matched items resets the stall timer.

- [chatgpt-codex-connector PRRT_kwDOSGizTs6GovS5](https://github.com/jonathanong/pr-shepherd/pull/260#discussion_r3346044531) (rule cache staleness): Acknowledged — the ruleCache is keyed by sorted file paths; if a rule file is edited in-place between poll ticks, the cached LoadedRule[] is returned and Node.js's module cache also holds the old import. Fixing this correctly requires cache-busting the module loader (e.g. file?t=<mtime>) on every tick with changed mtimes, which adds per-tick FS reads. Deferred to a follow-up issue. In practice, rules are stable committed files and a process restart clears both caches.

- Kilo Code Review check (https://app.kilo.ai/code-reviews/c6782a00-8dc9-49a4-9af0-ffb154958e2e): kilo-code-bot's PR comment reports "No Issues Found | Recommendation: Merge" for all 15 reviewed files, but the GitHub check status remains `FAILURE`. This is a Kilo Code infrastructure issue — the check conclusion does not auto-update to success when no issues are found. No code change warranted.
