### PR TITLE
feat(skill): add --quiet-status to default poll command

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -6,7 +6,7 @@ Each `pr-shepherd iterate` invocation returns exactly one action. The default `p
 
 The default output format is Markdown — what the skill receives from the default poll dispatcher and what direct CLI users see. `--format=json` emits the same action data as a single JSON object for scripting. Every example below shows what the agent actually sees in the default (lean) format.
 
-The shipped skill invokes the default command with `--interval`/`--timeout`, which is equivalent to `pr-shepherd poll` while the PR remains in `[WAIT]` and returns whenever an actionable or terminal state appears. Add `--quiet-status` when a long wait should print only changed WAIT status snapshots instead of one dot per unchanged tick. Do not run `while true` or unbounded polling loops outside of the poll dispatcher.
+The shipped skill invokes the default command with `--interval`/`--timeout`/`--quiet-status` (e.g. `pr-shepherd <PR> --interval 60s --timeout 4.5m --quiet-status`), which is equivalent to `pr-shepherd poll` while the PR remains in `[WAIT]` and returns whenever an actionable or terminal state appears. `--quiet-status` is included by default so agents only see changed WAIT snapshots during long waits rather than one dot per unchanged tick. Do not run `while true` or unbounded polling loops outside of the poll dispatcher.
 
 Command examples call `pr-shepherd` directly everywhere a follow-up command is emitted.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -51,7 +51,7 @@ pr-shepherd poll 42 --format=json
 | ----------------------- | ------- | ------------------------------------------------------------------ |
 | `--interval <duration>` | `60s`   | Sleep between `WAIT` ticks.                                        |
 | `--timeout <duration>`  | `4.5m`  | Maximum wall-clock wait before returning the latest `WAIT` result. |
-| `--quiet-status`        | false   | Print only changed WAIT snapshots instead of one dot per tick.     |
+| `--quiet-status`        | `false` | Print only changed WAIT snapshots instead of one dot per tick.     |
 
 Durations accept seconds, minutes, hours, or bare seconds: `30s`, `270s`, `4.5m`, `1h`, `45`.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -27,7 +27,7 @@ pr-shepherd log-file [--format text|json]
 
 ```sh
 pr-shepherd 42
-pr-shepherd 42 --interval 60s --timeout 270s
+pr-shepherd 42 --interval 60s --timeout 4.5m
 pr-shepherd 42 --interval 60s --timeout 4.5m --quiet-status
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -28,6 +28,7 @@ pr-shepherd log-file [--format text|json]
 ```sh
 pr-shepherd 42
 pr-shepherd 42 --interval 60s --timeout 270s
+pr-shepherd 42 --interval 60s --timeout 4.5m --quiet-status
 pr-shepherd 42 --ready-delay 15m
 pr-shepherd iterate 42
 pr-shepherd poll 42 --format=json
@@ -50,6 +51,7 @@ pr-shepherd poll 42 --format=json
 | ----------------------- | ------- | ------------------------------------------------------------------ |
 | `--interval <duration>` | `60s`   | Sleep between `WAIT` ticks.                                        |
 | `--timeout <duration>`  | `4.5m`  | Maximum wall-clock wait before returning the latest `WAIT` result. |
+| `--quiet-status`        | false   | Print only changed WAIT snapshots instead of one dot per tick.     |
 
 Durations accept seconds, minutes, hours, or bare seconds: `30s`, `270s`, `4.5m`, `1h`, `45`.
 

--- a/docs/watch-loop.md
+++ b/docs/watch-loop.md
@@ -22,7 +22,7 @@ Both runtimes use the same `pr-shepherd` skill. Claude Code users invoke it with
    The skill resolves the PR number and runs the default poll dispatcher:
 
    ```bash
-   pr-shepherd <PR> --interval 60s --timeout 4.5m
+   pr-shepherd <PR> --interval 60s --timeout 4.5m --quiet-status
    ```
 
 2. **CLI emits an action with `## Instructions`**

--- a/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
+++ b/plugins/pr-shepherd/skills/pr-shepherd/SKILL.md
@@ -16,7 +16,7 @@ Poll dispatcher for iterating a PR to completion.
 
 1. **Resolve the PR number** (`$N`): use the number or URL in `$ARGUMENTS`; otherwise infer it with `gh pr view --json number --jq .number`. If none is found, report an error and stop.
 
-2. **Define the poll command once:** `pr-shepherd $N --interval 60s --timeout 4.5m`. Do not forward `$ARGUMENTS` as extra flags. Run `pr-shepherd --help` to inspect supported options.
+2. **Define the poll command once:** `pr-shepherd $N --interval 60s --timeout 4.5m --quiet-status`. Do not forward `$ARGUMENTS` as extra flags. Run `pr-shepherd --help` to inspect supported options.
 
 3. **Loop:** Run the poll, print its full output, and follow its `## Instructions` section exactly. Then run the poll again. Repeat until the CLI emits `[CANCEL]` or `[ESCALATE]`, unless the human directs you to stop. Every other action (`[WAIT]`, `[MARK_READY]`, `[FIX_CODE]`) is non-terminal: do its instructions, then poll again. The poll already bounds each wait via `--interval`/`--timeout`; do not add manual `sleep`s between ticks.
 


### PR DESCRIPTION
## Summary
- Appends `--quiet-status` to the bundled skill's default poll command (`pr-shepherd $N --interval 60s --timeout 4.5m --quiet-status`)
- Keeps `docs/watch-loop.md` in sync (same command example)
- Updates `docs/actions.md` prose to reflect it is now part of the default invocation
- Adds `--quiet-status` to the Poll Flags table and example block in `docs/cli-usage.md`

Closes #270

## Test plan
- [ ] No tests assert the skill string — no test changes needed
- [ ] `npm run build && npm run lint && npm run typecheck && npm run format:check` all pass
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- [IC_kwDOSGizTs8AAAABFicMlw](https://github.com/jonathanong/pr-shepherd/pull/279#issuecomment-4666625175): CodeRabbit rate-limit notification — no actionable review content, minimized.
- PRR_kwDOSGizTs8AAAABChxHBw: Sourcery feedback addressed — standardized --timeout to 4.5m in cli-usage.md examples; CLI default=false for --quiet-status is correct and distinct from the bundled skill behavior (no doc change needed there).