### PR TITLE
fix(cli): pin inferred PR number across poll ticks

### DIFF
--- a/src/commands/poll.mts
+++ b/src/commands/poll.mts
@@ -109,10 +109,17 @@ export async function runPoll(opts: PollCommandOptions): Promise<IterateResult> 
   const untilTerminal = untilTerminalOpt === true;
   let dotsPrinted = false;
   let lastWaitSignature: string | null = null;
+  // When prNumber is omitted, iterateOpts.prNumber starts undefined and each tick would otherwise
+  // re-infer the PR from the current branch. That inference query only matches OPEN PRs, so once
+  // the monitored PR merges it returns nothing and runIterate throws instead of reporting the
+  // terminal CANCEL/merged result. Pin the PR resolved by the first tick so later ticks target it
+  // directly and never re-run branch discovery.
+  let prNumber = opts.prNumber;
 
   while (true) {
     tick += 1;
-    lastResult = await runIterate(iterateOpts);
+    lastResult = await runIterate({ ...iterateOpts, prNumber });
+    prNumber ??= lastResult.pr;
     if (lastResult.action !== "wait" && !(untilTerminal && lastResult.action === "mark_ready")) {
       break;
     }

--- a/src/commands/poll.pin-inferred-pr.mock.test.mts
+++ b/src/commands/poll.pin-inferred-pr.mock.test.mts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  registerIterateHooks,
+  mockGetCurrentPrNumber,
+  mockRunCheck,
+  makeReport,
+} from "../../test-helpers/commands/iterate-test-support.mts";
+import { runPoll } from "./poll.mts";
+
+// Regression test for https://github.com/jonathanong/pr-shepherd/issues/311.
+//
+// Unlike the other poll.*.mock.test.mts files, this test does NOT mock runIterate — it drives
+// the real runIterate (via the iterate test harness, which mocks runCheck/getCurrentPrNumber
+// instead) so the branch-inference bug can actually reproduce.
+
+registerIterateHooks();
+
+describe("runPoll — pins an inferred PR after the first tick", () => {
+  it("reports the terminal merged result instead of re-inferring and throwing", async () => {
+    // Branch inference resolves PR 123 exactly once. A second call (the bug path) would return
+    // null, since the PR has left the `states: OPEN` set the branch query filters on.
+    mockGetCurrentPrNumber.mockResolvedValueOnce(123).mockResolvedValue(null);
+
+    mockRunCheck
+      .mockResolvedValueOnce(makeReport({ pr: 123 })) // tick 1: OPEN -> WAIT
+      .mockResolvedValueOnce(
+        makeReport({
+          pr: 123,
+          mergeStatus: {
+            status: "CLEAN",
+            state: "MERGED",
+            isDraft: false,
+            mergeable: "MERGEABLE",
+            reviewDecision: "APPROVED",
+            blockingBotReviewInProgress: false,
+            mergeStateStatus: "CLEAN",
+          },
+        }), // tick 2: MERGED -> terminal cancel
+      );
+
+    const pollPromise = runPoll({
+      format: "json",
+      intervalSeconds: 30,
+      timeoutSeconds: 300,
+      untilTerminal: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const result = await pollPromise;
+
+    expect(mockGetCurrentPrNumber).toHaveBeenCalledTimes(1);
+    expect(mockRunCheck).toHaveBeenCalledTimes(2);
+    expect(result.action).toBe("cancel");
+    expect(result.pr).toBe(123);
+    if (result.action !== "cancel") throw new Error("expected cancel result");
+    expect(result.reason).toBe("merged");
+  });
+});


### PR DESCRIPTION
## Summary

- `runPoll` (`src/commands/poll.mts`) re-inferred the PR from the current branch on every tick whenever `prNumber` was omitted, because it passed the same options object to `runIterate` unchanged across ticks.
- The branch-inference GraphQL query (`pr-number-by-branch.gql`) only matches `states: OPEN` PRs. Once the monitored PR merged mid-poll, the next tick's inference returned nothing, and `runIterate` threw `"No open PR found for current branch..."` instead of reaching the graceful merged-terminal path that returns `{ action: "cancel", reason: "merged" }`.
- Fix: pin the PR resolved by the first tick (`prNumber ??= lastResult.pr`) and forward it explicitly on every later tick, so branch inference only ever runs once. Passing an explicit `--pr` was already unaffected by this bug.

Fixes #311.

## Test plan

- [x] Added `src/commands/poll.pin-inferred-pr.mock.test.mts` — an integration-style regression test that drives the real `runIterate` (via `iterate-test-support`, not the `runIterate`-mocked poll harness) through the issue's exact repro sequence: branch inference resolves PR 123 once, tick 1 returns `WAIT`, the PR merges, tick 2 must still resolve to PR 123 and return terminal `cancel`/`merged` — and asserts branch inference is called exactly once.
- [x] Verified fail-before/pass-after by temporarily reverting the `poll.mts` change: the new test failed with the exact reported error (`No open PR found for current branch...`), and passes with the fix restored.
- [x] `npm test` — 270 files / 1414 tests pass.
- [x] `npm run test:coverage` — 100% statements/lines, no regression (pre-existing `poll.mts` branch gaps are in unrelated quiet-status formatting helpers, untouched by this change).
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check` — all pass (also enforced by the `pre-push` hook, which ran on push).

Docs: n/a — `docs/cli-usage.md` already documents the intended inferred-PR behavior; this fix restores it rather than changing documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shepherd Journal

- Skipped code change for CodeRabbit rate-limit notice (review limit reached comment IC_kwDOSGizTs8AAAABJ0xjhg) — not actionable feedback, just minimized.