### PR TITLE
fix(commit-suggestion): trim duplicate context lines from over-broad suggestion boxes

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -107,7 +107,7 @@ Preconditions:
 - Target file is clean.
 - Thread is active, locatable, unresolved, not outdated, and not minimized.
 
-The output includes a unified diff, a suggested commit subject/body with reviewer attribution, files to stage, and post-action instructions. Invoke once per suggestion thread.
+The output includes a unified diff, a suggested commit subject/body with reviewer attribution, files to stage, and post-action instructions. Invoke once per suggestion thread. If a reviewer's suggestion box contains more lines than the highlighted range, the emitted diff trims leading/trailing lines that merely duplicate adjacent file context, so the patch applies cleanly without duplicating lines.
 
 Exit codes: `0` suggestion produced, `1` validation/lookup/precondition/parsing failure.
 

--- a/src/suggestions/patch.buildunifieddiff.trims-duplicated-context-lines.test.mts
+++ b/src/suggestions/patch.buildunifieddiff.trims-duplicated-context-lines.test.mts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { buildUnifiedDiff } from "../../test-helpers/suggestions/patch.test-support.mts";
+
+describe("buildUnifiedDiff (context-line trimming, issue #294)", () => {
+  it("issue repro: trims leading and trailing lines from an over-broad suggestion box", () => {
+    // Reviewer highlighted line 4 only (isStall) but pasted 4 lines into the box,
+    // including 2 lines already present before and 1 already present after the range.
+    const content =
+      [
+        "finish({",
+        "  code: a,",
+        "  retryable: b,",
+        "  isStall: x,", // line 4 — the highlighted / removed line
+        "  hung,",
+        "})",
+      ].join("\n") + "\n";
+
+    const patch = buildUnifiedDiff({
+      path: "foo.ts",
+      originalContent: content,
+      startLine: 4,
+      endLine: 4,
+      replacementLines: [
+        "  code: a,", // duplicates line 2 — should become context, not addition
+        "  retryable: b,", // duplicates line 3 — should become context, not addition
+        "  isStall: y,", // the actual change
+        "  hung,", // duplicates line 5 — should become context, not addition
+      ],
+    });
+
+    // Only the genuinely changed line is an addition.
+    expect(patch).toContain("-  isStall: x,\n");
+    expect(patch).toContain("+  isStall: y,\n");
+
+    // Duplicated lines must NOT appear as additions.
+    expect(patch).not.toContain("+  code: a,\n");
+    expect(patch).not.toContain("+  retryable: b,\n");
+    expect(patch).not.toContain("+  hung,\n");
+
+    // 1 removed, 1 added → hunk counts are unchanged (6 orig, 6 new).
+    expect(patch).toContain("@@ -1,6 +1,6 @@\n");
+  });
+
+  it("trims leading duplicate lines only", () => {
+    const content = "a\nb\nc\nd\n";
+    // Replace line 3 (c). Suggestion box prepends "b" — already present just before.
+    const patch = buildUnifiedDiff({
+      path: "f.ts",
+      originalContent: content,
+      startLine: 3,
+      endLine: 3,
+      replacementLines: ["b", "C"],
+    });
+
+    expect(patch).toContain("-c\n");
+    expect(patch).toContain("+C\n");
+    expect(patch).not.toContain("+b\n");
+    // "b" still appears as a context line.
+    expect(patch).toContain(" b\n");
+  });
+
+  it("trims trailing duplicate lines only", () => {
+    const content = "a\nb\nc\nd\n";
+    // Replace line 2 (b). Suggestion box appends "c" — already present just after.
+    const patch = buildUnifiedDiff({
+      path: "f.ts",
+      originalContent: content,
+      startLine: 2,
+      endLine: 2,
+      replacementLines: ["B", "c"],
+    });
+
+    expect(patch).toContain("-b\n");
+    expect(patch).toContain("+B\n");
+    expect(patch).not.toContain("+c\n");
+    // "c" still appears as a context line.
+    expect(patch).toContain(" c\n");
+  });
+
+  it("leaves replacement unchanged when no context duplication exists", () => {
+    const content = "a\nb\nc\nd\n";
+    const patch = buildUnifiedDiff({
+      path: "f.ts",
+      originalContent: content,
+      startLine: 2,
+      endLine: 2,
+      replacementLines: ["B"],
+    });
+
+    expect(patch).toContain("-b\n");
+    expect(patch).toContain("+B\n");
+    expect(patch).toContain("@@ -1,4 +1,4 @@\n");
+  });
+
+  it("trims leading duplicates that extend beyond the 3-line context window", () => {
+    // 8 lines before the removed range; suggestion duplicates 4 of them.
+    const content = ["p", "q", "r", "s", "t", "u", "v", "w", "X", "z"].join("\n") + "\n";
+    // Remove line 9 (X), replace with [t, u, v, w, Y] — 4 leading duplicates.
+    const patch = buildUnifiedDiff({
+      path: "f.ts",
+      originalContent: content,
+      startLine: 9,
+      endLine: 9,
+      replacementLines: ["t", "u", "v", "w", "Y"],
+      context: 3,
+    });
+
+    // Only "Y" should be an addition; t/u/v/w are already in the file above the removed range.
+    expect(patch).toContain("-X\n");
+    expect(patch).toContain("+Y\n");
+    expect(patch).not.toContain("+t\n");
+    expect(patch).not.toContain("+u\n");
+    expect(patch).not.toContain("+v\n");
+    expect(patch).not.toContain("+w\n");
+  });
+});

--- a/src/suggestions/patch.mts
+++ b/src/suggestions/patch.mts
@@ -5,6 +5,56 @@
  * `git apply --check` accept it without a `diff --git` preamble.
  */
 
+/**
+ * Strip leading/trailing replacement lines that are identical to the adjacent
+ * file lines just outside the removed range.
+ *
+ * GitHub stores a suggestion as a verbatim replacement for the *highlighted*
+ * line range, but reviewers often paste surrounding context into the box. Those
+ * context-duplicating lines must not appear as additions in the diff — they
+ * belong to the surrounding unchanged file content. Stripping them here produces
+ * a minimal diff that applies cleanly without duplicating lines.
+ *
+ * Comparison normalises trailing `\r` from file lines so CRLF files (which
+ * carry `\r` on each entry after `split("\n")`) still match suggestion lines
+ * delivered as LF-only by the GitHub API.
+ */
+function trimReplacementToContext(
+  fileLines: readonly string[],
+  startLine: number,
+  endLine: number,
+  replacementLines: readonly string[],
+): readonly string[] {
+  const norm = (s: string) => (s.endsWith("\r") ? s.slice(0, -1) : s);
+
+  // Leading trim: largest L where replacement[0..L) == fileLines[startLine-1-L..startLine-1)
+  const maxL = Math.min(startLine - 1, replacementLines.length);
+  let L = 0;
+  leading: for (let l = maxL; l >= 1; l--) {
+    for (let i = 0; i < l; i++) {
+      if (replacementLines[i] !== norm(fileLines[startLine - 1 - l + i]!)) continue leading;
+    }
+    L = l;
+    break;
+  }
+
+  const remainder = replacementLines.slice(L);
+
+  // Trailing trim: largest T where remainder[len-T..len) == fileLines[endLine..endLine+T)
+  const maxT = Math.min(fileLines.length - endLine, remainder.length);
+  let T = 0;
+  trailing: for (let t = maxT; t >= 1; t--) {
+    for (let j = 0; j < t; j++) {
+      if (remainder[remainder.length - t + j] !== norm(fileLines[endLine + j]!)) continue trailing;
+    }
+    T = t;
+    break;
+  }
+
+  if (L === 0 && T === 0) return replacementLines;
+  return T === 0 ? remainder : remainder.slice(0, remainder.length - T);
+}
+
 export function buildUnifiedDiff({
   path,
   originalContent,
@@ -31,9 +81,13 @@ export function buildUnifiedDiff({
   const afterEnd = Math.min(fileLines.length, endLine + context);
   const afterLines = fileLines.slice(endLine, afterEnd);
 
+  // Trim replacement lines that duplicate adjacent file context so the diff is
+  // minimal and `git apply`-clean (issue #294).
+  const replacement = trimReplacementToContext(fileLines, startLine, endLine, replacementLines);
+
   const hunkOrigStart = beforeStart + 1;
   const hunkOrigCount = beforeLines.length + removedLines.length + afterLines.length;
-  const hunkNewCount = beforeLines.length + replacementLines.length + afterLines.length;
+  const hunkNewCount = beforeLines.length + replacement.length + afterLines.length;
 
   const noNewline = "\\ No newline at end of file\n";
   const isLastOrigLine = (lineIdx: number) => !endsWithNewline && lineIdx === fileLines.length - 1;
@@ -58,10 +112,10 @@ export function buildUnifiedDiff({
   // not just because context is 0 (there may still be unshown lines beyond the hunk).
   const addedEndsFile = !endsWithNewline && endLine >= fileLines.length;
   const hasCr = originalContent.includes("\r\n");
-  for (let i = 0; i < replacementLines.length; i++) {
-    const line = hasCr ? replacementLines[i] + "\r" : replacementLines[i];
+  for (let i = 0; i < replacement.length; i++) {
+    const line = hasCr ? replacement[i] + "\r" : replacement[i];
     out.push(`+${line}\n`);
-    if (addedEndsFile && i === replacementLines.length - 1) out.push(noNewline);
+    if (addedEndsFile && i === replacement.length - 1) out.push(noNewline);
   }
 
   for (let i = 0; i < afterLines.length; i++) {

--- a/src/suggestions/patch.mts
+++ b/src/suggestions/patch.mts
@@ -32,7 +32,7 @@ function trimReplacementToContext(
   let L = 0;
   leading: for (let l = maxL; l >= 1; l--) {
     for (let i = 0; i < l; i++) {
-      if (replacementLines[i] !== norm(fileLines[startLine - 1 - l + i]!)) continue leading;
+      if (norm(replacementLines[i]!) !== norm(fileLines[startLine - 1 - l + i]!)) continue leading;
     }
     L = l;
     break;
@@ -45,7 +45,8 @@ function trimReplacementToContext(
   let T = 0;
   trailing: for (let t = maxT; t >= 1; t--) {
     for (let j = 0; j < t; j++) {
-      if (remainder[remainder.length - t + j] !== norm(fileLines[endLine + j]!)) continue trailing;
+      if (norm(remainder[remainder.length - t + j]!) !== norm(fileLines[endLine + j]!))
+        continue trailing;
     }
     T = t;
     break;

--- a/src/suggestions/patch.trimreplacementtocontext.test.mts
+++ b/src/suggestions/patch.trimreplacementtocontext.test.mts
@@ -119,6 +119,23 @@ describe("trimReplacementToContext (via buildUnifiedDiff)", () => {
     expect(lines).toEqual(["-c\r", "+C\r"]);
   });
 
+  it("normalises \\r on both sides: replacement lines that carry \\r still match CRLF file lines", () => {
+    // Both the file lines and the replacement lines carry \r.
+    // norm() must be applied to both sides so the trim still fires.
+    const content = "a\r\nb\r\nc\r\nd\r\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 3,
+        endLine: 3,
+        replacementLines: ["b\r", "C"],
+      }),
+    );
+    // "b\r" duplicates fileLines[1]="b\r" — should be trimmed, not added.
+    expect(lines).toEqual(["-c\r", "+C\r"]);
+  });
+
   it("trims leading duplicates longer than the 3-line context window", () => {
     // 8 lines before the removed range; 4 are duplicated in the replacement.
     const content = ["p", "q", "r", "s", "t", "u", "v", "w", "X", "z"].join("\n") + "\n";

--- a/src/suggestions/patch.trimreplacementtocontext.test.mts
+++ b/src/suggestions/patch.trimreplacementtocontext.test.mts
@@ -1,0 +1,137 @@
+/**
+ * Unit-style tests for the context-trimming logic inside buildUnifiedDiff.
+ * Each test uses the minimal file content needed to isolate one trimming behaviour,
+ * and inspects the diff output rather than the internal function directly.
+ */
+import { describe, it, expect } from "vitest";
+import { buildUnifiedDiff } from "../../test-helpers/suggestions/patch.test-support.mts";
+
+// Helper: build a diff and return only the +/- lines for easy assertion.
+function changedLines(patch: string): string[] {
+  return patch
+    .split("\n")
+    .filter((l) => l.startsWith("+") || l.startsWith("-"))
+    .filter((l) => !l.startsWith("---") && !l.startsWith("+++"));
+}
+
+describe("trimReplacementToContext (via buildUnifiedDiff)", () => {
+  it("returns replacementLines unchanged when nothing duplicates adjacent context", () => {
+    const content = "a\nb\nc\nd\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 2,
+        endLine: 2,
+        replacementLines: ["B"],
+      }),
+    );
+    expect(lines).toEqual(["-b", "+B"]);
+  });
+
+  it("trims one leading duplicate", () => {
+    // Remove line 3 (c); suggestion prepends "b" which is line 2.
+    const content = "a\nb\nc\nd\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 3,
+        endLine: 3,
+        replacementLines: ["b", "C"],
+      }),
+    );
+    expect(lines).toEqual(["-c", "+C"]);
+  });
+
+  it("trims one trailing duplicate", () => {
+    // Remove line 2 (b); suggestion appends "c" which is line 3.
+    const content = "a\nb\nc\nd\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 2,
+        endLine: 2,
+        replacementLines: ["B", "c"],
+      }),
+    );
+    expect(lines).toEqual(["-b", "+B"]);
+  });
+
+  it("trims both leading and trailing duplicates, leaving the changed line", () => {
+    // Remove line 2 (b); "a" before and "c" after are already in the file.
+    const content = "a\nb\nc\nd\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 2,
+        endLine: 2,
+        replacementLines: ["a", "NEW", "c"],
+      }),
+    );
+    expect(lines).toEqual(["-b", "+NEW"]);
+  });
+
+  it("returns empty additions when entire replacement is duplicated adjacent context (pure deletion)", () => {
+    // Remove line 2 (b); replacement ["a","c"] is entirely existing context — net effect is deletion.
+    const content = "a\nb\nc\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 2,
+        endLine: 2,
+        replacementLines: ["a", "c"],
+      }),
+    );
+    expect(lines).toEqual(["-b"]);
+  });
+
+  it("handles empty replacementLines (explicit deletion)", () => {
+    const content = "a\nb\nc\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 2,
+        endLine: 2,
+        replacementLines: [],
+      }),
+    );
+    expect(lines).toEqual(["-b"]);
+  });
+
+  it("normalises trailing \\r from CRLF file lines when comparing", () => {
+    // CRLF file: split("\n") leaves \r on each entry.
+    const content = "a\r\nb\r\nc\r\nd\r\n";
+    // Remove line 3; prepend "b" (no \r) which should match fileLines[1]="b\r".
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 3,
+        endLine: 3,
+        replacementLines: ["b", "C"],
+      }),
+    );
+    expect(lines).toEqual(["-c\r", "+C\r"]);
+  });
+
+  it("trims leading duplicates longer than the 3-line context window", () => {
+    // 8 lines before the removed range; 4 are duplicated in the replacement.
+    const content = ["p", "q", "r", "s", "t", "u", "v", "w", "X", "z"].join("\n") + "\n";
+    const lines = changedLines(
+      buildUnifiedDiff({
+        path: "f.ts",
+        originalContent: content,
+        startLine: 9,
+        endLine: 9,
+        replacementLines: ["t", "u", "v", "w", "Y"],
+        context: 3,
+      }),
+    );
+    expect(lines).toEqual(["-X", "+Y"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #294.

- `buildUnifiedDiff` in `src/suggestions/patch.mts` now calls a new internal `trimReplacementToContext` helper before building the hunk. It peels leading/trailing replacement lines that are identical to the file content immediately before/after the removed range, folding them into unchanged context instead of emitting them as `+` additions.
- Comparison normalises trailing `\r` so CRLF files work correctly.
- The removed range, hunk anchor, and all context window logic are unchanged — only the additions shrink.

## Test plan

- [ ] `src/suggestions/patch.buildunifieddiff.trims-duplicated-context-lines.test.mts` — 5 new tests: issue #294 repro, leading-only, trailing-only, no-duplication regression guard, run-longer-than-context-window
- [ ] `src/suggestions/patch.trimreplacementtocontext.test.mts` — 8 unit-style tests via `buildUnifiedDiff` covering each trim case + CRLF normalisation + pure-deletion edge case
- [ ] All 265 test files / 1377 tests pass; lint, typecheck, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)