### PR TITLE
feat(github): retry transport errors during GitHub API polling

### DIFF
--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -1,14 +1,11 @@
 import { runIterate } from "./iterate/index.mts";
 import type { IterateCommandOptions, IterateResult } from "../types.mts";
+import { sleep } from "../util/sleep.mts";
 
 interface PollCommandOptions extends IterateCommandOptions {
   intervalSeconds: number;
   timeoutSeconds: number;
   quietStatus?: boolean;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function writeTickProgress(

--- a/src/comments/sha-poll.mts
+++ b/src/comments/sha-poll.mts
@@ -1,5 +1,6 @@
 import { getPrHeadSha, type RepoInfo } from "../github/client.mts";
 import { loadConfig } from "../config/load.mts";
+import { sleep } from "../util/sleep.mts";
 
 export async function waitForSha(pr: number, repo: RepoInfo, expectedSha: string): Promise<void> {
   const { intervalMs: SHA_POLL_INTERVAL_MS, maxAttempts: SHA_POLL_MAX_ATTEMPTS } =
@@ -24,8 +25,4 @@ export async function waitForSha(pr: number, repo: RepoInfo, expectedSha: string
       ((SHA_POLL_MAX_ATTEMPTS - 1) * SHA_POLL_INTERVAL_MS) / 1000
     }s. Push may still be in transit — retry shortly.`,
   );
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/github/http-request.mts
+++ b/src/github/http-request.mts
@@ -1,13 +1,33 @@
 import { clearTokenCache, hasCachedToken } from "./http-auth.mts";
+import { isTransportError } from "./http-utils.mts";
+import { sleep } from "../util/sleep.mts";
 
 type RetryLogFn = (status: number, durationMs: number) => void;
+
+const TRANSPORT_RETRY_DELAYS = [250, 500];
+
+async function fetchWithTransportRetry(fn: () => Promise<Response>): Promise<Response> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= TRANSPORT_RETRY_DELAYS.length + 1; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!isTransportError(err)) throw err;
+      lastErr = err;
+      const delay = TRANSPORT_RETRY_DELAYS[attempt - 1];
+      if (delay === undefined) break;
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}
 
 export async function requestWithTokenRetry(
   fn: () => Promise<Response>,
   t0: number,
   onIntermediate?: RetryLogFn,
 ): Promise<{ res: Response; attempt: number; retryT0: number }> {
-  const res = await fn();
+  const res = await fetchWithTransportRetry(fn);
   if (res.status === 401 && hasCachedToken()) {
     onIntermediate?.(401, Math.round(performance.now() - t0));
     try {
@@ -15,7 +35,7 @@ export async function requestWithTokenRetry(
     } catch {}
     clearTokenCache();
     const retryT0 = performance.now();
-    return { res: await fn(), attempt: 2, retryT0 };
+    return { res: await fetchWithTransportRetry(fn), attempt: 2, retryT0 };
   }
   return { res, attempt: 1, retryT0: t0 };
 }

--- a/src/github/http-utils.mts
+++ b/src/github/http-utils.mts
@@ -1,3 +1,24 @@
+const TRANSPORT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EAI_AGAIN",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+export function isTransportError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code && TRANSPORT_ERROR_CODES.has(code)) return true;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    const causeCode = (cause as NodeJS.ErrnoException).code;
+    if (causeCode && TRANSPORT_ERROR_CODES.has(causeCode)) return true;
+  }
+  return false;
+}
+
 export interface RateLimitInfo {
   remaining: number;
   limit: number;

--- a/src/github/http.transport-retry.mock.test.mts
+++ b/src/github/http.transport-retry.mock.test.mts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { registerHooks, mockFetch, gqlOk } from "../../test-helpers/github/http.test-support.mts";
+import { graphql } from "./http.mts";
+
+registerHooks();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  process.env["GH_TOKEN"] = "test-token";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchWithTransportRetry", () => {
+  it("retries on transport error then succeeds", async () => {
+    mockFetch
+      .mockRejectedValueOnce(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }))
+      .mockResolvedValueOnce(gqlOk({ viewer: { login: "alice" } }));
+
+    const promise = graphql<{ viewer: { login: string } }>("{ viewer { login } }");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.data).toEqual({ viewer: { login: "alice" } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after retries exhausted", async () => {
+    const err = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    mockFetch.mockRejectedValueOnce(err).mockRejectedValueOnce(err).mockRejectedValueOnce(err);
+
+    const promise = expect(graphql("{ viewer { login } }")).rejects.toThrow("read ECONNRESET");
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-transport errors", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("oops"));
+
+    await expect(graphql("{ viewer { login } }")).rejects.toThrow("oops");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries when cause.code is a transport error code", async () => {
+    const cause = Object.assign(new Error("connect timeout"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+    const wrapper = Object.assign(new Error("fetch failed"), { cause });
+    mockFetch
+      .mockRejectedValueOnce(wrapper)
+      .mockResolvedValueOnce(gqlOk({ viewer: { login: "bob" } }));
+
+    const promise = graphql<{ viewer: { login: string } }>("{ viewer { login } }");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.data).toEqual({ viewer: { login: "bob" } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/util/sleep.mts
+++ b/src/util/sleep.mts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- Adds `fetchWithTransportRetry` wrapper in `src/github/http-request.mts` — 3 attempts, 250ms/500ms backoff for `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, `UND_ERR_CONNECT_TIMEOUT`, and related codes
- Extracts shared `sleep()` from `src/commands/poll.mts` and `src/comments/sha-poll.mts` into `src/util/sleep.mts`
- Covers all three primary fetch entry points (graphql, rest, restText) at the single `requestWithTokenRetry` chokepoint; redirect-follow fetch at `rest-http.mts:153` is explicitly out of scope

Closes #271

## Test plan
- [ ] New test file `src/github/http.transport-retry.mock.test.mts` covers retry-then-success, exhausted retries, non-transport errors, and `cause.code` variant
- [ ] `npm test` passes (including existing http tests)
- [ ] `npm run typecheck && npm run lint && npm run format:check` pass
- [ ] Source files remain ≤200 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- [IC_kwDOSGizTs8AAAABFidSxQ](https://github.com/jonathanong/pr-shepherd/pull/280#issuecomment-4666643141) CodeRabbit rate limit notice — not a code issue, no changes needed, minimized.