### PR TITLE
feat(journal): support --file <path> and --file - (stdin) for the entry

### DIFF
--- a/src/cli-parser.main-journal-file-flag.mock.test.mts
+++ b/src/cli-parser.main-journal-file-flag.mock.test.mts
@@ -65,6 +65,19 @@ describe("main — journal --file", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it("passes an empty file's content to runJournal instead of printing usage", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pr-shepherd-journal-"));
+    const filePath = join(dir, "empty.md");
+    writeFileSync(filePath, "");
+    try {
+      await main(["node", "shepherd", "journal", "42", "--file", filePath]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    expect(mockRunJournal).toHaveBeenCalledWith(expect.objectContaining({ rawItem: "" }));
+    expect(stderrSpy).not.toHaveBeenCalledWith(expect.stringContaining("Usage:"));
+  });
+
   it("accepts the --file=path form", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pr-shepherd-journal-"));
     const filePath = join(dir, "entry.md");

--- a/src/cli-parser.main-journal-file-flag.mock.test.mts
+++ b/src/cli-parser.main-journal-file-flag.mock.test.mts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { mockRunJournal } = vi.hoisted(() => ({ mockRunJournal: vi.fn() }));
+
+vi.mock("./commands/journal/index.mts", () => ({ runJournal: mockRunJournal }));
+vi.mock("./commands/resolve.mts", () => ({ runResolveMutate: vi.fn() }));
+vi.mock("./commands/log-file.mts", () => ({ runLogFile: vi.fn() }));
+vi.mock("./commands/commit-suggestion.mts", () => ({ runCommitSuggestion: vi.fn() }));
+vi.mock("./commands/mark-files-as-viewed.mts", () => ({ runMarkFilesAsViewed: vi.fn() }));
+vi.mock("./commands/iterate/index.mts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./commands/iterate/index.mts")>();
+  return { ...actual, runIterate: vi.fn() };
+});
+vi.mock("./github/client.mts", () => ({
+  getRepoInfo: vi.fn().mockResolvedValue({ owner: "owner", name: "repo" }),
+}));
+
+import { main } from "./cli-parser.mts";
+
+const HAPPY_RESULT = { prNumber: 42, mutated: true, sectionExisted: false, dryRun: false };
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+/** Swaps `process.stdin` for a fake async-iterable stream, returning a restore function. */
+function mockStdin(content: string): () => void {
+  const original = process.stdin;
+  const fake = {
+    [Symbol.asyncIterator]: async function* () {
+      yield Buffer.from(content, "utf8");
+    },
+  };
+  Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+  return () => Object.defineProperty(process, "stdin", { value: original, configurable: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  mockRunJournal.mockResolvedValue(HAPPY_RESULT);
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("main — journal --file", () => {
+  it("reads the entry from a file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pr-shepherd-journal-"));
+    const filePath = join(dir, "entry.md");
+    writeFileSync(filePath, "- Decision from file.\n");
+    try {
+      await main(["node", "shepherd", "journal", "42", "--file", filePath]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    expect(mockRunJournal).toHaveBeenCalledWith(
+      expect.objectContaining({ rawItem: "- Decision from file.\n" }),
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("accepts the --file=path form", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pr-shepherd-journal-"));
+    const filePath = join(dir, "entry.md");
+    writeFileSync(filePath, "- Decision via equals form.\n");
+    try {
+      await main(["node", "shepherd", "journal", "42", `--file=${filePath}`]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    expect(mockRunJournal).toHaveBeenCalledWith(
+      expect.objectContaining({ rawItem: "- Decision via equals form.\n" }),
+    );
+  });
+
+  it("reads the entry from stdin when --file is -", async () => {
+    const restore = mockStdin("- Decision from stdin with `backticks`.\n");
+    try {
+      await main(["node", "shepherd", "journal", "42", "--file", "-"]);
+    } finally {
+      restore();
+    }
+    expect(mockRunJournal).toHaveBeenCalledWith(
+      expect.objectContaining({ rawItem: "- Decision from stdin with `backticks`.\n" }),
+    );
+  });
+
+  it("errors when both a positional entry and --file are given", async () => {
+    await main(["node", "shepherd", "journal", "42", "- Decision.", "--file", "somefile.md"]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("not both"));
+    expect(process.exitCode).toBe(1);
+    expect(mockRunJournal).not.toHaveBeenCalled();
+  });
+
+  it("sets exitCode=1 when the --file path does not exist", async () => {
+    await main([
+      "node",
+      "shepherd",
+      "journal",
+      "42",
+      "--file",
+      "/nonexistent/pr-shepherd-entry.md",
+    ]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("journal:"));
+    expect(process.exitCode).toBe(1);
+    expect(mockRunJournal).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/help-command-pages.mts
+++ b/src/cli/help-command-pages.mts
@@ -176,12 +176,18 @@ Creates the section at the end if absent. Idempotent — duplicate items are ski
 
 Usage:
   pr-shepherd journal [PR] <item> [--dry-run] [--format text|json]
+  pr-shepherd journal [PR] --file <path> [--dry-run] [--format text|json]
+  pr-shepherd journal [PR] --file - [--dry-run] [--format text|json]
 
   PR     PR number or GitHub pull request URL. Defaults to current branch PR.
   item   Markdown list item: must start with "- " followed by non-whitespace text.
          Example: '- Rejected suggestion: kept existing pattern for consistency.'
+         Provide it as a positional argument, or via --file to avoid shell-escaping
+         backticks and multi-line Markdown. Exactly one of the two is required.
 
 Flags:
+  --file <path>        Read the entry from a file instead of a positional argument.
+                        Pass --file - to read from stdin.
   --dry-run            Preview the new PR body without writing it to GitHub.
   --format text|json   Output format. Default: text.
   --help, -h           Print this help and exit before any GitHub I/O.

--- a/src/cli/journal-handler.mts
+++ b/src/cli/journal-handler.mts
@@ -1,19 +1,38 @@
+import { readFileSync } from "node:fs";
 import { runJournal } from "../commands/journal/index.mts";
-import { parsePrNumber } from "./args.mts";
+import { getFlag, parsePrNumber } from "./args.mts";
 import { USAGE } from "./help.mts";
 
 export async function handleJournal(args: string[]): Promise<void> {
   for (const a of args) {
     if (!a.startsWith("--")) continue;
     if (a === "--dry-run" || a === "--format" || a.startsWith("--format=")) continue;
+    if (a === "--file" || a.startsWith("--file=")) continue;
     process.stderr.write(`pr-shepherd: journal: unknown flag: "${a}"\n`);
     process.exitCode = 1;
     return;
   }
 
   const { prNumber, extra } = parseJournalArgs(args);
+  const filePath = getFlag(args, "--file");
 
-  const rawItem = extra[0];
+  if (filePath !== null && extra[0]) {
+    process.stderr.write(
+      `pr-shepherd: journal: provide the entry as a positional argument or via --file, not both\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let rawItem: string | undefined;
+  try {
+    rawItem = filePath !== null ? await readItemSource(filePath) : extra[0];
+  } catch (e) {
+    process.stderr.write(`pr-shepherd: journal: ${String(e)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
   if (!rawItem) {
     process.stderr.write(`${USAGE.journal}\n`);
     process.exitCode = 1;
@@ -38,11 +57,29 @@ export async function handleJournal(args: string[]): Promise<void> {
   }
 }
 
+/** Reads the journal entry from a file, or from stdin when `filePath` is `-`. */
+async function readItemSource(filePath: string): Promise<string> {
+  if (filePath === "-") return readStdin();
+  return readFileSync(filePath, "utf8");
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
 function parseJournalArgs(args: string[]): { prNumber: number | undefined; extra: string[] } {
   const flagConsumedIndices = new Set<number>();
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
-    if (a === "--format" && i + 1 < args.length && !args[i + 1]!.startsWith("--")) {
+    if (
+      (a === "--format" || a === "--file") &&
+      i + 1 < args.length &&
+      !args[i + 1]!.startsWith("--")
+    ) {
       flagConsumedIndices.add(i);
       flagConsumedIndices.add(i + 1);
     }

--- a/src/cli/journal-handler.mts
+++ b/src/cli/journal-handler.mts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { runJournal } from "../commands/journal/index.mts";
 import { getFlag, parsePrNumber } from "./args.mts";
 import { USAGE } from "./help.mts";
@@ -33,7 +33,7 @@ export async function handleJournal(args: string[]): Promise<void> {
     return;
   }
 
-  if (!rawItem) {
+  if (rawItem === undefined) {
     process.stderr.write(`${USAGE.journal}\n`);
     process.exitCode = 1;
     return;
@@ -60,7 +60,7 @@ export async function handleJournal(args: string[]): Promise<void> {
 /** Reads the journal entry from a file, or from stdin when `filePath` is `-`. */
 async function readItemSource(filePath: string): Promise<string> {
   if (filePath === "-") return readStdin();
-  return readFileSync(filePath, "utf8");
+  return readFile(filePath, "utf8");
 }
 
 async function readStdin(): Promise<string> {


### PR DESCRIPTION
## Summary

- `pr-shepherd journal` now accepts `--file <path>` (read the entry from a file) or `--file -` (read from stdin), in addition to the existing positional entry argument.
- Exactly one of the positional entry or `--file` is required — supplying both is a validation error.
- Opt-in only: the CLI-emitted default push instruction (`` pr-shepherd journal 42 '- <decision>' ``) is unchanged. Switching the default would cascade into every instruction/snapshot test across the iterate output, which is out of scope for this fix.

## Motivation

[jonathanong/filaments#8071](https://github.com/jonathanong/filaments/issues/8071) reports that passing inline Markdown with backticks to `pr-shepherd journal` as a shell argument got interpreted by zsh as command substitution (`command not found: run_check`), silently stripping formatting from the journaled entry. Reading from a file or stdin sidesteps shell interpolation entirely.

`validateJournalItem`/`appendJournalItem` already handle multi-line content, so this only required updating the CLI handler (`src/cli/journal-handler.mts`) and its usage string.

## Test plan

- [x] `npm test` — full suite passes, including a new dedicated test file (`cli-parser.main-journal-file-flag.mock.test.mts`) covering: file read, `--file=path` form, stdin read, both-given error, nonexistent-file error.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` all pass (also verified via the `pre-push` hook).
- [x] End-to-end verified against the built `bin/` artifacts and this PR's own body (`--dry-run`, no mutation): `--file <path>` with backticks + a sub-bullet renders unmangled; `--file -` piped via stdin likewise; passing both a positional entry and `--file` together errors as expected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VRkBcTqBy4hqVjuKtYCpWm

## Shepherd Journal

- Applied gemini-code-assist review feedback ([thread](https://github.com/jonathanong/pr-shepherd/pull/318#discussion_r3602556406)): switched readItemSource to async fs/promises readFile, and changed the empty-entry check from !rawItem to rawItem === undefined so an empty file/entry surfaces runJournal's own validation error instead of the generic usage page.