### PR TITLE
[codex] update poll defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Direct CLI:
 
 ```sh
 pr-shepherd 42                         # poll until non-WAIT or timeout
-pr-shepherd 42 --interval 45s --timeout 4m
+pr-shepherd 42 --interval 60s --timeout 4.5m
 pr-shepherd 42 --quiet-status          # print only changed WAIT status snapshots
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42                 # single tick

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Direct CLI:
 
 ```sh
 pr-shepherd 42                         # poll until non-WAIT or timeout
-pr-shepherd 42 --interval 60s --timeout 4.5m
+pr-shepherd 42 --interval 60s --timeout 270s
 pr-shepherd 42 --quiet-status          # print only changed WAIT status snapshots
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42                 # single tick

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -27,7 +27,7 @@ pr-shepherd log-file [--format text|json]
 
 ```sh
 pr-shepherd 42
-pr-shepherd 42 --interval 45s --timeout 4m
+pr-shepherd 42 --interval 60s --timeout 4.5m
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42
 pr-shepherd poll 42 --format=json
@@ -48,10 +48,10 @@ pr-shepherd poll 42 --format=json
 
 | Flag                    | Default | Description                                                        |
 | ----------------------- | ------- | ------------------------------------------------------------------ |
-| `--interval <duration>` | `30s`   | Sleep between `WAIT` ticks.                                        |
-| `--timeout <duration>`  | `5m`    | Maximum wall-clock wait before returning the latest `WAIT` result. |
+| `--interval <duration>` | `60s`   | Sleep between `WAIT` ticks.                                        |
+| `--timeout <duration>`  | `4.5m`  | Maximum wall-clock wait before returning the latest `WAIT` result. |
 
-Durations accept seconds, minutes, hours, or bare seconds: `30s`, `2m`, `1h`, `45`.
+Durations accept seconds, minutes, hours, or bare seconds: `30s`, `4.5m`, `1h`, `45`.
 
 Exit codes for iterate and poll: `0` `WAIT`/`MARK_READY`, `1` `FIX_CODE` or command error, `2` `CANCEL`, `3` `ESCALATE`.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -27,7 +27,7 @@ pr-shepherd log-file [--format text|json]
 
 ```sh
 pr-shepherd 42
-pr-shepherd 42 --interval 60s --timeout 4.5m
+pr-shepherd 42 --interval 60s --timeout 270s
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42
 pr-shepherd poll 42 --format=json
@@ -51,7 +51,7 @@ pr-shepherd poll 42 --format=json
 | `--interval <duration>` | `60s`   | Sleep between `WAIT` ticks.                                        |
 | `--timeout <duration>`  | `4.5m`  | Maximum wall-clock wait before returning the latest `WAIT` result. |
 
-Durations accept seconds, minutes, hours, or bare seconds: `30s`, `4.5m`, `1h`, `45`.
+Durations accept seconds, minutes, hours, or bare seconds: `30s`, `270s`, `4.5m`, `1h`, `45`.
 
 Exit codes for iterate and poll: `0` `WAIT`/`MARK_READY`, `1` `FIX_CODE` or command error, `2` `CANCEL`, `3` `ESCALATE`.
 

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -22,7 +22,7 @@ Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with
    The skill resolves the PR number and runs the default poll dispatcher:
 
    ```bash
-   pr-shepherd <PR> --interval 45s --timeout 4m
+   pr-shepherd <PR> --interval 60s --timeout 4.5m
    ```
 
 2. **CLI emits an action with `## Instructions`**
@@ -66,6 +66,6 @@ User                    Active Goal             shepherd iterate / poll
 
 ## Notes
 
-- Poll uses `--interval` and `--timeout` for WAIT-state rechecks. Defaults are 30 seconds and 5 minutes.
+- Poll uses `--interval` and `--timeout` for WAIT-state rechecks. Defaults are 60 seconds and 4.5 minutes.
 - Code changes (`fix_code`, rebase) are handled inline by the active goal — no subagent is spawned.
 - The ready-delay (default 10 minutes) is read from `watch.readyDelayMinutes` in `.pr-shepherdrc.yml`. See [ready-delay.md](ready-delay.md) and [configuration.md](configuration.md).

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -16,7 +16,7 @@ Poll dispatcher for iterating a PR to completion.
 
 1. **Resolve the PR number** (`$N`): use the number or URL in `$ARGUMENTS`; otherwise infer it with `gh pr view --json number --jq .number`. If none is found, report an error and stop.
 
-2. **Define the poll command once:** `pr-shepherd $N --interval 45s --timeout 4m`. Do not forward `$ARGUMENTS` as extra flags. Run `pr-shepherd --help` to inspect supported options.
+2. **Define the poll command once:** `pr-shepherd $N --interval 60s --timeout 4.5m`. Do not forward `$ARGUMENTS` as extra flags. Run `pr-shepherd --help` to inspect supported options.
 
 3. **Loop:** Run the poll, print its full output, and follow its `## Instructions` section exactly. Then run the poll again. Repeat until the CLI emits `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) is non-terminal: do its instructions, then poll again. The poll already bounds each wait via `--interval`/`--timeout`; do not add manual `sleep`s between ticks.
 

--- a/src/cli-parser.iterate.main-iterate.mock.test.mts
+++ b/src/cli-parser.iterate.main-iterate.mock.test.mts
@@ -52,8 +52,8 @@ describe("main — default (poll)", () => {
       .mockResolvedValueOnce(makeIterateResult("wait"))
       .mockResolvedValue(makeIterateResult("cancel"));
 
-    const promise = main(["node", "shepherd", "42", "--interval", "45s", "--timeout", "4m"]);
-    await vi.advanceTimersByTimeAsync(45_000);
+    const promise = main(["node", "shepherd", "42", "--interval", "60s", "--timeout", "4.5m"]);
+    await vi.advanceTimersByTimeAsync(60_000);
     await promise;
 
     expect(mockRunIterate).toHaveBeenCalledTimes(2);

--- a/src/cli-parser.poll.mock.test.mts
+++ b/src/cli-parser.poll.mock.test.mts
@@ -59,17 +59,8 @@ describe("main — poll subcommand", () => {
       .mockResolvedValueOnce(makeIterateResult("wait"))
       .mockResolvedValue(makeIterateResult("cancel"));
 
-    const promise = main([
-      "node",
-      "shepherd",
-      "poll",
-      "42",
-      "--interval",
-      "30s",
-      "--timeout",
-      "300s",
-    ]);
-    await vi.advanceTimersByTimeAsync(30_000);
+    const promise = main(["node", "shepherd", "poll", "42"]);
+    await vi.advanceTimersByTimeAsync(60_000);
     await promise;
 
     expect(mockRunIterate).toHaveBeenCalledTimes(2);
@@ -80,7 +71,7 @@ describe("main — poll subcommand", () => {
   it("accepts --interval and --timeout as minute durations", async () => {
     mockRunIterate.mockResolvedValue(makeIterateResult("cancel"));
 
-    await main(["node", "shepherd", "poll", "42", "--interval", "1m", "--timeout", "5m"]);
+    await main(["node", "shepherd", "poll", "42", "--interval", "1m", "--timeout", "4.5m"]);
 
     expect(mockRunIterate).toHaveBeenCalledTimes(1);
   });

--- a/src/cli/args.default-poll-invocation-helpers.test.mts
+++ b/src/cli/args.default-poll-invocation-helpers.test.mts
@@ -21,8 +21,8 @@ describe("default poll invocation helpers", () => {
     expect(isDefaultPollInvocation("--format=json")).toBe(true);
     expect(isDefaultPollInvocation("--no-auto-mark-ready")).toBe(true);
     expect(isDefaultPollInvocation("--quiet-status")).toBe(true);
-    expect(isDefaultPollInvocation("--interval=45s")).toBe(true);
-    expect(isDefaultPollInvocation("--timeout=4m")).toBe(true);
+    expect(isDefaultPollInvocation("--interval=60s")).toBe(true);
+    expect(isDefaultPollInvocation("--timeout=4.5m")).toBe(true);
     expect(isDefaultPollInvocation("resolve")).toBe(false);
   });
 
@@ -36,9 +36,9 @@ describe("default poll invocation helpers", () => {
         "--stall-timeout",
         "1h",
         "--interval",
-        "45",
+        "60",
         "--timeout",
-        "4m",
+        "4.5m",
         "--verbose",
         "--quiet-status",
       ]),

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -71,6 +71,10 @@ describe("validateSecondsDurationFlag", () => {
     expect(validateSecondsDurationFlag("cmd", "--timeout", "4.5m", true)).toBe("4.5m");
   });
 
+  it("accepts .0 fractional durations with units", () => {
+    expect(validateSecondsDurationFlag("cmd", "--timeout", "4.0m", true)).toBe("4.0m");
+  });
+
   it("accepts Nh suffix", () => {
     expect(validateSecondsDurationFlag("cmd", "--interval", "1h", true)).toBe("1h");
   });
@@ -103,6 +107,10 @@ describe("parseDurationToSeconds", () => {
 
   it("parses fractional minutes as seconds", () => {
     expect(parseDurationToSeconds("4.5m", 60)).toBe(270);
+  });
+
+  it("parses .0 fractional minutes as seconds", () => {
+    expect(parseDurationToSeconds("4.0m", 60)).toBe(240);
   });
 
   it("parses Nmin suffix as minutes", () => {

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -49,6 +49,11 @@ describe("validateSecondsDurationFlag", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("rejects bare fractional seconds", () => {
+    expect(validateSecondsDurationFlag("cmd", "--timeout", "4.5", true)).toBeNull();
+    expect(process.exitCode).toBe(1);
+  });
+
   it("accepts bare integer (seconds)", () => {
     expect(validateSecondsDurationFlag("cmd", "--interval", "30", true)).toBe("30");
     expect(stderrSpy).not.toHaveBeenCalled();
@@ -60,6 +65,10 @@ describe("validateSecondsDurationFlag", () => {
 
   it("accepts Nm suffix", () => {
     expect(validateSecondsDurationFlag("cmd", "--interval", "5m", true)).toBe("5m");
+  });
+
+  it("accepts fractional durations with units", () => {
+    expect(validateSecondsDurationFlag("cmd", "--timeout", "4.5m", true)).toBe("4.5m");
   });
 
   it("accepts Nh suffix", () => {
@@ -92,6 +101,10 @@ describe("parseDurationToSeconds", () => {
     expect(parseDurationToSeconds("5m", 60)).toBe(300);
   });
 
+  it("parses fractional minutes as seconds", () => {
+    expect(parseDurationToSeconds("4.5m", 60)).toBe(270);
+  });
+
   it("parses Nmin suffix as minutes", () => {
     expect(parseDurationToSeconds("2min", 60)).toBe(120);
   });
@@ -110,6 +123,10 @@ describe("parseDurationToSeconds", () => {
 
   it("treats bare integer with no unit as seconds (not minutes)", () => {
     expect(parseDurationToSeconds("60", 0)).toBe(60);
+  });
+
+  it("returns default for bare fractional seconds", () => {
+    expect(parseDurationToSeconds("4.5", 30)).toBe(30);
   });
 
   it("returns default when integer overflows to Infinity", () => {

--- a/src/cli/args.validatesecondsdurationflag.test.mts
+++ b/src/cli/args.validatesecondsdurationflag.test.mts
@@ -65,13 +65,7 @@ describe("validateSecondsDurationFlag", () => {
 
   it("accepts Nm suffix", () => {
     expect(validateSecondsDurationFlag("cmd", "--interval", "5m", true)).toBe("5m");
-  });
-
-  it("accepts fractional durations with units", () => {
     expect(validateSecondsDurationFlag("cmd", "--timeout", "4.5m", true)).toBe("4.5m");
-  });
-
-  it("accepts .0 fractional durations with units", () => {
     expect(validateSecondsDurationFlag("cmd", "--timeout", "4.0m", true)).toBe("4.0m");
   });
 
@@ -103,13 +97,7 @@ describe("parseDurationToSeconds", () => {
 
   it("parses Nm suffix as minutes", () => {
     expect(parseDurationToSeconds("5m", 60)).toBe(300);
-  });
-
-  it("parses fractional minutes as seconds", () => {
     expect(parseDurationToSeconds("4.5m", 60)).toBe(270);
-  });
-
-  it("parses .0 fractional minutes as seconds", () => {
     expect(parseDurationToSeconds("4.0m", 60)).toBe(240);
   });
 

--- a/src/cli/duration-flag.mts
+++ b/src/cli/duration-flag.mts
@@ -18,9 +18,13 @@ export function validateSecondsDurationFlag(
     process.exitCode = 1;
     return null;
   }
-  if (!/^[1-9]\d*(?:s|sec|seconds?|m|min|minutes?|h|hours?)?$/.test(trimmed)) {
+  if (
+    !/^(?:[1-9]\d*(?:s|sec|seconds?|m|min|minutes?|h|hours?)?|(?:[1-9]\d*|0)\.\d*[1-9]\d*(?:s|sec|seconds?|m|min|minutes?|h|hours?))$/.test(
+      trimmed,
+    )
+  ) {
     process.stderr.write(
-      `${command}: invalid ${flag}: ${value}. Expected a duration like 30s, 5m, 1h, or bare seconds (e.g. 30).\n`,
+      `${command}: invalid ${flag}: ${value}. Expected a duration like 30s, 4.5m, 1h, or bare seconds (e.g. 30).\n`,
     );
     process.exitCode = 1;
     return null;

--- a/src/cli/duration-flag.mts
+++ b/src/cli/duration-flag.mts
@@ -1,3 +1,5 @@
+import { parseSecondsDurationParts } from "./exit-codes.mts";
+
 export function validateSecondsDurationFlag(
   command: string,
   flag: string,
@@ -18,11 +20,7 @@ export function validateSecondsDurationFlag(
     process.exitCode = 1;
     return null;
   }
-  if (
-    !/^(?:[1-9]\d*(?:s|sec|seconds?|m|min|minutes?|h|hours?)?|(?:[1-9]\d*|0)\.\d*[1-9]\d*(?:s|sec|seconds?|m|min|minutes?|h|hours?))$/.test(
-      trimmed,
-    )
-  ) {
+  if (!parseSecondsDurationParts(trimmed)) {
     process.stderr.write(
       `${command}: invalid ${flag}: ${value}. Expected a duration like 30s, 4.5m, 1h, or bare seconds (e.g. 30).\n`,
     );

--- a/src/cli/exit-codes.mts
+++ b/src/cli/exit-codes.mts
@@ -1,6 +1,25 @@
 import { loadConfig } from "../config/load.mts";
 import type { ShepherdAction } from "../types.mts";
 
+const SECOND_DURATION_UNITS = new Set([
+  "s",
+  "sec",
+  "second",
+  "seconds",
+  "m",
+  "min",
+  "minute",
+  "minutes",
+  "h",
+  "hour",
+  "hours",
+]);
+
+interface SecondsDurationParts {
+  value: number;
+  unit: string;
+}
+
 export function parseDurationToMinutes(s: string, defaultMinutes?: number): number {
   const m = /^(\d+)(m|min|minutes?|h|hours?)?$/.exec(s.trim());
   if (!m) return defaultMinutes ?? loadConfig().watch.readyDelayMinutes;
@@ -10,16 +29,30 @@ export function parseDurationToMinutes(s: string, defaultMinutes?: number): numb
   return n;
 }
 
+export function parseSecondsDurationParts(s: string): SecondsDurationParts | null {
+  const trimmed = s.trim();
+  const match = /^(\d+(?:\.\d+)?)([a-z]+)?$/.exec(trimmed);
+  if (!match) return null;
+
+  const amount = match[1];
+  const explicitUnit = match[2];
+  if (!amount || (amount.includes(".") && !explicitUnit)) return null;
+
+  const unit = explicitUnit ?? "s";
+  if (!SECOND_DURATION_UNITS.has(unit)) return null;
+
+  const value = Number(amount);
+  if (!Number.isFinite(value) || value <= 0) return null;
+
+  return { value, unit };
+}
+
 export function parseDurationToSeconds(s: string, defaultSeconds: number): number {
-  const m = /^(\d+|\d+\.\d+)(s|sec|seconds?|m|min|minutes?|h|hours?)?$/.exec(s.trim());
-  if (!m) return defaultSeconds;
-  if (m[1]!.includes(".") && !m[2]) return defaultSeconds;
-  const n = Number(m[1]!);
-  if (!Number.isFinite(n)) return defaultSeconds;
-  const unit = m[2] ?? "s";
-  if (unit.startsWith("h")) return n * 3600;
-  if (unit.startsWith("m")) return n * 60;
-  return n;
+  const parsed = parseSecondsDurationParts(s);
+  if (!parsed) return defaultSeconds;
+  if (parsed.unit.startsWith("h")) return parsed.value * 3600;
+  if (parsed.unit.startsWith("m")) return parsed.value * 60;
+  return parsed.value;
 }
 
 export function statusToExitCode(status: string): number {

--- a/src/cli/exit-codes.mts
+++ b/src/cli/exit-codes.mts
@@ -11,9 +11,10 @@ export function parseDurationToMinutes(s: string, defaultMinutes?: number): numb
 }
 
 export function parseDurationToSeconds(s: string, defaultSeconds: number): number {
-  const m = /^(\d+)(s|sec|seconds?|m|min|minutes?|h|hours?)?$/.exec(s.trim());
+  const m = /^(\d+|\d+\.\d+)(s|sec|seconds?|m|min|minutes?|h|hours?)?$/.exec(s.trim());
   if (!m) return defaultSeconds;
-  const n = parseInt(m[1]!, 10);
+  if (m[1]!.includes(".") && !m[2]) return defaultSeconds;
+  const n = Number(m[1]!);
   if (!Number.isFinite(n)) return defaultSeconds;
   const unit = m[2] ?? "s";
   if (unit.startsWith("h")) return n * 3600;

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -113,8 +113,8 @@ Usage:
   pr-shepherd poll [PR] [poll-flags] [iterate-flags]
 
 Poll flags:
-  --interval <duration>          Sleep between WAIT ticks. Default: 30s.
-  --timeout <duration>           Maximum wall-clock wait. Default: 5m.
+  --interval <duration>          Sleep between WAIT ticks. Default: 60s.
+  --timeout <duration>           Maximum wall-clock wait. Default: 4.5m.
   --quiet-status                 During WAIT polling, print only changed status snapshots.
 
 Forwarded iterate flags:
@@ -126,7 +126,7 @@ Forwarded iterate flags:
   --verbose                      Include verbose iterate fields and detailed per-tick lines.
   --help, -h                     Print this help and exit before GitHub, git, config, or log I/O.
 
-Durations accept seconds, minutes, or hours: 30s, 2m, 1h, or bare seconds.
+Durations accept seconds, minutes, or hours: 30s, 4.5m, 1h, or bare seconds.
 Each WAIT tick writes a single dot to stderr by default; --quiet-status prints only changed WAIT snapshots, and --verbose emits detailed per-tick lines.
 
 Exit codes:

--- a/src/cli/help-top-page.mts
+++ b/src/cli/help-top-page.mts
@@ -42,8 +42,8 @@ Iterate flags:
   --no-auto-cancel-actionable    Do not cancel in-progress runs before actionable fixes.
 
 Poll flags:
-  --interval <duration>          Sleep between WAIT ticks. Default: 30s.
-  --timeout <duration>           Maximum poll wall-clock wait. Default: 5m.
+  --interval <duration>          Sleep between WAIT ticks. Default: 60s.
+  --timeout <duration>           Maximum poll wall-clock wait. Default: 4.5m.
   --quiet-status                 During WAIT polling, print only changed status snapshots.
 
 Clean variants:
@@ -59,6 +59,6 @@ Exit codes for iterate and poll:
   2  CANCEL
   3  ESCALATE
 
-Durations accept seconds, minutes, or hours: 30s, 2m, 1h, or bare seconds.
+Durations accept seconds, minutes, or hours: 30s, 4.5m, 1h, or bare seconds.
 
 Run 'pr-shepherd <command> --help' for command-specific details.`;

--- a/src/cli/help-top-page.mts
+++ b/src/cli/help-top-page.mts
@@ -42,8 +42,8 @@ Iterate flags:
   --no-auto-cancel-actionable    Do not cancel in-progress runs before actionable fixes.
 
 Poll flags:
-  --interval <duration>          Sleep between WAIT ticks. Default: 60s.
-  --timeout <duration>           Maximum poll wall-clock wait. Default: 4.5m.
+  --interval <duration>          Delay between WAIT ticks. Default: 60s.
+  --timeout <duration>           Poll wall-clock cap. Default: 4.5m.
   --quiet-status                 During WAIT polling, print only changed status snapshots.
 
 Clean variants:
@@ -59,6 +59,6 @@ Exit codes for iterate and poll:
   2  CANCEL
   3  ESCALATE
 
-Durations accept seconds, minutes, or hours: 30s, 4.5m, 1h, or bare seconds.
+Duration examples: 30s, 4.5m, 1h, or bare seconds.
 
 Run 'pr-shepherd <command> --help' for command-specific details.`;

--- a/src/cli/poll-handler.mts
+++ b/src/cli/poll-handler.mts
@@ -6,8 +6,8 @@ import { validateSecondsDurationFlag } from "./duration-flag.mts";
 import { parseIterateFlags } from "./iterate-flags.mts";
 import { emitIterateResult } from "./iterate-emitter.mts";
 
-const DEFAULT_POLL_INTERVAL_SECONDS = 30;
-const DEFAULT_POLL_TIMEOUT_SECONDS = 300;
+const DEFAULT_POLL_INTERVAL_SECONDS = 60;
+const DEFAULT_POLL_TIMEOUT_SECONDS = 270;
 
 export async function handlePoll(args: string[]): Promise<void> {
   const { prNumber, global: globalOpts, extra } = parseCommonArgs(args);

--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -67,6 +67,31 @@ function writeQuietStatus(
 }
 
 const MAX_TIMER_MS = 2 ** 31 - 1;
+const TIMER_DRIFT_TOLERANCE_MS = 500;
+
+function writeWaitProgress(opts: {
+  tick: number;
+  elapsedMs: number;
+  sleepMs: number;
+  result: IterateResult;
+  quietStatus: boolean;
+  verbose: boolean;
+  lastWaitSignature: string | null;
+}): string | null {
+  const elapsedSeconds = Math.round(opts.elapsedMs / 1000);
+  const sleepSeconds = Math.round(opts.sleepMs / 1000);
+
+  if (!opts.quietStatus) {
+    writeTickProgress(opts.tick, elapsedSeconds, sleepSeconds, opts.verbose);
+    return opts.lastWaitSignature;
+  }
+
+  const signature = waitSignature(opts.result);
+  if (signature !== opts.lastWaitSignature) {
+    writeQuietStatus(opts.tick, elapsedSeconds, sleepSeconds, opts.result);
+  }
+  return signature;
+}
 
 export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> {
   const { intervalSeconds, timeoutSeconds, ...iterateOpts } = opts;
@@ -88,29 +113,19 @@ export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> 
     const elapsedMs = Date.now() - start;
     const remainingMs = timeoutMs - elapsedMs;
     if (remainingMs <= 0) break;
-    if (remainingMs < intervalMs) break;
+    if (remainingMs + TIMER_DRIFT_TOLERANCE_MS < intervalMs) break;
 
     const nextSleepMs = intervalMs;
-    if (quietStatus) {
-      const signature = waitSignature(lastResult);
-      if (signature !== lastWaitSignature) {
-        writeQuietStatus(
-          tick,
-          Math.round(elapsedMs / 1000),
-          Math.round(nextSleepMs / 1000),
-          lastResult,
-        );
-      }
-      lastWaitSignature = signature;
-    } else {
-      writeTickProgress(
-        tick,
-        Math.round(elapsedMs / 1000),
-        Math.round(nextSleepMs / 1000),
-        verbose,
-      );
-      if (!verbose) dotsPrinted = true;
-    }
+    lastWaitSignature = writeWaitProgress({
+      tick,
+      elapsedMs,
+      sleepMs: nextSleepMs,
+      result: lastResult,
+      quietStatus,
+      verbose,
+      lastWaitSignature,
+    });
+    if (!quietStatus && !verbose) dotsPrinted = true;
     await sleep(nextSleepMs);
   }
 

--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -88,8 +88,9 @@ export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> 
     const elapsedMs = Date.now() - start;
     const remainingMs = timeoutMs - elapsedMs;
     if (remainingMs <= 0) break;
+    if (remainingMs < intervalMs) break;
 
-    const nextSleepMs = Math.min(intervalMs, remainingMs);
+    const nextSleepMs = intervalMs;
     if (quietStatus) {
       const signature = waitSignature(lastResult);
       if (signature !== lastWaitSignature) {

--- a/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
+++ b/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
@@ -47,4 +47,23 @@ describe("runPoll — timeout returns final wait", () => {
     expect(result.action).toBe("wait");
     expect(mockRunIterate).toHaveBeenCalledTimes(3);
   });
+
+  it("does not skip a final wait tick because of small timer drift", async () => {
+    mockRunIterate.mockResolvedValue(makeWaitResult());
+
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 30,
+      timeoutSeconds: 60,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_250);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const result = await pollPromise;
+
+    expect(result.action).toBe("wait");
+    expect(mockRunIterate).toHaveBeenCalledTimes(3);
+  });
 });

--- a/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
+++ b/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
@@ -9,7 +9,27 @@ import { runPoll } from "./poll.mts";
 registerPollHooks();
 
 describe("runPoll — timeout returns final wait", () => {
-  it("returns the last wait result when timeout is exhausted", async () => {
+  it("returns the last wait result when the next full interval would exceed timeout", async () => {
+    mockRunIterate.mockResolvedValue(makeWaitResult());
+
+    // interval=60s, timeout=270s → ticks at t=0/60/120/180/240; at t=240 only
+    // 30s remains, so poll returns instead of sleeping a pointless partial interval.
+    const pollPromise = runPoll({
+      prNumber: 42,
+      format: "text",
+      intervalSeconds: 60,
+      timeoutSeconds: 270,
+    });
+
+    await vi.advanceTimersByTimeAsync(240_000);
+
+    const result = await pollPromise;
+
+    expect(result.action).toBe("wait");
+    expect(mockRunIterate).toHaveBeenCalledTimes(5);
+  });
+
+  it("runs a final wait tick when a full interval exactly fits the timeout", async () => {
     mockRunIterate.mockResolvedValue(makeWaitResult());
 
     // interval=30s, timeout=60s → tick1 at t=0 (sleep 30s), tick2 at t=30s (sleep 30s), tick3 at t=60s (remaining=0 → return)

--- a/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
+++ b/src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts
@@ -8,24 +8,35 @@ import { runPoll } from "./poll.mts";
 
 registerPollHooks();
 
+async function runWaitPoll(
+  intervalSeconds: number,
+  timeoutSeconds: number,
+  timerAdvancesMs: number[],
+): Promise<void> {
+  const pollPromise = runPoll({
+    prNumber: 42,
+    format: "text",
+    intervalSeconds,
+    timeoutSeconds,
+  });
+
+  for (const advanceMs of timerAdvancesMs) {
+    await vi.advanceTimersByTimeAsync(advanceMs);
+  }
+
+  const result = await pollPromise;
+
+  expect(result.action).toBe("wait");
+}
+
 describe("runPoll — timeout returns final wait", () => {
   it("returns the last wait result when the next full interval would exceed timeout", async () => {
     mockRunIterate.mockResolvedValue(makeWaitResult());
 
     // interval=60s, timeout=270s → ticks at t=0/60/120/180/240; at t=240 only
     // 30s remains, so poll returns instead of sleeping a pointless partial interval.
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      intervalSeconds: 60,
-      timeoutSeconds: 270,
-    });
+    await runWaitPoll(60, 270, [240_000]);
 
-    await vi.advanceTimersByTimeAsync(240_000);
-
-    const result = await pollPromise;
-
-    expect(result.action).toBe("wait");
     expect(mockRunIterate).toHaveBeenCalledTimes(5);
   });
 
@@ -33,37 +44,16 @@ describe("runPoll — timeout returns final wait", () => {
     mockRunIterate.mockResolvedValue(makeWaitResult());
 
     // interval=30s, timeout=60s → tick1 at t=0 (sleep 30s), tick2 at t=30s (sleep 30s), tick3 at t=60s (remaining=0 → return)
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      intervalSeconds: 30,
-      timeoutSeconds: 60,
-    });
+    await runWaitPoll(30, 60, [60_000]);
 
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    const result = await pollPromise;
-
-    expect(result.action).toBe("wait");
     expect(mockRunIterate).toHaveBeenCalledTimes(3);
   });
 
   it("does not skip a final wait tick because of small timer drift", async () => {
     mockRunIterate.mockResolvedValue(makeWaitResult());
 
-    const pollPromise = runPoll({
-      prNumber: 42,
-      format: "text",
-      intervalSeconds: 30,
-      timeoutSeconds: 60,
-    });
+    await runWaitPoll(30, 60, [30_250, 30_000]);
 
-    await vi.advanceTimersByTimeAsync(30_250);
-    await vi.advanceTimersByTimeAsync(30_000);
-
-    const result = await pollPromise;
-
-    expect(result.action).toBe("wait");
     expect(mockRunIterate).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary
- Change poll defaults to `--interval 60s` and `--timeout 4.5m`.
- Make poll return the latest WAIT result when the next full interval would exceed the timeout instead of sleeping a partial final interval.
- Accept fractional duration values with explicit units, update help/docs, and align the bundled pr-shepherd skill command.

## Validation
- `npx vitest run src/cli/args.validatesecondsdurationflag.test.mts src/cli-parser.poll.mock.test.mts src/cli-parser.iterate.main-iterate.mock.test.mts src/cli/args.default-poll-invocation-helpers.test.mts src/commands/poll.runpoll-timeout-returns-final-wait.mock.test.mts src/commands/poll.runpoll-tick-progress.mock.test.mts src/commands/poll.runpoll-loops-on-wait-then-stops.mock.test.mts src/commands/poll.runpoll-clamps-oversized-timer.mock.test.mts src/commands/poll.runpoll-stops-on-cancel.mock.test.mts src/commands/poll.runpoll-stops-on-mark-ready.mock.test.mts`
- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm test`
