### PR TITLE
fix: skip already-minimized PR comments in autoResolve minimize queue (#265)

### DIFF
--- a/src/classify/apply.mts
+++ b/src/classify/apply.mts
@@ -124,7 +124,7 @@ export function partitionBatch(index: ClassifyIndex, batch: BatchPrData): BatchP
     batch.changesRequestedReviews.filter((r) => suppressedIds.has(r.id)).map((r) => r.id),
   );
   const ruleAutoResolveCommentIds = batch.comments
-    .filter((c) => autoResolveIds.has(c.id))
+    .filter((c) => !c.isMinimized && autoResolveIds.has(c.id))
     .map((c) => c.id);
   const ruleAutoResolveThreadIds = batch.reviewThreads
     .filter((t) => !t.isResolved && !t.isOutdated && autoResolveIds.has(t.id))

--- a/src/classify/apply.test.mts
+++ b/src/classify/apply.test.mts
@@ -258,4 +258,15 @@ describe("partitionBatch", () => {
     expect(p.ruleAutoResolveThreadIds).not.toContain("t-resolved");
     expect(p.ruleAutoResolveThreadIds).not.toContain("t-outdated");
   });
+
+  it("skips already-minimized comments in ruleAutoResolveCommentIds", () => {
+    const rule = makeRule("r", () => ({ autoResolve: true }));
+    const batch = makeBatch({
+      comments: [makeComment("c-open"), { ...makeComment("c-min"), isMinimized: true }],
+    });
+    const idx = buildClassifyIndex([rule], batch);
+    const p = partitionBatch(idx, batch);
+    expect(p.ruleAutoResolveCommentIds).toContain("c-open");
+    expect(p.ruleAutoResolveCommentIds).not.toContain("c-min");
+  });
 });


### PR DESCRIPTION
Fixes #265.

## Problem

When a classification rule returns `{ suppress: true, autoResolve: true }` for a PR **comment**, pr-shepherd minimizes it on the first tick (correct) but then re-adds the same comment ID to `--minimize-comment-ids` on **every** subsequent tick — even though GitHub already reports `isMinimized: true`. The minimize mutation is idempotent, so nothing breaks server-side, but the perpetually non-empty minimize queue keeps `shepherd iterate` emitting `[FIX_CODE]` with nothing actionable to do → infinite loop.

## Root cause

In `partitionBatch` (`src/classify/apply.mts`), `ruleAutoResolveCommentIds` filtered `batch.comments` only by `autoResolveIds.has(c.id)` — it never checked the terminal `c.isMinimized` state. The review-thread branch right below it already gates on terminal states (`!isResolved && !isOutdated`), and review summaries are filtered by `!isMinimized` upstream in `batch-parsers.mts`. PR comments were the only path missing the gate.

## Fix

One-line terminal-state gate, mirroring the existing thread filter:

```ts
const ruleAutoResolveCommentIds = batch.comments
  .filter((c) => !c.isMinimized && autoResolveIds.has(c.id))
  .map((c) => c.id);
```

The `suppress` path is untouched — minimized comments are still hidden from agent output, which is already correct.

## Tests

Added a `partitionBatch` case asserting an already-minimized comment is excluded from `ruleAutoResolveCommentIds` while an open one is included, paralleling the existing already-resolved/outdated thread test.

`docs: n/a` — no user-facing behavior, command, flag, or output-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- [coderabbit rate-limit notice](https://github.com/jonathanong/pr-shepherd/pull/266#issuecomment-4609911511): no review content (rate limit reached), no code change warranted — minimized.