### PR TITLE
[codex] keep protected checks visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ checks:
 actions:
   autoMinimizeSuppressed: true
   autoMarkReady: false
+  neverCancelRuns:
+    - "Final Code Review"
 ```
 
 Environment variables:

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -26,7 +26,14 @@ Each check run is assigned a `CheckCategory`:
 | `failing`       | `status === 'COMPLETED'` and `conclusion` in `{FAILURE, TIMED_OUT, CANCELLED, STARTUP_FAILURE, ACTION_REQUIRED}` |
 | `in_progress`   | `status` in `{IN_PROGRESS, QUEUED, WAITING, PENDING, REQUESTED}`                                                 |
 | `skipped`       | `conclusion` in `{SKIPPED, NEUTRAL}` — reported but do not block readiness                                       |
+| `ignored`       | Matches `ignoreChecks`, unless the same Actions run is protected by `actions.neverCancelRuns`                    |
 | `filtered`      | Triggered by a non-PR event (see event filter below)                                                             |
+
+### Ignore/protection precedence
+
+`ignoreChecks` matches the raw check name (`CheckRun.name` or `StatusContext.context`) and removes matching checks from the CI verdict. For GitHub Actions check runs, `actions.neverCancelRuns` takes precedence when it matches the workflow name or check name for that run. This lets long-running protected workflows remain visible and continue blocking readiness even when one of their raw job names also appears in `ignoreChecks`.
+
+`actions.neverCancelRuns` does not bypass the event filter. A protected workflow triggered by `workflow_dispatch`, `push`, or another non-PR event still needs that event listed in `checks.ciTriggerEvents` if it should count toward readiness.
 
 ### Event filter
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,8 @@ Matching is case-insensitive and treats a trailing `[bot]` suffix as equivalent 
 
 Top-level list of case-insensitive glob patterns for GitHub check/status context names Shepherd should ignore completely. Ignored checks are removed before CI classification, so they do not affect readiness, summaries, triage, stall detection, JSON output, or text output.
 
+For GitHub Actions check runs, `actions.neverCancelRuns` takes precedence over `ignoreChecks` when it matches the workflow name or raw check name for the same run. Use this when a protected long-running workflow has child job names that would otherwise match `ignoreChecks`.
+
 Use exact names for one context, or glob patterns when a service emits multiple related contexts:
 
 ```yaml
@@ -233,6 +235,8 @@ actions:
 ```
 
 Protected runs still count as failing or in-progress checks. Shepherd surfaces them under `## Protected runs` in text output and `fix.protectedRuns` in JSON so the agent knows they were deliberately left running.
+
+Protection also takes precedence over `ignoreChecks` for GitHub Actions check runs from the same workflow/run: a protected check is kept visible and can block ready-delay even if its raw job name matches `ignoreChecks`.
 
 ---
 

--- a/src/checks/classify-ignore.test.mts
+++ b/src/checks/classify-ignore.test.mts
@@ -78,4 +78,22 @@ describe("classifyChecks — ignoreChecks", () => {
     ]);
     expect(classified[0]?.category).toBe("ignored");
   });
+
+  it("handles null workflow metadata while checking protected matches", () => {
+    mockLoadConfig.mockReturnValue({
+      ...config(["Claude Code Review"]),
+      actions: { neverCancelRuns: ["Final Code Review"] },
+    });
+    const classified = classifyChecks([
+      {
+        ...baseCheck,
+        name: "Claude Code Review",
+        status: "IN_PROGRESS",
+        conclusion: null,
+        runId: "run-final-review",
+        workflowName: null as unknown as string,
+      },
+    ]);
+    expect(classified[0]?.category).toBe("ignored");
+  });
 });

--- a/src/checks/classify-ignore.test.mts
+++ b/src/checks/classify-ignore.test.mts
@@ -16,7 +16,11 @@ const baseCheck: CheckRun = {
 };
 
 function config(ignoreChecks: string[] = []) {
-  return { ignoreChecks, checks: { ciTriggerEvents: ["pull_request", "pull_request_target"] } };
+  return {
+    ignoreChecks,
+    checks: { ciTriggerEvents: ["pull_request", "pull_request_target"] },
+    actions: { neverCancelRuns: [] },
+  };
 }
 
 beforeEach(() => {
@@ -37,5 +41,41 @@ describe("classifyChecks — ignoreChecks", () => {
     expect(verdict.anyFailing).toBe(false);
     expect(verdict.anyInProgress).toBe(false);
     expect(verdict.ignoredNames).toEqual(["Kilo Code Review"]);
+  });
+
+  it("does not ignore a GitHub Actions check protected by workflow name", () => {
+    mockLoadConfig.mockReturnValue({
+      ...config(["Claude Code Review"]),
+      actions: { neverCancelRuns: ["Final Code Review"] },
+    });
+    const classified = classifyChecks([
+      {
+        ...baseCheck,
+        name: "Claude Code Review",
+        status: "IN_PROGRESS",
+        conclusion: null,
+        runId: "run-final-review",
+        workflowName: "Final Code Review",
+      },
+    ]);
+    expect(classified[0]?.category).toBe("in_progress");
+    const verdict = getCiVerdict(classified);
+    expect(verdict.anyInProgress).toBe(true);
+    expect(verdict.ignoredNames).toEqual([]);
+  });
+
+  it("still ignores the same raw check name when no protected workflow matches", () => {
+    mockLoadConfig.mockReturnValue(config(["Claude Code Review"]));
+    const classified = classifyChecks([
+      {
+        ...baseCheck,
+        name: "Claude Code Review",
+        status: "IN_PROGRESS",
+        conclusion: null,
+        runId: "run-final-review",
+        workflowName: "Final Code Review",
+      },
+    ]);
+    expect(classified[0]?.category).toBe("ignored");
   });
 });

--- a/src/checks/classify-ignore.test.mts
+++ b/src/checks/classify-ignore.test.mts
@@ -64,6 +64,33 @@ describe("classifyChecks — ignoreChecks", () => {
     expect(verdict.ignoredNames).toEqual([]);
   });
 
+  it("does not ignore a GitHub Actions check in the same run as a protected sibling check", () => {
+    mockLoadConfig.mockReturnValue({
+      ...config(["Claude Code Review"]),
+      actions: { neverCancelRuns: ["Select final review"] },
+    });
+    const classified = classifyChecks([
+      {
+        ...baseCheck,
+        name: "Select final review",
+        runId: "run-final-review",
+        workflowName: "Final Code Review",
+      },
+      {
+        ...baseCheck,
+        name: "Claude Code Review",
+        status: "IN_PROGRESS",
+        conclusion: null,
+        runId: "run-final-review",
+        workflowName: "Final Code Review",
+      },
+    ]);
+    expect(classified.find((c) => c.name === "Claude Code Review")?.category).toBe("in_progress");
+    const verdict = getCiVerdict(classified);
+    expect(verdict.anyInProgress).toBe(true);
+    expect(verdict.ignoredNames).toEqual([]);
+  });
+
   it("still ignores the same raw check name when no protected workflow matches", () => {
     mockLoadConfig.mockReturnValue(config(["Claude Code Review"]));
     const classified = classifyChecks([

--- a/src/checks/classify.mts
+++ b/src/checks/classify.mts
@@ -24,8 +24,9 @@ export function classifyChecks(checks: CheckRun[]): ClassifiedCheck[] {
   const relevantEvents = new Set(config.checks.ciTriggerEvents);
   const isIgnored = buildMatcher(config.ignoreChecks ?? []);
   const isProtected = buildMatcher(config.actions.neverCancelRuns ?? []);
+  const protectedRunIds = buildProtectedRunIds(checks, isProtected);
   return checks.map((c) =>
-    isIgnored(c.name) && !isProtectedCheck(c, isProtected)
+    isIgnored(c.name) && !isProtectedCheck(c, protectedRunIds)
       ? { ...c, category: "ignored" as const }
       : classify(c, relevantEvents),
   );
@@ -36,8 +37,25 @@ function buildMatcher(patterns: string[]): (name: string) => boolean {
   return picomatch(patterns, { nocase: true });
 }
 
-function isProtectedCheck(check: CheckRun, isProtected: (name: string) => boolean): boolean {
-  if (check.runId == null) return false;
+function buildProtectedRunIds(
+  checks: CheckRun[],
+  isProtected: (name: string) => boolean,
+): Set<string> {
+  const protectedRunIds = new Set<string>();
+  for (const check of checks) {
+    if (check.runId == null) continue;
+    if (protectedRunIds.has(check.runId) || checkMatchesProtection(check, isProtected)) {
+      protectedRunIds.add(check.runId);
+    }
+  }
+  return protectedRunIds;
+}
+
+function isProtectedCheck(check: CheckRun, protectedRunIds: Set<string>): boolean {
+  return check.runId != null && protectedRunIds.has(check.runId);
+}
+
+function checkMatchesProtection(check: CheckRun, isProtected: (name: string) => boolean): boolean {
   return [check.workflowName, check.name]
     .filter((name): name is string => typeof name === "string" && name.trim() !== "")
     .some((name) => isProtected(name));

--- a/src/checks/classify.mts
+++ b/src/checks/classify.mts
@@ -37,9 +37,9 @@ function buildMatcher(patterns: string[]): (name: string) => boolean {
 }
 
 function isProtectedCheck(check: CheckRun, isProtected: (name: string) => boolean): boolean {
-  if (check.runId === null) return false;
+  if (check.runId == null) return false;
   return [check.workflowName, check.name]
-    .filter((name): name is string => name !== undefined && name.trim() !== "")
+    .filter((name): name is string => typeof name === "string" && name.trim() !== "")
     .some((name) => isProtected(name));
 }
 

--- a/src/checks/classify.mts
+++ b/src/checks/classify.mts
@@ -22,15 +22,25 @@ import picomatch from "picomatch";
 export function classifyChecks(checks: CheckRun[]): ClassifiedCheck[] {
   const config = loadConfig();
   const relevantEvents = new Set(config.checks.ciTriggerEvents);
-  const isIgnored = buildIgnoreMatcher(config.ignoreChecks ?? []);
+  const isIgnored = buildMatcher(config.ignoreChecks ?? []);
+  const isProtected = buildMatcher(config.actions.neverCancelRuns ?? []);
   return checks.map((c) =>
-    isIgnored(c.name) ? { ...c, category: "ignored" as const } : classify(c, relevantEvents),
+    isIgnored(c.name) && !isProtectedCheck(c, isProtected)
+      ? { ...c, category: "ignored" as const }
+      : classify(c, relevantEvents),
   );
 }
 
-function buildIgnoreMatcher(patterns: string[]): (name: string) => boolean {
+function buildMatcher(patterns: string[]): (name: string) => boolean {
   if (patterns.length === 0) return () => false;
   return picomatch(patterns, { nocase: true });
+}
+
+function isProtectedCheck(check: CheckRun, isProtected: (name: string) => boolean): boolean {
+  if (check.runId === null) return false;
+  return [check.workflowName, check.name]
+    .filter((name): name is string => name !== undefined && name.trim() !== "")
+    .some((name) => isProtected(name));
 }
 
 function classify(check: CheckRun, relevantEvents: Set<string>): ClassifiedCheck {

--- a/src/commands/check.runcheck-skiptriage.mock.test.mts
+++ b/src/commands/check.runcheck-skiptriage.mock.test.mts
@@ -45,6 +45,34 @@ describe("runCheck — skipTriage", () => {
     expect(mockTriageFailingChecks).not.toHaveBeenCalled();
   });
 
+  it("keeps protected workflow checks visible even when the raw job name is ignored", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...defaultConfig(),
+      ignoreChecks: ["Claude Code Review"],
+      actions: {
+        ...defaultConfig().actions,
+        neverCancelRuns: ["Final Code Review"],
+      },
+    });
+    const protectedCheck = makeCheck({
+      name: "Claude Code Review",
+      workflowName: "Final Code Review",
+      status: "IN_PROGRESS",
+      conclusion: null,
+      runId: "run-final-review",
+    });
+    mockFetchPrBatch.mockResolvedValue({
+      data: makeBatchData({ checks: [protectedCheck] }),
+    });
+
+    const report = await runCheck(BASE_OPTS);
+
+    expect(report.status).toBe("IN_PROGRESS");
+    expect(report.checks.inProgress.map((c) => c.name)).toEqual(["Claude Code Review"]);
+    expect(report.checks.ignoredNames).toBeUndefined();
+    expect(mockTriageFailingChecks).not.toHaveBeenCalled();
+  });
+
   it("treats UNSTABLE with only ignored failures as ready without actionable failing checks", async () => {
     mockLoadConfig.mockReturnValue({
       ...defaultConfig(),


### PR DESCRIPTION
## Summary
- Fixes protected GitHub Actions runs being hidden when a child job raw name also matches `ignoreChecks`.
- Lets `actions.neverCancelRuns` take precedence over `ignoreChecks` for Actions check runs from the same workflow/run, so long-running protected review workflows stay visible and block ready-delay.
- Adds classifier and runCheck regression coverage plus docs for the precedence.

## Validation
- `npx vitest run src/checks/classify-ignore.test.mts src/checks/classify.test.mts src/commands/check.runcheck-skiptriage.mock.test.mts`
- `npm run typecheck`
- `npm run format:check`
- `npx oxlint src/checks/classify.mts src/checks/classify-ignore.test.mts src/commands/check.runcheck-skiptriage.mock.test.mts`
- `npm test`
- pre-push hook: `npm run lint`, `npm run typecheck`, `npm run format:check`
